### PR TITLE
docs(governance): 命名規則と用語集を正本化する (#5)

### DIFF
--- a/.cursor/rules/20-modern-php.mdc
+++ b/.cursor/rules/20-modern-php.mdc
@@ -10,6 +10,6 @@ alwaysApply: false
 - Namespace: `NeneCorpus\` — domain-grouped modules（`Chat/`, `Chunk/`, `Ingestion/` 等）。
 - Handler → UseCase → RepositoryInterface → PdoRepository。Handler にビジネスロジックを置かない。
 - PDO/SQL は `Pdo*Repository` 内のみ。LLM HTTP 呼び出しは `Llm/` アダプター内のみ。
-- Problem Details: `https://nene-corpus.dev/problems/{name}`
+- Problem Details type slug: kebab-case per [`naming-conventions.md`](../development/naming-conventions.md) §4.
 - OpenAPI と MCP は同一 HTTP 契約。コンシューマーチャットに MCP を露出しない。
-- 正本は `docs/development/backend-standards.md`。
+- 正本: [`backend-standards.md`](../../docs/development/backend-standards.md), [`naming-conventions.md`](../../docs/development/naming-conventions.md), [`glossary.md`](../../docs/explanation/glossary.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This file is the entry point for AI agents working on NeNe Corpus.
 
 - **Current work & status:** `docs/todo/current.md`
 - **Product vision:** `docs/explanation/product-vision.md`
+- **Glossary:** `docs/explanation/glossary.md`
+- **Naming conventions:** `docs/development/naming-conventions.md`
 - **Deployment (dual Tier A/B):** `docs/deployment/README.md`, ADR 0003
 - Inheritance map: `docs/inheritance-from-nene2.md`
 - Human and AI collaboration: `docs/CONTRIBUTING.md`
@@ -38,8 +40,8 @@ NeNe Corpus is a self-hosted knowledge chat OSS on NENE2:
 
 - **Primary operators:** Japan SMB on PHP shared hosting (Tier A); **also** Docker/VPS (Tier B). Same codebase — ADR 0003.
 - Ingest PDF, CSV, and structured sources into a searchable corpus.
-- Answer end-user questions with **cited** responses (sync JSON default; SSE optional on Tier B).
-- Embed consumer chat on existing homepages with one same-origin `<script>` (Phase 3 widget).
+- Answer end-user questions with **cited** responses (**sync JSON chat** default; **SSE streaming** optional on Tier B).
+- Embed **embed widget** on existing homepages with one same-origin `<script>` (Phase 3).
 - Admin UI for ingestion, corpus management, conversation logs, and settings.
 - OpenAPI as the contract; MCP for ops/read-only agent tooling only.
 - **Not** a CMS or WordPress plugin — sibling to [NeNe Records](https://github.com/hideyukiMORI/nene-records), not a module inside it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Claude Code / AI agent guide for this repository. Cursor summaries live in `.cur
 | Workflow | `docs/workflow.md` |
 | Commits | `docs/development/commit-conventions.md` |
 | Coding | `docs/development/coding-standards.md` |
+| Naming / glossary | `docs/development/naming-conventions.md`, `docs/explanation/glossary.md` |
 | Deployment / dual Tier A·B | `docs/deployment/README.md`, ADR 0003 |
 | Current tasks | `docs/todo/current.md` |
 | Roadmap | `docs/roadmap.md` |
@@ -30,7 +31,7 @@ Claude Code / AI agent guide for this repository. Cursor summaries live in `.cur
 
 ## Product Direction
 
-Self-hosted knowledge corpus — ingest documents, chat with citations, keep data on your stack. **Dual deployment:** PHP shared hosting (Tier A, Japan SMB primary) or Docker/VPS (Tier B). Same-origin widget embed; sync JSON chat default. Admin UI + consumer chat widget. Optional NeNe Records as one upstream data source. ADR 0003.
+Self-hosted knowledge corpus — ingest documents, chat with citations, keep data on your stack. **Dual deployment:** **Tier A** shared hosting or **Tier B** Docker/VPS. Same-origin **embed widget**; **sync JSON chat** default. Admin UI + consumer chat. Optional NeNe Records upstream. ADR 0003; terms in `docs/explanation/glossary.md`.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 NeNe Corpus is a self-hosted, open-source knowledge chat platform built on [NENE2](https://github.com/hideyukiMORI/NENE2). Upload PDF and CSV, build a searchable corpus, and answer end-user questions with source citations — without sending your data to a SaaS vendor.
 
-**Primary audience:** Japan SMB on PHP shared hosting — add chat to an existing homepage with one script tag. **Also:** developers and VPS operators via Docker Compose (same product, two install paths — ADR 0003).
+**Primary audience:** Japan SMB on **Tier A** **shared hosting** — add **embed widget** to an existing homepage with one script tag. **Also:** **Tier B** developers and VPS operators via Docker Compose (**dual deployment** — ADR 0003).
 
 ## Goals
 
 - **Self-hosted OSS** — MIT licensed; shared hosting or VPS/private cloud
 - **Cited answers** — every response links back to document chunks
-- **Easy embed** — one `<script>` on same-origin pages (Phase 3 widget)
+- **Easy embed** — one `<script>` for the **embed widget** on same-origin pages (Phase 3)
 - **Secure by design** — audit logs, tenant boundaries, no DB bypass for AI tools
 - **AI-readable** — OpenAPI contract, MCP for ops, explicit Clean Architecture
 - **Sibling to NeNe Records** — optional CMS upstream; never merged into the CMS repo
@@ -55,7 +55,7 @@ Ops / AI (MCP)         ───────────────────
 - **Backend**: PHP 8.4, NENE2, Handler → UseCase → Repository
 - **API contract**: OpenAPI 3.1 ([`docs/openapi/openapi.yaml`](./docs/openapi/openapi.yaml))
 - **Ingestion**: PDF text extraction, CSV row mapping (planned)
-- **Chat**: sync JSON + citations, rate limits (SSE optional on Tier B — planned)
+- **Chat**: **sync JSON chat** + citations, rate limits (**SSE streaming** optional on Tier B — planned)
 - **Deploy**: dual path — [`docs/deployment/README.md`](./docs/deployment/README.md)
 
 ## Current Status
@@ -68,7 +68,7 @@ Ops / AI (MCP)         ───────────────────
 | Runtime scaffold | NENE2 consumer, `GET /health`, CI |
 | Ingestion API | Planned (Phase 1) |
 | Chat + citations | Planned (Phase 2) |
-| Admin UI + widget + Tier A installer | Planned (Phase 3) |
+| Admin UI + embed widget + Tier A installer | Planned (Phase 3) |
 
 See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 
@@ -85,6 +85,8 @@ See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/t
 | Topic | Document |
 | --- | --- |
 | **Product vision** | [`docs/explanation/product-vision.md`](./docs/explanation/product-vision.md) |
+| **Glossary** | [`docs/explanation/glossary.md`](./docs/explanation/glossary.md) |
+| **Naming conventions** | [`docs/development/naming-conventions.md`](./docs/development/naming-conventions.md) |
 | **Deployment** | [`docs/deployment/README.md`](./docs/deployment/README.md) |
 | **Start here (agents)** | [`AGENTS.md`](./AGENTS.md) |
 | NENE2 inheritance map | [`docs/inheritance-from-nene2.md`](./docs/inheritance-from-nene2.md) |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,6 +10,8 @@ NeNe Corpus is built through small, Issue-driven changes. This document is the s
 | NeNe Records boundary | `docs/integrations/nene-records-client.md` |
 | Workflow | `docs/workflow.md` |
 | Coding standards | `docs/development/coding-standards.md` |
+| Naming conventions | `docs/development/naming-conventions.md` |
+| Glossary | `docs/explanation/glossary.md` |
 | Backend standards (PHP/API) | `docs/development/backend-standards.md` |
 | Docker development | `docs/development/docker.md` |
 | Deployment (Tier A/B) | `docs/deployment/README.md` |

--- a/docs/adr/0003-dual-deployment-and-embed-widget.md
+++ b/docs/adr/0003-dual-deployment-and-embed-widget.md
@@ -22,8 +22,8 @@ NeNe Corpus supports **two deployment tiers** with one runtime codebase:
 
 | Tier | Audience | Install path | Chat transport |
 | --- | --- | --- | --- |
-| **A — Shared hosting** | Japan SMB primary | ZIP + web installer + FTP/SSH; MySQL | Sync JSON (default) |
-| **B — Docker / VPS** | Developers, VPS, private cloud | `docker compose up` | Sync JSON (default); SSE optional later |
+| **A — Shared hosting** | Japan SMB primary | ZIP + web installer + FTP/SSH; MySQL | **sync JSON chat** (default) |
+| **B — Docker / VPS** | Developers, VPS, private cloud | `docker compose up` | **sync JSON chat** (default); **SSE streaming** optional later |
 
 **Product delivery:**
 
@@ -33,13 +33,13 @@ NeNe Corpus supports **two deployment tiers** with one runtime codebase:
 
 **Chat API (Phase 2):**
 
-- Default: `POST` message → wait → JSON response with full text and `citations[]`.
-- Optional later (Tier B): SSE streaming endpoint for progressive display.
+- Default (**sync JSON chat**): `POST` message → wait → JSON response with full text and `citations[]`.
+- Optional later (Tier B — **SSE streaming**): progressive display endpoint.
 
 **Markets:**
 
-- **Primary:** Japan SMB on PHP shared hosting.
-- **Secondary:** VPS/Docker self-hosters globally; Southeast Asia and EU where data sovereignty matters (internationalization and extra channels are follow-up, not Phase 1 blockers).
+- **Primary:** Japan SMB on **Tier A** **shared hosting**.
+- **Secondary:** **Tier B** VPS/Docker self-hosters globally; Southeast Asia and EU where data sovereignty matters (internationalization and extra channels are follow-up, not Phase 1 blockers).
 
 ## Consequences
 
@@ -47,21 +47,22 @@ NeNe Corpus supports **two deployment tiers** with one runtime codebase:
 
 - Largest Japan SMB segment remains in scope without forking the product.
 - Developers keep Docker as the authoritative dev and Tier B path.
-- Sync JSON improves shared-hosting compatibility (timeouts, proxies, no long-lived connections).
-- Clear embed story for existing homepages.
+- **sync JSON chat** improves shared-hosting compatibility (timeouts, proxies, no long-lived connections).
+- Clear **embed widget** story for existing homepages.
 
 **Costs**
 
 - Two deployment doc tracks and a broader smoke-test matrix.
-- Tier A requires release ZIP packaging and web installer (Phase 3 deliverables).
+- Tier A requires **release ZIP** packaging and **web installer** (Phase 3 deliverables).
 - PHP version support for Tier A may need a wider floor (e.g. 8.2+) than dev-only 8.4 — track in Phase 1 Issues.
 
 **Follow-up**
 
 - `docs/deployment/shared-hosting.md` — Tier A operator guide (stub until installer lands).
 - `docs/development/docker.md` — Tier B (existing).
-- Phase 2 OpenAPI: document sync chat first; SSE as optional extension.
-- Phase 3: web installer, release ZIP, widget bundle.
+- Phase 2 OpenAPI: document **sync JSON chat** first; **SSE streaming** as optional extension.
+- Phase 3: **web installer**, **release ZIP**, **embed widget** bundle.
+- Terminology: `docs/explanation/glossary.md`, `docs/development/naming-conventions.md`.
 
 ## Related
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,11 +1,11 @@
 # Deployment
 
-NeNe Corpus supports **dual deployment** — same product, two installation paths. See ADR 0003.
+NeNe Corpus supports **dual deployment** — same product, two installation paths. See ADR 0003 and [`glossary.md`](../explanation/glossary.md).
 
 | Tier | Document | Audience |
 | --- | --- | --- |
-| **A — Shared hosting** | [`shared-hosting.md`](./shared-hosting.md) | Japan SMB, PHP hosting + MySQL |
-| **B — Docker / VPS** | [`../development/docker.md`](../development/docker.md) | Developers, VPS, private cloud |
+| **Tier A — shared hosting** | [`shared-hosting.md`](./shared-hosting.md) | Japan SMB, PHP hosting + MySQL |
+| **Tier B — Docker / VPS** | [`../development/docker.md`](../development/docker.md) | Developers, VPS, private cloud |
 
 ## Quick reference
 
@@ -23,7 +23,7 @@ See [`shared-hosting.md`](./shared-hosting.md).
 
 ## Embed on an existing site
 
-After install, add the widget with one script tag on any page **under the same origin**:
+After install, add the **embed widget** with one script tag on any page on the **same origin**:
 
 ```html
 <script
@@ -33,11 +33,11 @@ After install, add the widget with one script tag on any page **under the same o
 ></script>
 ```
 
-Exact paths and attributes will be documented when the widget ships (Phase 3). Same-origin avoids CORS complexity on shared hosting.
+Exact paths and attributes will be documented when the **embed widget** ships (Phase 3). **Same origin** avoids CORS complexity on **shared hosting**.
 
 ## Chat transport
 
-- **Default (both tiers):** synchronous JSON — POST a message, receive full reply + citations.
-- **Optional (Tier B, later):** SSE streaming for progressive display.
+- **Default (both tiers):** **sync JSON chat** — POST a message, receive full reply + **citations**.
+- **Optional (Tier B, later):** **SSE streaming** for progressive display.
 
-Low-frequency FAQ-style traffic (rate limits per session/IP) does not require streaming.
+Low-frequency FAQ-style traffic (**rate limit** per session/IP) does not require **SSE streaming**.

--- a/docs/deployment/shared-hosting.md
+++ b/docs/deployment/shared-hosting.md
@@ -1,8 +1,8 @@
 # Shared Hosting Deployment (Tier A)
 
-Operator guide for **PHP-capable shared hosting** — the primary deployment target for Japan SMB. See ADR 0003.
+Operator guide for **Tier A** **shared hosting** — the primary deployment target for Japan SMB. See ADR 0003 and [`glossary.md`](../explanation/glossary.md).
 
-> **Status:** This path is the **product target** for operators. The web installer and release ZIP ship in **Phase 3**. Until then, advanced operators can deploy manually using the requirements below; Docker remains the supported development path.
+> **Status:** This path is the **product target** for operators. The **web installer** and **release ZIP** ship in **Phase 3**. Until then, advanced operators can deploy manually using the requirements below; Docker remains the supported development path (Tier B).
 
 ## Who this is for
 
@@ -10,7 +10,7 @@ Operator guide for **PHP-capable shared hosting** — the primary deployment tar
 - Operators who want **WordPress-like adoption** — upload, run installer, use admin UI — without replacing their current site
 - Teams that need corpus and chat data on **their MySQL**, not a SaaS vendor
 
-NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on the same domain and embeds into existing pages via one script tag.
+NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on the **same origin** and embeds **embed widget** into existing pages via one script tag.
 
 ## Requirements
 
@@ -30,11 +30,11 @@ NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on 
 2. Upload via FTP or hosting file manager to e.g. `/nene-corpus/` under the domain.
 3. Open **web installer** in browser — database credentials, admin account, optional API keys.
 4. Run migrations from installer (no SSH required).
-5. Copy the **embed snippet** from admin UI into existing homepage template.
+5. Copy the **embed widget** snippet from admin UI into existing homepage template.
 
 ## Embed on existing homepage
 
-Same origin — add one line to any page:
+**Same origin** — add one line to any page:
 
 ```html
 <script
@@ -44,7 +44,7 @@ Same origin — add one line to any page:
 ></script>
 ```
 
-Works alongside WordPress, static HTML, or other CMS pages on the same domain. The widget calls the sync JSON chat API (loading indicator while waiting; no SSE required).
+Works alongside WordPress, static HTML, or other CMS pages on the **same origin**. The **embed widget** calls **sync JSON chat** (loading indicator while waiting; **SSE streaming** not required on Tier A).
 
 ## Manual deploy (until web installer exists)
 
@@ -60,8 +60,8 @@ See [Docker development](../development/docker.md) for the canonical runtime lay
 
 ## Limitations on shared hosting
 
-- **PDF ingestion** may hit execution time and upload size limits — split large files or use VPS for heavy ingestion.
-- **SSE streaming** is not planned as Tier A default; use sync JSON.
+- **PDF ingestion** may hit execution time and upload size limits — split large files or use Tier B for heavy **ingestion**.
+- **SSE streaming** is not planned as Tier A default; use **sync JSON chat**.
 - **Claude API** usage is pay-as-you-go — configure keys in admin UI (Phase 2+).
 
 ## Troubleshooting
@@ -77,3 +77,4 @@ Document host-specific fixes in Issues/PRs as they appear. Common checks:
 - ADR 0003: `docs/adr/0003-dual-deployment-and-embed-widget.md`
 - Docker / VPS (Tier B): `docs/development/docker.md`
 - Product vision: `docs/explanation/product-vision.md`
+- Glossary: `docs/explanation/glossary.md`

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -4,6 +4,8 @@ NeNe Corpus backend policy for PHP API code. This document adapts [NeNe Records 
 
 **Framework baseline:** NENE2 `docs/development/` — deviate only via local ADR.
 
+**Naming and terms:** [`naming-conventions.md`](./naming-conventions.md), [`glossary.md`](../explanation/glossary.md).
+
 ---
 
 ## 1. Project shape
@@ -36,7 +38,7 @@ src/
   Source/             # source file metadata
   Document/           # logical documents
   Chunk/              # searchable text segments
-  Chat/               # send message (sync JSON; SSE optional Tier B)
+  Chat/               # send message (sync JSON chat; optional SSE streaming on Tier B)
   Session/            # consumer sessions
   Message/            # chat messages
   Search/             # full-text over chunks
@@ -58,7 +60,7 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 
 | Layer | May | Must not |
 | --- | --- | --- |
-| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response (or SSE when enabled) | SQL, business rules, direct LLM calls |
+| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response (or **SSE streaming** when enabled) | SQL, business rules, direct LLM calls |
 | **UseCase** | Business rules, orchestration | `$_SERVER`, PDO, raw HTTP to Claude |
 | **Repository** | SQL / persistence | HTTP, session logic |
 | **Llm adapter** | Call Claude API from infrastructure | Domain invariants |
@@ -71,8 +73,8 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 
 - Every public route appears in `docs/openapi/openapi.yaml` with `operationId`.
 - Success and Problem Details error shapes documented.
-- Chat: document **sync JSON** contract first (ADR 0003 — default for Tier A and Tier B).
-- Optional SSE: document in OpenAPI when implemented (Tier B polish).
+- Chat: document **sync JSON chat** contract first (ADR 0003 — default for Tier A and Tier B). See [`glossary.md`](../explanation/glossary.md).
+- Optional **SSE streaming**: document in OpenAPI when implemented (Tier B only).
 - RFC 9457 Problem Details for errors; base URL `https://nene-corpus.dev/problems/`.
 
 ---
@@ -127,7 +129,7 @@ NeNe Records and other CMS APIs are accessed only via `Upstream/` adapters imple
 - HTTP tests: exercise handlers through runtime or narrow integration tests.
 - OpenAPI contract tests in `tests/OpenApi/`.
 
-Naming: `test_{behavior}_when_{condition}`
+Test method naming: see [`naming-conventions.md`](./naming-conventions.md) §7.
 
 ---
 

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -5,6 +5,8 @@ NeNe Corpus coding standards split by surface. **Full policies live in the dedic
 | Surface | Source of truth |
 | --- | --- |
 | **PHP / API / database** | [`backend-standards.md`](./backend-standards.md) |
+| **Naming (code, API, DB, tests)** | [`naming-conventions.md`](./naming-conventions.md) |
+| **Product terms (glossary)** | [`../explanation/glossary.md`](../explanation/glossary.md) |
 | **React / TypeScript admin & widget** | Phase 3 — policy will be added with `frontend/` |
 | **NENE2 inheritance map** | [`../inheritance-from-nene2.md`](../inheritance-from-nene2.md) |
 
@@ -27,7 +29,7 @@ NeNe Corpus coding standards split by surface. **Full policies live in the dedic
 
 ## Backend (summary)
 
-Full policy: **`docs/development/backend-standards.md`**.
+Full policy: **`docs/development/backend-standards.md`**. Naming: **`docs/development/naming-conventions.md`**. Terms: **`docs/explanation/glossary.md`**.
 
 - NENE2 consumer — framework in `vendor/`, product in `src/`
 - Domain-grouped modules — not layer folders

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -1,0 +1,239 @@
+# Naming Conventions
+
+Authoritative naming rules for NeNe Corpus code, API contracts, database objects, tests, and English documentation.
+
+**Glossary (product terms):** [`docs/explanation/glossary.md`](../explanation/glossary.md)
+
+**Reserved (not defined here):** product name vs repository slug vs namespace branding — tracked separately; do not invent alternate spellings until that policy lands.
+
+**Framework baseline:** NENE2 [`domain-layer.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/domain-layer.md) and [`database-migrations.md`](https://github.com/hideyukiMORI/NENE2/blob/main/docs/development/database-migrations.md). This document is the NeNe Corpus override and extension list.
+
+---
+
+## 1. PHP
+
+### Files and namespaces
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Namespace root | `NeneCorpus\` | `NeneCorpus\Chat\SendMessageHandler` |
+| Domain folder | PascalCase singular domain name | `src/Chat/`, `src/RateLimit/` |
+| File name | Match the primary class | `SendMessageHandler.php` |
+| One public class per file | Required | — |
+
+### Classes and interfaces
+
+| Role | Pattern | Example |
+| --- | --- | --- |
+| HTTP handler | `{Verb}{Noun}Handler` | `SendMessageHandler`, `ListSourcesHandler` |
+| Use case interface | `{Verb}{Noun}UseCaseInterface` | `SendMessageUseCaseInterface` |
+| Use case impl | `{Verb}{Noun}UseCase` | `SendMessageUseCase` |
+| Use case method | Always `execute` | `execute(SendMessageInput $input): SendMessageOutput` |
+| Input DTO | `{Verb}{Noun}Input` | `SendMessageInput` |
+| Output DTO | `{Verb}{Noun}Output` | `SendMessageOutput` |
+| Domain entity | Singular noun, no suffix | `Chunk`, `Source`, `ChatSession` |
+| Repository interface | `{Entity}RepositoryInterface` | `ChunkRepositoryInterface` |
+| PDO repository | `Pdo{Entity}Repository` | `PdoChunkRepository` |
+| LLM adapter | `{Provider}{Purpose}Client` or `{Purpose}LlmClient` in `Llm/` | `ClaudeToolUseClient` |
+| Domain exception | `{Entity}{Reason}Exception` | `ChunkNotFoundException` |
+| Service provider | `{Purpose}ServiceProvider` | `RuntimeServiceProvider` |
+
+All application classes: `final` and `readonly` where applicable. Every PHP file: `declare(strict_types=1);`.
+
+### Modules (`src/`)
+
+Use only domain-grouped top-level folders defined in [`backend-standards.md`](./backend-standards.md). Do not add layer folders (`Handlers/`, `Repositories/`, `UseCases/`).
+
+| Folder | Code symbol | Prose term |
+| --- | --- | --- |
+| `Llm/` | `Llm` namespace segment | **LLM** (concept) or **Claude API** (service) |
+| `RateLimit/` | `RateLimit` namespace segment | **rate limit** |
+
+### Methods and properties
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Methods | camelCase | `findById`, `existsByName` |
+| Properties | camelCase | `$sessionId`, `$chunkRepository` |
+| Constants | UPPER_SNAKE_CASE | `MAX_UPLOAD_BYTES` |
+
+Repository methods use **domain verbs**, not SQL verbs: `findById`, `save`, `delete` — not `selectById`, `insertRow`.
+
+---
+
+## 2. HTTP routes and OpenAPI
+
+### URL paths
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Path segments | lowercase **kebab-case** | `/admin/sources`, `/chat/messages` |
+| Collection paths | plural noun | `/chat/sessions`, `/chunks` |
+| Single resource | `{id}` path param | `/admin/sources/{id}` |
+| Path param name | lowercase singular | `id`, `sessionId` |
+| Query params | lowercase; multi-word **snake_case** | `limit`, `source_id` |
+| File endpoints | noun, not verb | `/health` (system exception) |
+
+Admin mutating routes live under `/admin/…`. Consumer chat routes under `/chat/…` (Phase 2+).
+
+### operationId
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Case | camelCase | `getHealth`, `sendChatMessage` |
+| Shape | `{verb}{Resource}` or `{verb}{Resource}ById` | `listSources`, `getSourceById`, `createChatMessage` |
+| Verbs | `get`, `list`, `create`, `update`, `delete`, `send` (chat) | — |
+| Stability | Never rename after release; deprecate instead | — |
+
+Must match between `docs/openapi/openapi.yaml`, route registration, and `docs/mcp/tools.json` `operationId`.
+
+### OpenAPI schema names
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Response schema | `{Resource}Response` | `ChatMessageResponse` |
+| List response | `{Resource}ListResponse` with `items`, `limit`, `offset` | `SourceListResponse` |
+| Create request | `Create{Resource}Request` | `CreateSourceRequest` |
+| Update request | `Update{Resource}Request` | `UpdateSourceRequest` |
+| Tag names | PascalCase singular group | `System`, `Admin`, `Chat`, `Ingestion` |
+
+Public OpenAPI summaries, descriptions, and examples: **English only**.
+
+---
+
+## 3. JSON (request and response bodies)
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Property names | **snake_case** | `document_id`, `created_at`, `session_id` |
+| Single-word fields | lowercase English word | `id`, `status`, `body`, `title`, `items` |
+| Booleans | `is_` / `has_` prefix | `is_deleted`, `has_citations` |
+| Timestamps | `_at` suffix, ISO 8601 string | `created_at`, `updated_at` |
+| Foreign keys in JSON | `{entity}_id` | `source_id`, `chunk_id` |
+| List envelope | `items`, `limit`, `offset` | Same as NENE2 list pattern |
+| Chat citation object | `citations` array; each item includes `document_id`, `chunk_id`, and optional `page`, `section`, `excerpt` | Phase 2 contract |
+
+Do not mix camelCase in public JSON. Widget and admin UI must consume snake_case API fields as documented.
+
+---
+
+## 4. Problem Details and validation errors
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Base URL | `https://nene-corpus.dev/problems/` | — |
+| Type slug | kebab-case | `validation-failed`, `rate-limit-exceeded`, `source-not-found` |
+| Full type URI | base + slug | `https://nene-corpus.dev/problems/source-not-found` |
+| Validation `errors[].field` | snake_case path | `body.email`, `query.limit` |
+| Validation `errors[].code` | snake_case | `required`, `invalid_mime_type` |
+
+Problem Details `title` and `detail`: English. See [`backend-standards.md`](./backend-standards.md) §4.
+
+---
+
+## 5. Database
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Table names | snake_case, **plural** | `sources`, `documents`, `chunks`, `chat_sessions`, `chat_messages`, `rate_limit_buckets` |
+| Column names | snake_case | `source_id`, `created_at`, `is_deleted` |
+| Primary key | `id` | `BIGINT` / `INTEGER` auto-increment |
+| Foreign key column | `{singular_entity}_id` | `document_id`, `session_id` |
+| Index names | `idx_{table}_{columns}` | `idx_chunks_source_id` |
+| Unique constraints | `uniq_{table}_{columns}` | `uniq_sources_path` |
+
+SQL lives only in `Pdo*Repository` classes. No table or column names in handlers or use cases except as mapped domain properties.
+
+### Migrations
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| File name | `YYYYMMDDHHMMSS_snake_description.php` | `20260525120000_create_sources_table.php` |
+| Class name | Phinx PascalCase derived from description | `CreateSourcesTable` |
+| Snapshot file | `database/schema/{table}.sql` | `database/schema/sources.sql` |
+
+See [`docs/review/database.md`](../review/database.md).
+
+---
+
+## 6. Environment variables
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Names | UPPER_SNAKE_CASE | `ANTHROPIC_API_KEY`, `DB_HOST` |
+| Prefix | Product-specific vars may use `NENE_CORPUS_` for compose overrides | `NENE_CORPUS_PORT` |
+| Secrets | Never commit; document only in `.env.example` with empty value | — |
+
+---
+
+## 7. Tests
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Test class | `{ClassUnderTest}Test` | `SendMessageUseCaseTest` |
+| Test method | `test_{behavior}_when_{condition}` | `test_returns_citations_when_chunks_match` |
+| Test namespace | Mirror `src/` under `tests/` | `tests/Chat/SendMessageUseCaseTest.php` |
+
+---
+
+## 8. MCP tools
+
+| Item | Rule | Example |
+| --- | --- | --- |
+| Tool `name` | Same as OpenAPI `operationId` | `getHealth` |
+| Tool `title` | Short English Title Case | `Health` |
+| `safety` | `read` or `write` | Phase 0+ ops: prefer `read` |
+
+Catalog: `docs/mcp/tools.json`. Validate with `composer mcp`.
+
+---
+
+## 9. Frontend (Phase 3+)
+
+Policy lands with `frontend/`. Until then, reserve:
+
+| Item | Rule |
+| --- | --- |
+| Components | PascalCase file and export (`EmbedWidget.tsx`) |
+| Hooks | camelCase with `use` prefix (`useChatSession`) |
+| API client | Maps snake_case JSON to typed TS interfaces; do not rename API fields in transit |
+| Embed bundle | **`widget.js`** (fixed public file name) |
+| CSS | BEM-style or scoped modules; prefix block with `nene-corpus-` to avoid host site collisions |
+
+Full frontend standards: add `docs/development/frontend-standards.md` in the Phase 3 Issue that introduces `frontend/`.
+
+---
+
+## 10. Documentation and commits
+
+| Surface | Language | Naming |
+| --- | --- | --- |
+| Public docs, OpenAPI, API errors | English | Use glossary canonical terms |
+| Issues, PRs, commit bodies | Japanese allowed | Prefer glossary English term on first mention |
+| Commit subject | Conventional Commits + `(#issue)` | See [`commit-conventions.md`](./commit-conventions.md) |
+| ADR file | `NNNN-kebab-title.md` | `0003-dual-deployment-and-embed-widget.md` |
+
+When adding a new public term, update [`glossary.md`](../explanation/glossary.md) in the same PR.
+
+---
+
+## 11. Prohibited patterns
+
+- Layer-first folders (`src/Handlers/`, `src/Repositories/`)
+- SQL outside `Pdo*Repository`
+- camelCase in public JSON property names
+- Renaming shipped `operationId` values
+- New synonyms for glossary terms in English docs (e.g. do not write "streaming chat" when the doc means **SSE streaming**; do not write "synchronous JSON" when the doc means **sync JSON chat**)
+- MCP tools exposed to **embed widget** or consumer chat clients
+
+---
+
+## Verification
+
+```bash
+composer check
+composer openapi
+composer mcp
+```
+
+Review checklists: [`docs/review/`](../review/) — cite `Self-review: openapi-contract`, `database`, or `docs-policy` as applicable.

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -1,0 +1,115 @@
+# Glossary
+
+Canonical English terms for NeNe Corpus documentation, OpenAPI, code comments, and AI agent output.
+
+**Naming rules (code, API, DB):** [`docs/development/naming-conventions.md`](../development/naming-conventions.md)
+
+**Reserved:** product name vs repository slug vs filesystem path branding — not defined here; do not standardize alternate spellings until a dedicated policy Issue closes.
+
+---
+
+## How to use this glossary
+
+1. In **English docs and OpenAPI**, use the **Canonical term** exactly. Synonyms listed under **Do not use** are forbidden in new text.
+2. In **Issues and PRs (Japanese)**, you may use the **Japanese note** column on first mention, then the canonical English term in backticks.
+3. Adding or changing a term requires updating this file in the same PR.
+
+---
+
+## Deployment and product shape
+
+| Canonical term | Definition | Japanese note | Do not use |
+| --- | --- | --- | --- |
+| **Tier A** | PHP **shared hosting** deployment path: ZIP upload, web installer, MySQL, FTP/SSH. Primary operator audience: Japan SMB. | ティア A / 共用ホスティング向け | "rental server tier", "hosting-only", "FTP tier" |
+| **Tier B** | **Docker / VPS** deployment path: `docker compose up`, reproducible dev and production on controlled servers. | ティア B / Docker・VPS 向け | "cloud-only", "dev tier" (Tier B is also production) |
+| **dual deployment** | Same codebase and API; Tier A and Tier B differ only in packaging, installer, and docs. ADR 0003. | デュアルデプロイ | "multi-deploy", "two products" |
+| **shared hosting** | PHP-capable operator hosting (MySQL, FTP/file manager, no Docker required). Tier A target. | 共用ホスティング / レンタルサーバー（日本語 docs のみ） | "shared server", "mutual hosting" |
+| **web installer** | Browser-based first-time setup (DB, admin account, keys). Tier A Phase 3 deliverable. | Web インストーラ | "setup wizard" (unless referring to the same UI) |
+| **release ZIP** | Distribution archive with `vendor/` bundled for Tier A upload. | 配布 ZIP | "deployment pack", "hosting bundle" |
+
+---
+
+## Chat, widget, and transport
+
+| Canonical term | Definition | Japanese note | Do not use |
+| --- | --- | --- | --- |
+| **sync JSON chat** | Default consumer chat transport: HTTP POST → wait → single JSON body with message text and **citations**. Tier A and Tier B default. | 同期 JSON チャット | "synchronous JSON", "async chat", "REST polling" (unless describing a future job poll API) |
+| **SSE streaming** | Optional Tier B enhancement: token-by-token Server-Sent Events stream. Not required for FAQ traffic. | SSE ストリーミング | "streaming chat" (ambiguous), "websocket chat" |
+| **embed widget** | The `widget.js` bundle plus one same-origin `<script>` embed on an existing site. Phase 3. | 埋め込みウィジェット | "chat widget" alone, "plugin", "snippet" |
+| **consumer chat** | End-user Q&A feature (sessions, messages, citations). Distinct from admin UI and MCP. | コンシューマーチャット | "user chatbot", "public bot" |
+| **same origin** | Widget and API share scheme + host + port; avoids CORS on shared hosting. | 同一オリジン | "same domain" (acceptable in casual Japanese; English docs use **same origin**) |
+| **citation** | Reference to a corpus **chunk** in an assistant message (`document_id`, `chunk_id`, optional page/section/excerpt). | 引用 / 出典 | "source link", "reference" (without corpus meaning) |
+| **rate limit** | Request cap per session and/or IP before LLM calls. | レート制限 | "throttle" (internal only), "daily cap" (unless specifically daily) |
+
+---
+
+## Corpus domain
+
+| Canonical term | Definition | Japanese note | Do not use |
+| --- | --- | --- | --- |
+| **corpus** | The searchable body of ingested knowledge (documents split into chunks). | コーパス | "knowledge base" (marketing OK once; spec uses **corpus**) |
+| **source** | Uploaded or registered origin of content (file path, upload batch, upstream ref). Table: `sources`. | ソース | "file" (when meaning source entity), "dataset" |
+| **document** | Logical document derived from a source (PDF, CSV row set, etc.). Table: `documents`. | ドキュメント | "file", "record" |
+| **chunk** | Searchable text segment indexed for retrieval and citation. Table: `chunks`. | チャンク | "paragraph", "embedding row" |
+| **ingestion** | Upload, parse, chunk, and index pipeline. Module: `Ingestion/`. | 取り込み | "import", "ETL" (unless external systems) |
+| **reindex** | Rebuild chunks/index for a source. | 再インデックス | "refresh", "resync" |
+
+---
+
+## Sessions and auth
+
+| Canonical term | Definition | Japanese note | Do not use |
+| --- | --- | --- | --- |
+| **chat session** | Consumer conversation container. Table: `chat_sessions`. | チャットセッション | "thread", "room" |
+| **chat message** | Single user or assistant turn. Table: `chat_messages`. | チャットメッセージ | "utterance", "post" |
+| **admin auth** | JWT Bearer for mutating admin routes. Module: `AdminAuth/`. | 管理認証 | "user login" (ambiguous with consumer) |
+| **consumer session token** | Anonymous or lightweight token for embed widget; never admin JWT. | コンシューマーセッション | "API key" (consumer), "guest JWT" |
+
+---
+
+## LLM and integrations
+
+| Canonical term | Definition | JavaScript note | Do not use |
+| --- | --- | --- | --- |
+| **LLM** | Large language model capability in prose/docs. | — | "AI" alone in specs |
+| **Claude API** | Anthropic HTTP API used server-side (`ANTHROPIC_API_KEY`). | — | "OpenAI", "GPT" (wrong vendor) |
+| **tool_use** | Claude server-side tool orchestration mapped to HTTP/search operations. Module folder: `Llm/`. | snake_case in API payloads if exposed | "function calling" in OpenAPI titles |
+| **upstream** | Optional external HTTP content API (e.g. NeNe Records). Module: `Upstream/`. | — | "plugin", "CMS embed" |
+| **MCP** | Model Context Protocol tools for **ops read-only** agents; maps to OpenAPI. Not for embed widget. | — | "consumer MCP", "chat MCP" |
+
+---
+
+## API and errors
+
+| Canonical term | Definition | Do not use |
+| --- | --- | --- |
+| **Problem Details** | RFC 9457 error envelope (`application/problem+json`). | "error JSON", "exception response" |
+| **operationId** | Stable camelCase identifier shared by OpenAPI, routes, and MCP. | "endpoint name", "route id" |
+| **OpenAPI contract** | `docs/openapi/openapi.yaml` — public API source of truth. | "Swagger doc" in policy text |
+
+---
+
+## Architecture layers
+
+| Canonical term | Definition | Do not use |
+| --- | --- | --- |
+| **handler** | HTTP adapter class (`*Handler`); thin. | "controller" in new NeNe Corpus code/docs |
+| **use case** | Application operation (`*UseCase`, method `execute`). | "service" for use-case layer |
+| **repository** | Persistence port (`*RepositoryInterface`, `Pdo*Repository`). | "DAO", "model" |
+
+---
+
+## Explicit non-goals (terminology)
+
+| Term | Meaning |
+| --- | --- |
+| **WordPress plugin** | Not supported. Coexist on same origin only. |
+| **Docker-only deployment** | Not a goal. Tier A must remain first-class. |
+
+---
+
+## Related
+
+- ADR 0003: dual deployment and embed widget
+- [`docs/deployment/README.md`](../deployment/README.md)
+- [`docs/development/backend-standards.md`](../development/backend-standards.md)

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -24,13 +24,13 @@ NeNe Corpus is **not** a PHP framework. It is a **product** that consumes NENE2.
 
 ## Target operators and markets
 
-**Primary — Japan SMB on PHP shared hosting**
+**Primary — Japan SMB on Tier A shared hosting**
 
-Operators who already have a company website on rental hosting and want a FAQ / manual chatbot **without SaaS lock-in**. Adoption should feel as approachable as WordPress: upload, run installer, manage from admin UI — **not** as a WordPress plugin, but as a sibling app on the same domain.
+Operators who already have a company website on **shared hosting** and want a FAQ / manual **consumer chat** **without SaaS lock-in**. Adoption should feel as approachable as WordPress: upload, **web installer**, manage from admin UI — **not** as a WordPress plugin, but as a sibling app on the **same origin**.
 
-**Secondary — developers and VPS / private cloud**
+**Secondary — Tier B developers and VPS / private cloud**
 
-Docker Compose for local dev and production on VPS. Same API and widget as Tier A; optional SSE streaming later.
+Docker Compose for local dev and production on VPS. Same API and **embed widget** as Tier A; optional **SSE streaming** later.
 
 **Later — international**
 
@@ -42,14 +42,14 @@ Same codebase, two installation paths (ADR 0003):
 
 | Tier | Path | Chat transport |
 | --- | --- | --- |
-| **A — Shared hosting** | ZIP + web installer + MySQL | Sync JSON (default) |
-| **B — Docker / VPS** | `docker compose up` | Sync JSON (default); SSE optional |
+| **Tier A — shared hosting** | **release ZIP** + **web installer** + MySQL | **sync JSON chat** (default) |
+| **Tier B — Docker / VPS** | `docker compose up` | **sync JSON chat** (default); **SSE streaming** optional |
 
-See [`docs/deployment/README.md`](../deployment/README.md).
+See [`docs/deployment/README.md`](../deployment/README.md) and [`glossary.md`](./glossary.md).
 
 ## Embed on existing sites
 
-Consumer chat is added to an **existing homepage** with one script tag on the **same origin**:
+**Consumer chat** is added to an **existing homepage** with one script tag on the **same origin** (**embed widget**):
 
 ```html
 <script src="/nene-corpus/widget.js" data-endpoint="/nene-corpus/api" defer></script>
@@ -57,13 +57,13 @@ Consumer chat is added to an **existing homepage** with one script tag on the **
 
 No site rebuild required. Works with WordPress themes, static HTML, or any CMS that allows a custom script include.
 
-FAQ-style traffic is **low frequency** (rate limits per session/IP). Synchronous JSON responses with a loading state are sufficient; streaming is optional polish for Tier B.
+FAQ-style traffic is **low frequency** (**rate limit** per session/IP). **sync JSON chat** with a loading state is sufficient; **SSE streaming** is optional polish for Tier B.
 
 ## Philosophy
 
 ### 1. Self-hosted OSS first
 
-MIT license. **Dual deployment:** Docker Compose for developers and VPS; web installer + ZIP for PHP shared hosting. No mandatory cloud vendor.
+MIT license. **Dual deployment:** Docker Compose for Tier B; **web installer** + **release ZIP** for Tier A **shared hosting**. No mandatory cloud vendor.
 
 ### 2. Citations are the contract
 
@@ -85,8 +85,8 @@ NENE2 (framework)
 | --- | --- |
 | **NENE2 runtime** | HTTP, DI, middleware, Problem Details |
 | **NeNe Corpus API** | Ingestion, corpus storage, chat, rate limits, audit |
-| **Admin UI** | Upload, reindex, logs, prompt settings, widget embed snippet |
-| **Consumer widget** | Chat UX over sync JSON (SSE optional on Tier B) |
+| **Admin UI** | Upload, reindex, logs, prompt settings, **embed widget** snippet |
+| **Embed widget** | **Consumer chat** UX over **sync JSON chat** (**SSE streaming** optional on Tier B) |
 | **Claude API** | Reasoning + tool_use (server-side only) |
 | **Upstream APIs** | NeNe Records public/search APIs (read-only client) |
 | **MCP tools** | Ops read-only — never consumer-facing |
@@ -108,7 +108,7 @@ Explicit domain modules, small use cases, typed DTOs, ADRs, Issue-driven workflo
 | Customization | Limited | Fork, extend, self-host |
 | Citations | Varies | Core product promise |
 | CMS | Bundled or separate | Optional NeNe Records upstream |
-| Deploy | Vendor-hosted | Shared hosting or Docker/VPS |
+| Deploy | Vendor-hosted | **Tier A** shared hosting or **Tier B** Docker/VPS |
 
 ## Relationship to NENE2
 
@@ -135,4 +135,9 @@ NeNe Records   → sibling CMS (optional upstream)
 
 ## Naming
 
-**NeNe Corpus** — a body of knowledge you own. Pairs with **NeNe Records** (typed records you edit).
+Product display names (reserved policy — full rules in a follow-up Issue):
+
+- **NeNe Corpus** — a body of knowledge you own.
+- **NeNe Records** — typed records you edit (optional upstream).
+
+All other terms: [`glossary.md`](./glossary.md). Code and API naming: [`naming-conventions.md`](../development/naming-conventions.md).

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -48,10 +48,12 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | Public Problem Details base URL | `https://nene-corpus.dev/problems/` |
 | Namespace | `NeneCorpus\` |
 | Coding standards | `docs/development/coding-standards.md` — NENE2 baseline + chat domains |
+| Naming conventions | `docs/development/naming-conventions.md` |
+| Glossary | `docs/explanation/glossary.md` |
 | Backend standards | `docs/development/backend-standards.md` |
 | Language policy | English for public docs, OpenAPI, API errors; Japanese allowed in Issues, PRs, commits, `.cursor/rules/` |
 | Review checklists | `docs/review/` — task-specific lists for this product |
-| Transport | Sync JSON chat (Phase 2+ default); SSE optional (Tier B) — ADR 0003 |
+| Transport | **sync JSON chat** (Phase 2+ default); **SSE streaming** optional (Tier B) — ADR 0003, [`glossary.md`](./explanation/glossary.md) |
 | Deployment | Tier A shared hosting + Tier B Docker/VPS — `docs/deployment/` |
 | External services | Claude API (server-side), optional NeNe Records HTTP client |
 

--- a/docs/review/backend-api.md
+++ b/docs/review/backend-api.md
@@ -1,6 +1,6 @@
 # Self-Review: Backend API
 
-Use when changing handlers, use cases, routes, or OpenAPI paths under `src/`.
+Use when changing handlers, use cases, routes, or OpenAPI paths under `src/`. Policy: **`docs/development/backend-standards.md`**, **`docs/development/naming-conventions.md`**, **`docs/explanation/glossary.md`**.
 
 ## Contract
 

--- a/docs/review/database.md
+++ b/docs/review/database.md
@@ -1,6 +1,6 @@
 # Database Self-Review
 
-Use for migrations, schema docs, repositories, and soft-delete behavior. Policy source: **`docs/development/backend-standards.md`**.
+Use for migrations, schema docs, repositories, and soft-delete behavior. Policy sources: **`docs/development/backend-standards.md`**, **`docs/development/naming-conventions.md`** §5.
 
 Also read:
 

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -7,6 +7,8 @@ Source policies:
 - `docs/workflow.md`
 - `docs/development/adr.md`
 - `docs/inheritance-from-nene2.md`
+- `docs/explanation/glossary.md`
+- `docs/development/naming-conventions.md`
 - `docs/todo/current.md`
 - `docs/roadmap.md`
 
@@ -20,4 +22,6 @@ Source policies:
 - [ ] Cursor rules stay concise; full policy not duplicated in `.cursor/rules/`.
 - [ ] Issue and PR references included where useful.
 - [ ] Wording is concrete enough for humans and AI agents to follow.
+- [ ] English docs use canonical terms from `docs/explanation/glossary.md` (no forbidden synonyms).
+- [ ] New public terms or API field names added to glossary and/or `naming-conventions.md` when introduced.
 - [ ] `git diff --check` reviewed for whitespace errors.

--- a/docs/review/openapi-contract.md
+++ b/docs/review/openapi-contract.md
@@ -1,6 +1,6 @@
 # OpenAPI Contract Self-Review
 
-Use when changing `docs/openapi/openapi.yaml` or API response shapes. Policy source: **`docs/development/backend-standards.md`**.
+Use when changing `docs/openapi/openapi.yaml` or API response shapes. Policy sources: **`docs/development/backend-standards.md`**, **`docs/development/naming-conventions.md`**, **`docs/explanation/glossary.md`**.
 
 Also read:
 
@@ -8,10 +8,11 @@ Also read:
 
 ## Contract completeness
 
-- [ ] Every shipped JSON endpoint has an OpenAPI path with stable `operationId`.
+- [ ] Every shipped JSON endpoint has an OpenAPI path with stable `operationId` (camelCase per naming conventions).
 - [ ] Summary, description, request body, query params match handler format validation.
 - [ ] Success response has schema and realistic `ok` example.
 - [ ] Problem Details responses documented (`401`, `404`, `422`, `500`, … as applicable).
+- [ ] JSON property names use snake_case; list responses use `items`, `limit`, `offset`.
 - [ ] Public OpenAPI text is English.
 
 ## Runtime alignment

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,10 +9,10 @@ Operators can self-host a corpus + chat platform that:
 - ingests PDF and CSV into searchable, citable chunks
 - answers consumer questions with source references
 - provides admin UI for uploads, logs, and configuration
-- embeds chat on an **existing homepage** with one script tag (same origin)
+- embeds **embed widget** on an **existing homepage** with one script tag (**same origin**)
 - optionally queries [NeNe Records](https://github.com/hideyukiMORI/nene-records) via read-only HTTP
 
-**Primary market:** Japan SMB on PHP shared hosting. **Dual deployment:** Tier A (shared hosting) and Tier B (Docker/VPS) — ADR 0003.
+**Primary market:** Japan SMB on **Tier A** **shared hosting**. **Dual deployment:** Tier A and Tier B — ADR 0003. Terms: [`glossary.md`](./explanation/glossary.md).
 
 ## Phase 0: Governance and Foundation
 
@@ -44,19 +44,19 @@ Goal: grounded Q&A with cited responses.
 - Chat sessions and messages
 - Full-text search over chunks
 - Claude tool_use orchestration (server-side)
-- **Sync JSON chat endpoint** (default for Tier A and Tier B)
-- Citation payload in responses
-- Rate limiting per session/IP
-- Optional: SSE streaming endpoint (Tier B polish — not required for low-frequency FAQ traffic)
+- **sync JSON chat** endpoint (default for Tier A and Tier B)
+- **Citation** payload in responses
+- **Rate limit** per session/IP
+- Optional: **SSE streaming** endpoint (Tier B — not required for low-frequency FAQ traffic)
 
 ## Phase 3: Admin UI & Widget
 
 Goal: operable product without curl; Tier A install path.
 
 - React admin: sources, ingestion status, conversation logs
-- **Embeddable consumer chat widget** (`widget.js` + embed snippet for same-origin pages)
+- **Embeddable embed widget** (`widget.js` + snippet for **same origin** pages)
 - Prompt / scope / fallback settings UI
-- **Tier A deliverables:** web installer, release ZIP (vendor bundled), shared-hosting operator docs
+- **Tier A deliverables:** **web installer**, **release ZIP** (vendor bundled), shared-hosting operator docs
 
 ## Phase 4: Upstream Integrations
 
@@ -70,10 +70,10 @@ Goal: optional NeNe Records and export APIs.
 
 | Tier | Phase | Deliverable |
 | --- | --- | --- |
-| **B — Docker / VPS** | 0 (now) | `docker compose up`, `docs/development/docker.md` |
-| **A — Shared hosting** | 3 | Web installer, ZIP, `docs/deployment/shared-hosting.md` |
+| **Tier B — Docker / VPS** | 0 (now) | `docker compose up`, `docs/development/docker.md` |
+| **Tier A — shared hosting** | 3 | **web installer**, **release ZIP**, `docs/deployment/shared-hosting.md` |
 
-Same API and widget for both tiers. Chat uses sync JSON by default.
+Same API and **embed widget** for both tiers. Chat uses **sync JSON chat** by default.
 
 ## Non-goals
 
@@ -99,3 +99,5 @@ Framework changes → NENE2. CMS → nene-records. Chat/corpus → here.
 - ADR 0003: dual deployment and embed widget
 - Deployment: `docs/deployment/README.md`
 - Product vision: `docs/explanation/product-vision.md`
+- Glossary: `docs/explanation/glossary.md`
+- Naming: `docs/development/naming-conventions.md`

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,6 +5,7 @@ Last updated: 2026-05-25
 ## 最近の docs 更新
 
 - ADR 0003: デュアルデプロイ（Tier A 共用ホスティング / Tier B Docker）、同期 JSON チャット、1行 embed — Issue #3
+- 命名規則 + 用語集（`naming-conventions.md`, `glossary.md`）— Issue #5
 
 ## 状態サマリー
 
@@ -49,9 +50,9 @@ Last updated: 2026-05-25
 | P0 | Sessions + messages | 会話永続化 |
 | P0 | Chunk search | full-text |
 | P0 | Claude tool_use + citations | サーバー側のみ |
-| P0 | Sync JSON chat API | Tier A/B 共通デフォルト（ADR 0003） |
-| P1 | Rate limiting | session / IP |
-| P2 | SSE streaming | Tier B 任意（低頻度 FAQ では不要） |
+| P0 | Sync JSON chat API | Tier A/B 共通デフォルト（ADR 0003） — 用語: **sync JSON chat** |
+| P1 | Rate limiting | session / IP — 用語: **rate limit** |
+| P2 | SSE streaming | Tier B 任意 — 用語: **SSE streaming** |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add **`docs/development/naming-conventions.md`** — authoritative rules for PHP classes, HTTP/OpenAPI, JSON (snake_case), DB, tests, MCP, Problem Details
- Add **`docs/explanation/glossary.md`** — canonical English terms with forbidden synonyms (Tier A/B, sync JSON chat, embed widget, corpus domain, etc.)
- Wire indexes, review checklists, inheritance map, and existing docs to glossary terms
- **Reserved:** product name vs repository slug policy — explicitly deferred

## Test plan

- [x] Glossary ↔ naming-conventions cross-links
- [x] Review checklists reference new docs
- [x] Existing deployment/product docs aligned to canonical terms
- [ ] CI green (docs-only)

Closes #5

Self-review: docs-policy


Made with [Cursor](https://cursor.com)