### PR TITLE
docs(governance): Issue 駆動ワークフローを NENE2 正本に整合する (#1)

### DIFF
--- a/.cursor/rules/10-issue-driven-workflow.mdc
+++ b/.cursor/rules/10-issue-driven-workflow.mdc
@@ -5,11 +5,11 @@ alwaysApply: true
 
 # Issue Driven Workflow
 
-- コード、ドキュメント、設定変更は GitHub Issue ベースで進める。
+- コード、ドキュメント、設定変更は **必ず GitHub Issue ベース**。Issue 作成前に編集しない。
 - 作業開始時に `docs/roadmap.md`、`docs/milestones/`、`docs/todo/current.md`、関連 Issue/PR を確認する。
-- `main` へ直接コミットしない。ブランチ名は `type/issue-number-summary` を基本にする。
-- 作業完了時は通常、commit、push、PR 作成、チェック確認、merge、Issue close/update、`main` 同期まで進める。
-- PR には目的、変更点、検証結果、関連 Issue または `Closes #番号`、使用したセルフレビューチェックリスト名を書く。
-- コミットは Conventional Commits。description/body は日本語、type/scope は英語。Issue 番号を subject に含める。
-- ユーザーが「調査だけ」「コミットしない」「PR まで」など範囲を明示した場合は、その指示を優先する。
-- 正本は `docs/workflow.md` と `docs/development/commit-conventions.md`。
+- **`main` へ直接 commit / push しない。** ブランチ名は `type/issue-number-summary`。
+- 標準完了フロー: commit → push → PR 作成（`Closes #番号` + セルフレビューチェックリスト名）→ CI 確認 → **merge** → ローカル `main` 同期。
+- コミットは Conventional Commits（`docs/development/commit-conventions.md`）。description/body は日本語、type/scope は英語。**subject に `(#issue)` を含める。**
+- Phase 0 bootstrap（2026-05-24 — 25）は Issue 前の例外。**Phase 1 以降は例外なし。**
+- ユーザーが「調査だけ」「コミットしない」「PR まで」など範囲を明示した場合はその指示を優先する。
+- 正本: `docs/workflow.md`、`docs/development/commit-conventions.md`（NENE2 継承）。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,10 @@ This file is the entry point for AI agents working on NeNe Corpus.
 
 ## Operating Rules
 
-- Work from GitHub Issues. Create an Issue before implementation or doc changes that lack one.
-- Do not commit directly to `main`. Use branches named like `type/issue-number-summary`.
+- **Issue-driven**: no substantive code, doc, or config change without a GitHub Issue. Create one first.
+- **No direct commits to `main`**. Branch `type/issue-number-summary` → PR → merge after checks.
+- **Commits**: Conventional Commits; type/scope English, description/body Japanese, `(#issue)` in subject.
+- **Full lifecycle** (unless user limits scope): Issue → branch → implement → verify → commit → push → PR → merge → sync `main`.
 - Read NENE2 upstream docs for framework behavior; read local docs for product rules.
 - **Never integrate this chat system into NeNe Records.** Dependency direction is `NeNe Corpus → upstream APIs`, never the reverse. See ADR 0002.
 - Keep `docs/todo/current.md` and milestones aligned with Issues and PRs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,11 @@ Claude Code / AI agent guide for this repository. Cursor summaries live in `.cur
 
 ## Quick Rules
 
-- **Issue-driven**: no Issue, no code/doc change (except explicit user scope limits).
-- **Branch**: `type/issue-number-summary` from `main`; never commit directly to `main`.
-- **Commits**: Conventional Commits; type/scope English, description/body Japanese, include `(#issue)`.
-- **PR**: purpose, changes, verification, checklist name, `Closes #n`.
+- **Issue-driven**: no Issue, no code/doc/config change (except explicit user scope limits).
+- **Branch**: `type/issue-number-summary` from `main`; **never** commit or push directly to `main`.
+- **Commits**: Conventional Commits; type/scope English, description/body Japanese; subject includes `(#issue)`.
+- **PR → merge**: push branch, open PR with `Closes #n` and checklist name, merge after CI green, sync local `main`.
+- **Phase 0 note**: bootstrap commits predated Issues; **Phase 1+ must follow full workflow** (`docs/workflow.md`).
 - **Secrets**: never commit `.env`, tokens, API keys (`ANTHROPIC_API_KEY`, upstream JWTs), or credentials.
 - **Separation**: do not embed chat logic in NeNe Records; consume upstream via HTTP client only (ADR 0002).
 - **Framework**: NENE2 via Composer — read `vendor/hideyukimori/nene2/docs/` for runtime patterns.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,9 +20,16 @@ NeNe Corpus is built through small, Issue-driven changes. This document is the s
 
 ## Collaboration Policy
 
-- Start work from a GitHub Issue.
+Follow [`docs/workflow.md`](workflow.md) — inherited from [NENE2](https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md):
+
+1. Create or reuse a GitHub Issue **before** editing.
+2. Branch from `main` as `type/issue-number-summary`.
+3. Implement, verify (`composer check` when applicable), commit with `(#issue)`.
+4. Push, open PR with `Closes #number`, merge after checks — **do not push directly to `main`**.
+
+Phase 0 bootstrap (2026-05-24 — 2026-05-25) used direct `main` commits as a one-time exception. **Phase 1 onward uses Issue → PR → merge only.**
+
 - Use one branch and one PR per focused work unit.
-- Do not commit directly to `main`.
 - Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when direction changes.
 - Explain intent, impact, verification, and remaining risk in PRs.
 - Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.

--- a/docs/development/commit-conventions.md
+++ b/docs/development/commit-conventions.md
@@ -16,13 +16,27 @@ NeNe Corpus uses Conventional Commits, inherited from [NENE2](https://github.com
 
 - Keep `type`, `scope`, `BREAKING CHANGE`, and other Conventional Commits keywords in **English**.
 - Write the **description and body in Japanese**.
-- Include the related GitHub Issue number in the subject when practical.
+- Include the related GitHub Issue number in the **subject** for all work after Phase 0 bootstrap.
 
 Example:
 
 ```text
-docs(governance): NENE2 系ワークフロー規約を継承する (#2)
+docs(governance): Issue 駆動ワークフローを NENE2 正本に整合する (#1)
 ```
+
+```text
+feat(ingestion): sources テーブルの migration を追加する (#5)
+```
+
+## Issue number
+
+| Situation | Rule |
+| --- | --- |
+| Normal work (Phase 1+) | Subject **must** include `(#issue)` |
+| Phase 0 bootstrap commits (historical) | Predate Issues — do not retroactively rewrite unless doing a dedicated history cleanup Issue |
+| Docs-only follow-up on same Issue | Reuse the same Issue number |
+
+If you start editing without an Issue, **stop and create one first** — see `docs/workflow.md`.
 
 ## Common Types
 

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -17,8 +17,8 @@ NeNe Corpus is a **consumer project**, not a fork of NENE2. Framework code stays
 
 | Topic | Local document |
 | --- | --- |
-| Issue-driven workflow | `docs/workflow.md` |
-| Conventional Commits | `docs/development/commit-conventions.md` |
+| Issue-driven workflow | `docs/workflow.md` (inherits [NENE2 workflow](https://github.com/hideyukiMORI/NENE2/blob/main/docs/workflow.md)) |
+| Conventional Commits | `docs/development/commit-conventions.md` (inherits [NENE2 commit conventions](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/commit-conventions.md)) |
 | Self-review before PR | `docs/development/self-review.md` |
 | ADR operation | `docs/development/adr.md` |
 | AI agent workflow | `docs/integrations/ai-tools.md`, `AGENTS.md` |

--- a/docs/milestones/2026-05-governance-and-foundation.md
+++ b/docs/milestones/2026-05-governance-and-foundation.md
@@ -4,6 +4,8 @@ Goal: establish NeNe Corpus engineering discipline inherited from NENE2 before p
 
 **Status: complete (2026-05-25)**
 
+> **Workflow note:** Phase 0 landed via direct `main` commits before Issues existed (bootstrap exception). Phase 1+ must use Issue → branch → PR → merge. See `docs/workflow.md`.
+
 ## Acceptance Criteria
 
 - [x] GitHub repository created (`hideyukiMORI/nene-corpus`)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -23,9 +23,11 @@ Last updated: 2026-05-25
 
 ## Up Next — Phase 1（Corpus & Ingestion）
 
+**運用:** Issue → `type/issue-number-summary` ブランチ → PR → merge（`main` 直 push 禁止）。Phase 0 bootstrap のみ historical exception — `docs/workflow.md` 参照。
+
 | 優先 | 項目 | 説明 |
 | --- | --- | --- |
-| P0 | Issue 起票 + branch | `feat/N-schema-sources-documents-chunks` 等 |
+| P0 | Issue 起票 + branch | 例: `feat/2-schema-sources-documents-chunks` |
 | P0 | Schema: sources, documents, chunks | 取り込み正本 |
 | P0 | Admin auth (JWT) | 管理 API 保護 |
 | P1 | CSV upload API | 列マッピング preview |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -13,16 +13,18 @@ See also: `docs/inheritance-from-nene2.md`.
 5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
 6. Review the relevant self-review checklist in `docs/review/`.
 7. Run the narrowest meaningful verification available.
-8. Commit with Conventional Commits and include the Issue number.
+8. Commit with [Conventional Commits](development/commit-conventions.md) and include the Issue number in the subject.
 9. Push the branch and create a PR linked to the Issue.
-10. Merge after review and checks.
+10. Merge after review and checks pass.
 11. Return local `main` to the merged, clean state.
+
+**Do not commit directly to `main`.** Every merge to `main` goes through a PR tied to an Issue (except the documented bootstrap below).
 
 ## Branch Names
 
 Use Conventional Commit style as the prefix:
 
-- `docs/1-initial-governance`
+- `docs/1-issue-driven-workflow-alignment`
 - `feat/5-pdf-ingestion`
 - `fix/12-rate-limit-bypass`
 - `test/8-chat-citation-format`
@@ -34,11 +36,9 @@ Every PR should include:
 - purpose
 - change summary
 - verification results
-- self-review checklist used, when applicable
-- related Issue, preferably `Closes #number`
+- self-review checklist used, when applicable (example: `Self-review: docs-policy`)
+- related Issue — prefer `Closes #number` in the PR body
 - remaining risks or follow-up work
-
-Do not commit directly to `main`.
 
 ## Local Project Memory
 
@@ -56,16 +56,26 @@ Use self-review checklists before push or PR. See `docs/development/self-review.
 
 ## AI Agent Responsibilities
 
-AI agents should manage the normal lifecycle when asked to complete work:
+When asked to complete work, AI agents should run the **full lifecycle** unless the user narrows scope (investigation only, no commit, no PR, etc.):
 
-1. Create or reuse an Issue.
-2. Branch from `main`.
-3. Implement focused changes.
-4. Run verification (`composer check` minimum when runtime exists).
-5. Commit, push, open PR with checklist name and `Closes #n`.
-6. Update `docs/todo/current.md` when state changes.
+- create or reuse the Issue
+- create the Issue branch from `main`
+- read `AGENTS.md` and relevant docs before editing
+- edit only relevant files
+- review relevant self-review checklists in `docs/review/`
+- verify the change (`composer check` when runtime code exists)
+- commit with `(#issue)` in the subject
+- push the branch and open a PR with checklist name and `Closes #number`
+- merge after checks pass and sync local `main`
+- update `docs/todo/current.md` and milestones when state changes
 
-When the user explicitly limits scope (investigation only, no commit, no PR), follow that instruction.
+Direct pushes to `main` are **not** part of the normal agent workflow.
+
+## Phase 0 bootstrap (historical exception)
+
+The initial repository bootstrap (2026-05-24 — 2026-05-25) landed on `main` via direct commits **before** GitHub Issues existed. That was a one-time scaffold exception.
+
+**From Phase 1 onward**, treat Issue → branch → PR → merge as mandatory. Do not repeat bootstrap-style direct commits.
 
 ## Language
 


### PR DESCRIPTION
## Summary

- NENE2 `docs/workflow.md` / `docs/development/commit-conventions.md` に合わせ、Issue → branch → PR → merge の標準フローを明文化
- Phase 0 bootstrap（main 直 push）を **historical exception** として記録し、Phase 1 以降は例外なしと明記
- `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` / `.cursor/rules/` / `docs/todo/current.md` / milestone を同期

## Test plan

- [x] docs-only change — `composer check` 不要
- [x] Self-review: docs-policy

Closes #1

Made with [Cursor](https://cursor.com)