### PR TITLE
docs(product): デュアルデプロイと embed 方針を ADR 0003 で明文化する (#3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This file is the entry point for AI agents working on NeNe Corpus.
 
 - **Current work & status:** `docs/todo/current.md`
 - **Product vision:** `docs/explanation/product-vision.md`
+- **Deployment (dual Tier A/B):** `docs/deployment/README.md`, ADR 0003
 - Inheritance map: `docs/inheritance-from-nene2.md`
 - Human and AI collaboration: `docs/CONTRIBUTING.md`
 - Workflow: `docs/workflow.md`
@@ -35,11 +36,13 @@ This file is the entry point for AI agents working on NeNe Corpus.
 
 NeNe Corpus is a self-hosted knowledge chat OSS on NENE2:
 
+- **Primary operators:** Japan SMB on PHP shared hosting (Tier A); **also** Docker/VPS (Tier B). Same codebase — ADR 0003.
 - Ingest PDF, CSV, and structured sources into a searchable corpus.
-- Answer end-user questions with **cited** responses (SSE streaming).
+- Answer end-user questions with **cited** responses (sync JSON default; SSE optional on Tier B).
+- Embed consumer chat on existing homepages with one same-origin `<script>` (Phase 3 widget).
 - Admin UI for ingestion, corpus management, conversation logs, and settings.
 - OpenAPI as the contract; MCP for ops/read-only agent tooling only.
-- **Not** a CMS — sibling to [NeNe Records](https://github.com/hideyukiMORI/nene-records), not a module inside it.
+- **Not** a CMS or WordPress plugin — sibling to [NeNe Records](https://github.com/hideyukiMORI/nene-records), not a module inside it.
 
 ## Framework Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Claude Code / AI agent guide for this repository. Cursor summaries live in `.cur
 | Workflow | `docs/workflow.md` |
 | Commits | `docs/development/commit-conventions.md` |
 | Coding | `docs/development/coding-standards.md` |
+| Deployment / dual Tier A·B | `docs/deployment/README.md`, ADR 0003 |
 | Current tasks | `docs/todo/current.md` |
 | Roadmap | `docs/roadmap.md` |
 
@@ -29,7 +30,7 @@ Claude Code / AI agent guide for this repository. Cursor summaries live in `.cur
 
 ## Product Direction
 
-Self-hosted knowledge corpus — ingest documents, chat with citations, keep data on your stack. Admin UI + consumer chat widget. Optional NeNe Records as one upstream data source.
+Self-hosted knowledge corpus — ingest documents, chat with citations, keep data on your stack. **Dual deployment:** PHP shared hosting (Tier A, Japan SMB primary) or Docker/VPS (Tier B). Same-origin widget embed; sync JSON chat default. Admin UI + consumer chat widget. Optional NeNe Records as one upstream data source. ADR 0003.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,20 @@
 
 NeNe Corpus is a self-hosted, open-source knowledge chat platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). Upload PDF and CSV, build a searchable corpus, and answer end-user questions with source citations — without sending your data to a SaaS vendor.
 
+**Primary audience:** Japan SMB on PHP shared hosting — add chat to an existing homepage with one script tag. **Also:** developers and VPS operators via Docker Compose (same product, two install paths — ADR 0003).
+
 ## Goals
 
-- **Self-hosted OSS** — MIT licensed; run on your VPS or private cloud
+- **Self-hosted OSS** — MIT licensed; shared hosting or VPS/private cloud
 - **Cited answers** — every response links back to document chunks
+- **Easy embed** — one `<script>` on same-origin pages (Phase 3 widget)
 - **Secure by design** — audit logs, tenant boundaries, no DB bypass for AI tools
 - **AI-readable** — OpenAPI contract, MCP for ops, explicit Clean Architecture
 - **Sibling to NeNe Records** — optional CMS upstream; never merged into the CMS repo
 
 ## Quick Start
+
+### Docker — developers and VPS (Tier B)
 
 ```bash
 git clone https://github.com/hideyukiMORI/nene-corpus.git
@@ -29,55 +34,65 @@ curl -fsS http://localhost:8080/health
 
 > See [`docs/development/docker.md`](./docs/development/docker.md) for full setup details.
 
+### Shared hosting — Japan SMB (Tier A)
+
+Web installer and release ZIP ship in Phase 3. Requirements and planned flow:
+
+> [`docs/deployment/shared-hosting.md`](./docs/deployment/shared-hosting.md)
+
 ## Architecture
 
 ```
-Admin UI (React)     ──┐
-Consumer chat widget ──┼──→  NeNe Corpus API (NENE2)  ──→  Corpus DB
-Ops / AI (MCP)       ──┘              │
-                                      ↓ (optional read-only HTTP)
-                              NeNe Records / other upstream APIs
-                                      ↓
-                              Claude API (tool_use — server-side only)
+Existing homepage      ──→  <script widget.js>  ──┐
+Admin UI (React)       ────────────────────────────┼──→  NeNe Corpus API (NENE2)  ──→  Corpus DB
+Ops / AI (MCP)         ────────────────────────────┘              │
+                                                                 ↓ (optional read-only HTTP)
+                                                         NeNe Records / other upstream APIs
+                                                                 ↓
+                                                         Claude API (tool_use — server-side only)
 ```
 
 - **Backend**: PHP 8.4, NENE2, Handler → UseCase → Repository
 - **API contract**: OpenAPI 3.1 ([`docs/openapi/openapi.yaml`](./docs/openapi/openapi.yaml))
 - **Ingestion**: PDF text extraction, CSV row mapping (planned)
-- **Chat**: SSE streaming, rate limits, session audit (planned)
+- **Chat**: sync JSON + citations, rate limits (SSE optional on Tier B — planned)
+- **Deploy**: dual path — [`docs/deployment/README.md`](./docs/deployment/README.md)
 
 ## Current Status
 
-**Phase 0 — Governance & Foundation: in progress**
+**Phase 0 — Governance & Foundation: complete (2026-05-25)**
 
 | Area | State |
 | --- | --- |
-| Governance docs | ADR 0001/0002, inheritance map, Cursor rules |
+| Governance docs | ADR 0001/0002/0003, inheritance map, Cursor rules |
 | Runtime scaffold | NENE2 consumer, `GET /health`, CI |
 | Ingestion API | Planned (Phase 1) |
 | Chat + citations | Planned (Phase 2) |
-| Admin UI | Planned (Phase 3) |
+| Admin UI + widget + Tier A installer | Planned (Phase 3) |
 
 See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 
 ## Non-goals
 
 - Not a Notion / Slack replacement
-- Not WordPress-compatible
+- Not a WordPress **plugin** (coexist on same domain is fine)
 - Not embedded inside [NeNe Records](https://github.com/hideyukiMORI/nene-records)
 - Not exposing MCP protocol to end-user chat clients
+- Not Docker-only (shared hosting is a first-class deployment target)
 
 ## Contributing
 
 | Topic | Document |
 | --- | --- |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
+| **Deployment** | [`docs/deployment/README.md`](./docs/deployment/README.md) |
 | **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
 | NENE2 inheritance map | [`docs/inheritance-from-nene2.md`](./docs/inheritance-from-nene2.md) |
 | Workflow | [`docs/workflow.md`](./docs/workflow.md) |
 | Commit conventions | [`docs/development/commit-conventions.md`](./docs/development/commit-conventions.md) |
 | Coding standards | [`docs/development/coding-standards.md`](./docs/development/coding-standards.md) |
 | Docker development | [`docs/development/docker.md`](./docs/development/docker.md) |
+| Shared hosting | [`docs/deployment/shared-hosting.md`](./docs/deployment/shared-hosting.md) |
 | Full contributing guide | [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md) |
 
 Work from GitHub Issues. Do not commit directly to `main`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,6 +12,7 @@ NeNe Corpus is built through small, Issue-driven changes. This document is the s
 | Coding standards | `docs/development/coding-standards.md` |
 | Backend standards (PHP/API) | `docs/development/backend-standards.md` |
 | Docker development | `docs/development/docker.md` |
+| Deployment (Tier A/B) | `docs/deployment/README.md` |
 | Commit messages | `docs/development/commit-conventions.md` |
 | AI tools | `docs/integrations/ai-tools.md` |
 | Agent entry point | `AGENTS.md` |

--- a/docs/adr/0003-dual-deployment-and-embed-widget.md
+++ b/docs/adr/0003-dual-deployment-and-embed-widget.md
@@ -1,0 +1,71 @@
+# ADR 0003: Dual Deployment and Embed Widget
+
+## Status
+
+accepted
+
+## Context
+
+NeNe Corpus targets self-hosted knowledge chat for small and medium businesses. In Japan, many operators already run company websites on **PHP-capable shared hosting** (FTP upload, MySQL, same domain as their public site). Developers and VPS operators prefer **Docker Compose** for reproducible setup.
+
+These audiences share the same product (corpus, cited chat, admin UI) but need different **installation paths**. The consumer chat use case is typically **low frequency** (rate limits per session/IP, not high-throughput streaming), so token-by-token SSE is a UX enhancement, not a core requirement.
+
+Alternatives considered:
+
+1. **Docker-only** — rejected for Japan SMB reach; shared hosting is the larger addressable market.
+2. **Shared-hosting-only** — rejected; developers and VPS users need a fast, reproducible path.
+3. **Dual deployment, single codebase** (chosen): same API and widget; Tier A and Tier B differ in packaging and docs only.
+
+## Decision
+
+NeNe Corpus supports **two deployment tiers** with one runtime codebase:
+
+| Tier | Audience | Install path | Chat transport |
+| --- | --- | --- | --- |
+| **A — Shared hosting** | Japan SMB primary | ZIP + web installer + FTP/SSH; MySQL | Sync JSON (default) |
+| **B — Docker / VPS** | Developers, VPS, private cloud | `docker compose up` | Sync JSON (default); SSE optional later |
+
+**Product delivery:**
+
+- **Embed widget:** one `<script>` tag on any page under the **same origin** as the NeNe Corpus install (existing WordPress, static HTML, or other CMS pages).
+- **Not a WordPress plugin** — coexist on the same server and domain; no WP theme/DB integration.
+- **WordPress-like adoption feel** for Tier A: web installer, admin UI as primary operator surface, minimal CLI for day-to-day use (implementation in Phase 3).
+
+**Chat API (Phase 2):**
+
+- Default: `POST` message → wait → JSON response with full text and `citations[]`.
+- Optional later (Tier B): SSE streaming endpoint for progressive display.
+
+**Markets:**
+
+- **Primary:** Japan SMB on PHP shared hosting.
+- **Secondary:** VPS/Docker self-hosters globally; Southeast Asia and EU where data sovereignty matters (internationalization and extra channels are follow-up, not Phase 1 blockers).
+
+## Consequences
+
+**Benefits**
+
+- Largest Japan SMB segment remains in scope without forking the product.
+- Developers keep Docker as the authoritative dev and Tier B path.
+- Sync JSON improves shared-hosting compatibility (timeouts, proxies, no long-lived connections).
+- Clear embed story for existing homepages.
+
+**Costs**
+
+- Two deployment doc tracks and a broader smoke-test matrix.
+- Tier A requires release ZIP packaging and web installer (Phase 3 deliverables).
+- PHP version support for Tier A may need a wider floor (e.g. 8.2+) than dev-only 8.4 — track in Phase 1 Issues.
+
+**Follow-up**
+
+- `docs/deployment/shared-hosting.md` — Tier A operator guide (stub until installer lands).
+- `docs/development/docker.md` — Tier B (existing).
+- Phase 2 OpenAPI: document sync chat first; SSE as optional extension.
+- Phase 3: web installer, release ZIP, widget bundle.
+
+## Related
+
+- Issue: #3
+- Product vision: `docs/explanation/product-vision.md`
+- Deployment index: `docs/deployment/README.md`
+- Docker development: `docs/development/docker.md`

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,43 @@
+# Deployment
+
+NeNe Corpus supports **dual deployment** — same product, two installation paths. See ADR 0003.
+
+| Tier | Document | Audience |
+| --- | --- | --- |
+| **A — Shared hosting** | [`shared-hosting.md`](./shared-hosting.md) | Japan SMB, PHP hosting + MySQL |
+| **B — Docker / VPS** | [`../development/docker.md`](../development/docker.md) | Developers, VPS, private cloud |
+
+## Quick reference
+
+**Tier B (available now — development and VPS):**
+
+```bash
+cp .env.example .env
+docker compose up --build -d
+curl -fsS http://localhost:8080/health
+```
+
+**Tier A (operator guide — web installer in Phase 3):**
+
+See [`shared-hosting.md`](./shared-hosting.md).
+
+## Embed on an existing site
+
+After install, add the widget with one script tag on any page **under the same origin**:
+
+```html
+<script
+  src="/nene-corpus/widget.js"
+  data-endpoint="/nene-corpus/api"
+  defer
+></script>
+```
+
+Exact paths and attributes will be documented when the widget ships (Phase 3). Same-origin avoids CORS complexity on shared hosting.
+
+## Chat transport
+
+- **Default (both tiers):** synchronous JSON — POST a message, receive full reply + citations.
+- **Optional (Tier B, later):** SSE streaming for progressive display.
+
+Low-frequency FAQ-style traffic (rate limits per session/IP) does not require streaming.

--- a/docs/deployment/shared-hosting.md
+++ b/docs/deployment/shared-hosting.md
@@ -1,0 +1,79 @@
+# Shared Hosting Deployment (Tier A)
+
+Operator guide for **PHP-capable shared hosting** — the primary deployment target for Japan SMB. See ADR 0003.
+
+> **Status:** This path is the **product target** for operators. The web installer and release ZIP ship in **Phase 3**. Until then, advanced operators can deploy manually using the requirements below; Docker remains the supported development path.
+
+## Who this is for
+
+- Companies with an existing homepage on rental hosting (さくura, エックスサーバー, ロリポップ, ConoHa WING, etc.)
+- Operators who want **WordPress-like adoption** — upload, run installer, use admin UI — without replacing their current site
+- Teams that need corpus and chat data on **their MySQL**, not a SaaS vendor
+
+NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on the same domain and embeds into existing pages via one script tag.
+
+## Requirements
+
+| Requirement | Notes |
+| --- | --- |
+| PHP | 8.2+ planned for Tier A (8.4 for development); confirm with host |
+| Database | MySQL 8.x or MariaDB 10.x (SQLite possible for very small installs — not recommended for production chat) |
+| Web server | Apache with `mod_rewrite` or nginx equivalent; document root includes `public_html/` |
+| HTTPS | Recommended for admin JWT and widget sessions |
+| Outbound HTTPS | Required from Phase 2 (Claude API) — confirm host allows external API calls |
+| Writable dirs | `storage/uploads/`, `var/` or configured cache paths |
+| Cron | Optional but recommended for reindex and cleanup (Phase 1+) |
+
+## Planned install flow (Phase 3)
+
+1. Download **release ZIP** (includes `vendor/` — no Composer required on server).
+2. Upload via FTP or hosting file manager to e.g. `/nene-corpus/` under the domain.
+3. Open **web installer** in browser — database credentials, admin account, optional API keys.
+4. Run migrations from installer (no SSH required).
+5. Copy the **embed snippet** from admin UI into existing homepage template.
+
+## Embed on existing homepage
+
+Same origin — add one line to any page:
+
+```html
+<script
+  src="https://example.com/nene-corpus/widget.js"
+  data-endpoint="/nene-corpus/api"
+  defer
+></script>
+```
+
+Works alongside WordPress, static HTML, or other CMS pages on the same domain. The widget calls the sync JSON chat API (loading indicator while waiting; no SSE required).
+
+## Manual deploy (until web installer exists)
+
+For early adopters with SSH or FTP + local build:
+
+1. Run `composer install --no-dev` locally and create a ZIP of the project (including `vendor/`).
+2. Upload to hosting; point a subdomain or subdirectory to `public_html/`.
+3. Copy `.env.example` to `.env` and set `DB_*` for MySQL.
+4. Run `composer migrations:migrate` via SSH, or use a one-time migration script (to be provided in Phase 3).
+5. Ensure `storage/` is writable and not web-accessible.
+
+See [Docker development](../development/docker.md) for the canonical runtime layout.
+
+## Limitations on shared hosting
+
+- **PDF ingestion** may hit execution time and upload size limits — split large files or use VPS for heavy ingestion.
+- **SSE streaming** is not planned as Tier A default; use sync JSON.
+- **Claude API** usage is pay-as-you-go — configure keys in admin UI (Phase 2+).
+
+## Troubleshooting
+
+Document host-specific fixes in Issues/PRs as they appear. Common checks:
+
+- `public_html/index.php` reachable; rewrite rules pass requests to front controller
+- MySQL user has CREATE/ALTER during install only
+- `storage/` permissions (typically `755` or `775` depending on host)
+
+## Related
+
+- ADR 0003: `docs/adr/0003-dual-deployment-and-embed-widget.md`
+- Docker / VPS (Tier B): `docs/development/docker.md`
+- Product vision: `docs/explanation/product-vision.md`

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -20,6 +20,8 @@ Do **not** use ADRs for routine task detail — use Issues, PRs, and `docs/todo/
 docs/adr/
 ├── 0000-template.md
 ├── 0001-inherit-nene2-governance.md
+├── 0002-separate-from-nene-records.md
+├── 0003-dual-deployment-and-embed-widget.md
 └── NNNN-short-title.md
 ```
 

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -36,7 +36,7 @@ src/
   Source/             # source file metadata
   Document/           # logical documents
   Chunk/              # searchable text segments
-  Chat/               # send message, streaming
+  Chat/               # send message (sync JSON; SSE optional Tier B)
   Session/            # consumer sessions
   Message/            # chat messages
   Search/             # full-text over chunks
@@ -58,7 +58,7 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 
 | Layer | May | Must not |
 | --- | --- | --- |
-| **Handler** | Parse HTTP, build DTO, call UseCase, map response/SSE | SQL, business rules, direct LLM calls |
+| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response (or SSE when enabled) | SQL, business rules, direct LLM calls |
 | **UseCase** | Business rules, orchestration | `$_SERVER`, PDO, raw HTTP to Claude |
 | **Repository** | SQL / persistence | HTTP, session logic |
 | **Llm adapter** | Call Claude API from infrastructure | Domain invariants |
@@ -71,7 +71,8 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 
 - Every public route appears in `docs/openapi/openapi.yaml` with `operationId`.
 - Success and Problem Details error shapes documented.
-- Chat streaming: document SSE contract in OpenAPI when Phase 2 lands (extension or separate path doc).
+- Chat: document **sync JSON** contract first (ADR 0003 — default for Tier A and Tier B).
+- Optional SSE: document in OpenAPI when implemented (Tier B polish).
 - RFC 9457 Problem Details for errors; base URL `https://nene-corpus.dev/problems/`.
 
 ---

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -22,11 +22,48 @@ End users get fast, grounded answers. Operators keep data sovereignty.
 
 NeNe Corpus is **not** a PHP framework. It is a **product** that consumes NENE2.
 
+## Target operators and markets
+
+**Primary — Japan SMB on PHP shared hosting**
+
+Operators who already have a company website on rental hosting and want a FAQ / manual chatbot **without SaaS lock-in**. Adoption should feel as approachable as WordPress: upload, run installer, manage from admin UI — **not** as a WordPress plugin, but as a sibling app on the same domain.
+
+**Secondary — developers and VPS / private cloud**
+
+Docker Compose for local dev and production on VPS. Same API and widget as Tier A; optional SSE streaming later.
+
+**Later — international**
+
+Southeast Asia and EU operators who value data sovereignty. May need multilingual UI and messaging-app channels; not Phase 1 blockers.
+
+## Dual deployment
+
+Same codebase, two installation paths (ADR 0003):
+
+| Tier | Path | Chat transport |
+| --- | --- | --- |
+| **A — Shared hosting** | ZIP + web installer + MySQL | Sync JSON (default) |
+| **B — Docker / VPS** | `docker compose up` | Sync JSON (default); SSE optional |
+
+See [`docs/deployment/README.md`](../deployment/README.md).
+
+## Embed on existing sites
+
+Consumer chat is added to an **existing homepage** with one script tag on the **same origin**:
+
+```html
+<script src="/nene-corpus/widget.js" data-endpoint="/nene-corpus/api" defer></script>
+```
+
+No site rebuild required. Works with WordPress themes, static HTML, or any CMS that allows a custom script include.
+
+FAQ-style traffic is **low frequency** (rate limits per session/IP). Synchronous JSON responses with a loading state are sufficient; streaming is optional polish for Tier B.
+
 ## Philosophy
 
 ### 1. Self-hosted OSS first
 
-MIT license. Docker Compose quick start. No mandatory cloud vendor. Optional managed hosting may exist later; the core stays open.
+MIT license. **Dual deployment:** Docker Compose for developers and VPS; web installer + ZIP for PHP shared hosting. No mandatory cloud vendor.
 
 ### 2. Citations are the contract
 
@@ -48,8 +85,8 @@ NENE2 (framework)
 | --- | --- |
 | **NENE2 runtime** | HTTP, DI, middleware, Problem Details |
 | **NeNe Corpus API** | Ingestion, corpus storage, chat, rate limits, audit |
-| **Admin UI** | Upload, reindex, logs, prompt settings, widget config |
-| **Consumer widget** | Chat UX over SSE |
+| **Admin UI** | Upload, reindex, logs, prompt settings, widget embed snippet |
+| **Consumer widget** | Chat UX over sync JSON (SSE optional on Tier B) |
 | **Claude API** | Reasoning + tool_use (server-side only) |
 | **Upstream APIs** | NeNe Records public/search APIs (read-only client) |
 | **MCP tools** | Ops read-only — never consumer-facing |
@@ -71,6 +108,7 @@ Explicit domain modules, small use cases, typed DTOs, ADRs, Issue-driven workflo
 | Customization | Limited | Fork, extend, self-host |
 | Citations | Varies | Core product promise |
 | CMS | Bundled or separate | Optional NeNe Records upstream |
+| Deploy | Vendor-hosted | Shared hosting or Docker/VPS |
 
 ## Relationship to NENE2
 
@@ -87,11 +125,13 @@ NeNe Records   → sibling CMS (optional upstream)
 ## Non-goals
 
 - Rebuilding Laravel/Symfony or a generic RAG framework
-- WordPress / Notion compatibility
+- **WordPress plugin** or theme integration (coexist on same domain is fine)
+- Notion / WordPress content import as a primary goal
 - Embedding chat into NeNe Records
 - Exposing MCP to end-user chat clients
 - Direct database access for LLM or MCP tools
 - Subscription-only SaaS as the primary delivery model
+- Docker-only deployment (shared hosting must remain a first-class path)
 
 ## Naming
 

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -51,7 +51,8 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | Backend standards | `docs/development/backend-standards.md` |
 | Language policy | English for public docs, OpenAPI, API errors; Japanese allowed in Issues, PRs, commits, `.cursor/rules/` |
 | Review checklists | `docs/review/` — task-specific lists for this product |
-| Transport | REST JSON + SSE for chat streaming (Phase 2+) |
+| Transport | Sync JSON chat (Phase 2+ default); SSE optional (Tier B) — ADR 0003 |
+| Deployment | Tier A shared hosting + Tier B Docker/VPS — `docs/deployment/` |
 | External services | Claude API (server-side), optional NeNe Records HTTP client |
 
 ## NeNe Corpus–specific (not inherited)
@@ -64,6 +65,7 @@ Record these in ADRs or product docs when they stabilize:
 - Admin auth vs anonymous consumer sessions
 - LLM tool_use orchestration boundaries
 - Upstream API client policy (ADR 0002)
+- Dual deployment and embed widget policy (ADR 0003)
 
 ## When upstream and local docs conflict
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,7 +9,10 @@ Operators can self-host a corpus + chat platform that:
 - ingests PDF and CSV into searchable, citable chunks
 - answers consumer questions with source references
 - provides admin UI for uploads, logs, and configuration
+- embeds chat on an **existing homepage** with one script tag (same origin)
 - optionally queries [NeNe Records](https://github.com/hideyukiMORI/nene-records) via read-only HTTP
+
+**Primary market:** Japan SMB on PHP shared hosting. **Dual deployment:** Tier A (shared hosting) and Tier B (Docker/VPS) — ADR 0003.
 
 ## Phase 0: Governance and Foundation
 
@@ -21,6 +24,8 @@ Goal: engineering discipline and minimal runtime scaffold.
 
 Tracked by `docs/milestones/2026-05-governance-and-foundation.md`.
 
+**Status: complete (2026-05-25).**
+
 ## Phase 1: Corpus Storage & Ingestion
 
 Goal: store documents and chunks; admin upload API.
@@ -30,25 +35,28 @@ Goal: store documents and chunks; admin upload API.
 - PDF text extraction (text PDF first)
 - Admin auth (JWT) for mutating routes
 - OpenAPI + tests
+- Tier A: MySQL on shared hosting; consider PHP 8.2+ floor for host compatibility
 
 ## Phase 2: Chat & Citations
 
-Goal: grounded Q&A with streaming.
+Goal: grounded Q&A with cited responses.
 
 - Chat sessions and messages
 - Full-text search over chunks
 - Claude tool_use orchestration (server-side)
-- SSE streaming consumer endpoint
+- **Sync JSON chat endpoint** (default for Tier A and Tier B)
 - Citation payload in responses
 - Rate limiting per session/IP
+- Optional: SSE streaming endpoint (Tier B polish — not required for low-frequency FAQ traffic)
 
 ## Phase 3: Admin UI & Widget
 
-Goal: operable product without curl.
+Goal: operable product without curl; Tier A install path.
 
 - React admin: sources, ingestion status, conversation logs
-- Embeddable consumer chat widget
+- **Embeddable consumer chat widget** (`widget.js` + embed snippet for same-origin pages)
 - Prompt / scope / fallback settings UI
+- **Tier A deliverables:** web installer, release ZIP (vendor bundled), shared-hosting operator docs
 
 ## Phase 4: Upstream Integrations
 
@@ -58,13 +66,23 @@ Goal: optional NeNe Records and export APIs.
 - Unified search across local corpus + upstream
 - Webhook or poll reindex hooks
 
+## Deployment tiers
+
+| Tier | Phase | Deliverable |
+| --- | --- | --- |
+| **B — Docker / VPS** | 0 (now) | `docker compose up`, `docs/development/docker.md` |
+| **A — Shared hosting** | 3 | Web installer, ZIP, `docs/deployment/shared-hosting.md` |
+
+Same API and widget for both tiers. Chat uses sync JSON by default.
+
 ## Non-goals
 
 - Notion / Slack replacement
-- WordPress compatibility
+- WordPress **plugin** (coexist on same domain is supported)
 - Embedding inside NeNe Records
 - Consumer-facing MCP
 - Mandatory SaaS hosting
+- Docker-only deployment
 
 ## Ecosystem
 
@@ -75,3 +93,9 @@ NENE2 (framework)
 ```
 
 Framework changes → NENE2. CMS → nene-records. Chat/corpus → here.
+
+## Related
+
+- ADR 0003: dual deployment and embed widget
+- Deployment: `docs/deployment/README.md`
+- Product vision: `docs/explanation/product-vision.md`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -2,6 +2,10 @@
 
 Last updated: 2026-05-25
 
+## 最近の docs 更新
+
+- ADR 0003: デュアルデプロイ（Tier A 共用ホスティング / Tier B Docker）、同期 JSON チャット、1行 embed — Issue #3
+
 ## 状態サマリー
 
 **Phase 0 — Governance & Foundation: 完了（2026-05-25）**
@@ -45,8 +49,9 @@ Last updated: 2026-05-25
 | P0 | Sessions + messages | 会話永続化 |
 | P0 | Chunk search | full-text |
 | P0 | Claude tool_use + citations | サーバー側のみ |
-| P1 | SSE streaming | コンシューマー向け |
+| P0 | Sync JSON chat API | Tier A/B 共通デフォルト（ADR 0003） |
 | P1 | Rate limiting | session / IP |
+| P2 | SSE streaming | Tier B 任意（低頻度 FAQ では不要） |
 
 ---
 
@@ -54,6 +59,9 @@ Last updated: 2026-05-25
 
 > **NeNe Records とは完全に分離。** 依存方向は `NeNe Corpus → NeNe Records API` のみ。
 > 詳細: [`docs/adr/0002-separate-from-nene-records.md`](../adr/0002-separate-from-nene-records.md)
+
+> **デュアルデプロイ:** Tier A = PHP 共用ホスティング + 1行 embed / Tier B = Docker・VPS。同一 API。
+> 詳細: [`docs/adr/0003-dual-deployment-and-embed-widget.md`](../adr/0003-dual-deployment-and-embed-widget.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- ADR 0003 を追加し、**Tier A（PHP 共用ホスティング）** と **Tier B（Docker/VPS）** のデュアルデプロイを正式決定
- 日本 SMB を primary market、既存 HP への **同一オリジン 1 行 embed**、**同期 JSON チャット default**（SSE は Tier B 任意）を product-vision / roadmap / README に反映
- `docs/deployment/` を新設（索引 + 共用ホスティング向け operator guide stub）

## Test plan

- [x] docs の相互リンク（ADR 0003 ↔ deployment ↔ product-vision ↔ roadmap）を目視確認
- [x] Non-goals の WordPress 表現が「プラグイン非対応・同ドメイン共存 OK」と整合していること
- [ ] CI green（docs-only のため Backend CI は変更なし想定）

Closes #3

Self-review: docs-policy


Made with [Cursor](https://cursor.com)