### PR TITLE
feat(corpus): sources/documents/chunks スキーマとリポジトリを追加する (#7)

### DIFF
--- a/database/migrations/20260525120000_create_corpus_tables.php
+++ b/database/migrations/20260525120000_create_corpus_tables.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateCorpusTables extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('sources')
+            ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('source_type', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('status', 'string', ['limit' => 32, 'null' => false, 'default' => 'pending'])
+            ->addColumn('storage_path', 'string', ['limit' => 512, 'null' => false])
+            ->addColumn('original_filename', 'string', ['limit' => 255, 'null' => true])
+            ->addColumn('mime_type', 'string', ['limit' => 127, 'null' => true])
+            ->addColumn('byte_size', 'biginteger', ['null' => true, 'signed' => false])
+            ->addColumn('error_message', 'text', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true])
+            ->addIndex(['status'], ['name' => 'idx_sources_status'])
+            ->addIndex(['is_deleted'], ['name' => 'idx_sources_is_deleted'])
+            ->create();
+
+        $this->table('documents')
+            ->addColumn('source_id', 'biginteger', ['null' => false, 'signed' => false])
+            ->addColumn('title', 'string', ['limit' => 512, 'null' => false])
+            ->addColumn('position', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('metadata_json', 'text', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addColumn('is_deleted', 'boolean', ['null' => false, 'default' => false])
+            ->addColumn('deleted_at', 'datetime', ['null' => true])
+            ->addIndex(['source_id'], ['name' => 'idx_documents_source_id'])
+            ->addIndex(['is_deleted'], ['name' => 'idx_documents_is_deleted'])
+            ->addForeignKey('source_id', 'sources', 'id', ['delete' => 'CASCADE', 'update' => 'CASCADE'])
+            ->create();
+
+        $this->table('chunks')
+            ->addColumn('document_id', 'biginteger', ['null' => false, 'signed' => false])
+            ->addColumn('source_id', 'biginteger', ['null' => false, 'signed' => false])
+            ->addColumn('chunk_index', 'integer', ['null' => false, 'default' => 0])
+            ->addColumn('content', 'text', ['null' => false])
+            ->addColumn('page_number', 'integer', ['null' => true])
+            ->addColumn('section_label', 'string', ['limit' => 255, 'null' => true])
+            ->addColumn('token_count', 'integer', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['document_id'], ['name' => 'idx_chunks_document_id'])
+            ->addIndex(['source_id'], ['name' => 'idx_chunks_source_id'])
+            ->addForeignKey('document_id', 'documents', 'id', ['delete' => 'CASCADE', 'update' => 'CASCADE'])
+            ->addForeignKey('source_id', 'sources', 'id', ['delete' => 'CASCADE', 'update' => 'CASCADE'])
+            ->create();
+    }
+}

--- a/database/schema/chunks.sql
+++ b/database/schema/chunks.sql
@@ -1,0 +1,18 @@
+-- Snapshot: chunks (searchable text segments for citation)
+CREATE TABLE chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    document_id BIGINT UNSIGNED NOT NULL,
+    source_id BIGINT UNSIGNED NOT NULL,
+    chunk_index INTEGER NOT NULL DEFAULT 0,
+    content TEXT NOT NULL,
+    page_number INTEGER NULL,
+    section_label VARCHAR(255) NULL,
+    token_count INTEGER NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE ON UPDATE CASCADE,
+    FOREIGN KEY (source_id) REFERENCES sources (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX idx_chunks_document_id ON chunks (document_id);
+CREATE INDEX idx_chunks_source_id ON chunks (source_id);

--- a/database/schema/documents.sql
+++ b/database/schema/documents.sql
@@ -1,0 +1,16 @@
+-- Snapshot: documents (logical document within a source)
+CREATE TABLE documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id BIGINT UNSIGNED NOT NULL,
+    title VARCHAR(512) NOT NULL,
+    position INTEGER NOT NULL DEFAULT 0,
+    metadata_json TEXT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL,
+    FOREIGN KEY (source_id) REFERENCES sources (id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX idx_documents_source_id ON documents (source_id);
+CREATE INDEX idx_documents_is_deleted ON documents (is_deleted);

--- a/database/schema/sources.sql
+++ b/database/schema/sources.sql
@@ -1,0 +1,19 @@
+-- Snapshot: sources (corpus ingestion origin)
+CREATE TABLE sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name VARCHAR(255) NOT NULL,
+    source_type VARCHAR(32) NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'pending',
+    storage_path VARCHAR(512) NOT NULL,
+    original_filename VARCHAR(255) NULL,
+    mime_type VARCHAR(127) NULL,
+    byte_size BIGINT UNSIGNED NULL,
+    error_message TEXT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT 0,
+    deleted_at DATETIME NULL
+);
+
+CREATE INDEX idx_sources_status ON sources (status);
+CREATE INDEX idx_sources_is_deleted ON sources (is_deleted);

--- a/docs/milestones/2026-05-corpus-ingestion.md
+++ b/docs/milestones/2026-05-corpus-ingestion.md
@@ -1,0 +1,31 @@
+# Milestone: Corpus Storage & Ingestion (2026-05)
+
+Goal: store **sources**, **documents**, and **chunks** — the canonical ingestion model for Phase 1.
+
+**Status: in progress**
+
+Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 1.
+
+## Acceptance Criteria
+
+- [x] Phinx migration for `sources`, `documents`, `chunks` (#7)
+- [x] Schema snapshots in `database/schema/`
+- [x] Domain entities + `Pdo*Repository` adapters + service providers
+- [x] Repository tests (SQLite `:memory:`)
+- [ ] Admin auth (JWT) for mutating routes
+- [ ] CSV upload API + column mapping preview
+- [ ] PDF text extraction (text PDF first)
+- [ ] Admin HTTP routes + OpenAPI
+- [ ] Reindex / delete **source** operations API
+
+## Verification
+
+```bash
+composer migrations:migrate
+composer check
+```
+
+## Related
+
+- Issue #7 — schema foundation
+- [`docs/explanation/glossary.md`](../explanation/glossary.md) — corpus domain terms

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -9,9 +9,27 @@ Last updated: 2026-05-25
 
 ## 状態サマリー
 
-**Phase 0 — Governance & Foundation: 完了（2026-05-25）**
+**Phase 1 — Corpus & Ingestion: 進行中（2026-05-25）**
+
+- ✅ Schema: `sources`, `documents`, `chunks`（#7）
+- 🔜 Admin auth (JWT)
+- 🔜 CSV / PDF ingestion API
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
+
+---
+
+## Phase 1 進捗
+
+| 項目 | 状態 |
+| --- | --- |
+| Schema: sources, documents, chunks | ✅ (#7) |
+| Admin auth (JWT) | 🔜 |
+| CSV upload API | 🔜 |
+| PDF text extraction | 🔜 |
+| Reindex / delete source | 🔜 |
+
+Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05-corpus-ingestion.md)
 
 ---
 
@@ -32,8 +50,7 @@ Last updated: 2026-05-25
 
 | 優先 | 項目 | 説明 |
 | --- | --- | --- |
-| P0 | Issue 起票 + branch | 例: `feat/2-schema-sources-documents-chunks` |
-| P0 | Schema: sources, documents, chunks | 取り込み正本 |
+| ~~P0~~ | ~~Schema: sources, documents, chunks~~ | ✅ #7 |
 | P0 | Admin auth (JWT) | 管理 API 保護 |
 | P1 | CSV upload API | 列マッピング preview |
 | P1 | PDF text extraction | テキスト PDF のみ（Phase 1） |

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -7,6 +7,9 @@ namespace NeneCorpus;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneCorpus\Chunk\ChunkServiceProvider;
+use NeneCorpus\Document\DocumentServiceProvider;
+use NeneCorpus\Source\SourceServiceProvider;
 use Psr\Container\ContainerInterface;
 
 final readonly class ApplicationServiceProvider implements ServiceProviderInterface
@@ -18,6 +21,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
     public function register(ContainerBuilder $builder): void
     {
         $builder
+            ->addProvider(new SourceServiceProvider())
+            ->addProvider(new DocumentServiceProvider())
+            ->addProvider(new ChunkServiceProvider())
             ->set(
                 self::ROUTE_REGISTRARS,
                 static fn (ContainerInterface $container): array => [],

--- a/src/Chunk/Chunk.php
+++ b/src/Chunk/Chunk.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chunk;
+
+final readonly class Chunk
+{
+    public function __construct(
+        public int $documentId,
+        public int $sourceId,
+        public string $content,
+        public int $chunkIndex = 0,
+        public ?int $pageNumber = null,
+        public ?string $sectionLabel = null,
+        public ?int $tokenCount = null,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Chunk/ChunkRepositoryInterface.php
+++ b/src/Chunk/ChunkRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chunk;
+
+interface ChunkRepositoryInterface
+{
+    public function findById(int $id): ?Chunk;
+
+    /** @return list<Chunk> */
+    public function findByDocumentId(int $documentId): array;
+
+    public function save(Chunk $chunk): int;
+}

--- a/src/Chunk/ChunkServiceProvider.php
+++ b/src/Chunk/ChunkServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chunk;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class ChunkServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            ChunkRepositoryInterface::class,
+            static function (ContainerInterface $container): ChunkRepositoryInterface {
+                $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoChunkRepository($query);
+            },
+        );
+    }
+}

--- a/src/Chunk/PdoChunkRepository.php
+++ b/src/Chunk/PdoChunkRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chunk;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoChunkRepository implements ChunkRepositoryInterface
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        id, document_id, source_id, chunk_index, content, page_number, section_label,
+        token_count, created_at, updated_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Chunk
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chunks WHERE id = ?',
+            [$id],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    /** @return list<Chunk> */
+    public function findByDocumentId(int $documentId): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chunks WHERE document_id = ? ORDER BY chunk_index ASC, id ASC',
+            [$documentId],
+        );
+
+        return array_map(fn (array $row): Chunk => $this->mapRow($row), $rows);
+    }
+
+    public function save(Chunk $chunk): int
+    {
+        $now = $this->now();
+
+        $this->query->execute(
+            <<<'SQL'
+                INSERT INTO chunks (
+                    document_id, source_id, chunk_index, content, page_number,
+                    section_label, token_count, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                SQL,
+            [
+                $chunk->documentId,
+                $chunk->sourceId,
+                $chunk->chunkIndex,
+                $chunk->content,
+                $chunk->pageNumber,
+                $chunk->sectionLabel,
+                $chunk->tokenCount,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): Chunk
+    {
+        return new Chunk(
+            documentId: (int) $row['document_id'],
+            sourceId: (int) $row['source_id'],
+            content: (string) $row['content'],
+            chunkIndex: (int) $row['chunk_index'],
+            pageNumber: isset($row['page_number']) ? (int) $row['page_number'] : null,
+            sectionLabel: isset($row['section_label']) ? (string) $row['section_label'] : null,
+            tokenCount: isset($row['token_count']) ? (int) $row['token_count'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+
+    private function now(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+}

--- a/src/Document/Document.php
+++ b/src/Document/Document.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Document;
+
+final readonly class Document
+{
+    public function __construct(
+        public int $sourceId,
+        public string $title,
+        public int $position = 0,
+        public ?string $metadataJson = null,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+        public bool $isDeleted = false,
+        public ?string $deletedAt = null,
+    ) {
+    }
+}

--- a/src/Document/DocumentRepositoryInterface.php
+++ b/src/Document/DocumentRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Document;
+
+interface DocumentRepositoryInterface
+{
+    public function findById(int $id): ?Document;
+
+    /** @return list<Document> */
+    public function findBySourceId(int $sourceId, int $limit, int $offset): array;
+
+    public function save(Document $document): int;
+
+    public function softDelete(int $id, string $deletedAt): void;
+}

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Document;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class DocumentServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            DocumentRepositoryInterface::class,
+            static function (ContainerInterface $container): DocumentRepositoryInterface {
+                $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoDocumentRepository($query);
+            },
+        );
+    }
+}

--- a/src/Document/PdoDocumentRepository.php
+++ b/src/Document/PdoDocumentRepository.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Document;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoDocumentRepository implements DocumentRepositoryInterface
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        id, source_id, title, position, metadata_json, created_at, updated_at, is_deleted, deleted_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Document
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM documents WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    /** @return list<Document> */
+    public function findBySourceId(int $sourceId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM documents WHERE source_id = ? AND is_deleted = 0 ORDER BY position ASC, id ASC LIMIT ? OFFSET ?',
+            [$sourceId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): Document => $this->mapRow($row), $rows);
+    }
+
+    public function save(Document $document): int
+    {
+        $now = $this->now();
+
+        $this->query->execute(
+            <<<'SQL'
+                INSERT INTO documents (
+                    source_id, title, position, metadata_json, created_at, updated_at, is_deleted, deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 0, NULL)
+                SQL,
+            [
+                $document->sourceId,
+                $document->title,
+                $document->position,
+                $document->metadataJson,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function softDelete(int $id, string $deletedAt): void
+    {
+        $this->query->execute(
+            'UPDATE documents SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            [$deletedAt, $this->now(), $id],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): Document
+    {
+        return new Document(
+            sourceId: (int) $row['source_id'],
+            title: (string) $row['title'],
+            position: (int) $row['position'],
+            metadataJson: isset($row['metadata_json']) ? (string) $row['metadata_json'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+            isDeleted: (bool) $row['is_deleted'],
+            deletedAt: isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
+        );
+    }
+
+    private function now(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+}

--- a/src/Source/PdoSourceRepository.php
+++ b/src/Source/PdoSourceRepository.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use InvalidArgumentException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoSourceRepository implements SourceRepositoryInterface
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        id, name, source_type, status, storage_path, original_filename, mime_type,
+        byte_size, error_message, created_at, updated_at, is_deleted, deleted_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Source
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM sources WHERE id = ? AND is_deleted = 0',
+            [$id],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    /** @return list<Source> */
+    public function findAll(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM sources WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$limit, $offset],
+        );
+
+        return array_map(fn (array $row): Source => $this->mapRow($row), $rows);
+    }
+
+    public function save(Source $source): int
+    {
+        $now = $this->now();
+
+        $this->query->execute(
+            <<<'SQL'
+                INSERT INTO sources (
+                    name, source_type, status, storage_path, original_filename, mime_type,
+                    byte_size, error_message, created_at, updated_at, is_deleted, deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
+                SQL,
+            [
+                $source->name,
+                $source->sourceType->value,
+                $source->status->value,
+                $source->storagePath,
+                $source->originalFilename,
+                $source->mimeType,
+                $source->byteSize,
+                $source->errorMessage,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Source $source): void
+    {
+        if ($source->id === null) {
+            throw new InvalidArgumentException('Source id is required for update.');
+        }
+
+        $this->query->execute(
+            <<<'SQL'
+                UPDATE sources SET
+                    name = ?, source_type = ?, status = ?, storage_path = ?,
+                    original_filename = ?, mime_type = ?, byte_size = ?, error_message = ?,
+                    updated_at = ?
+                WHERE id = ? AND is_deleted = 0
+                SQL,
+            [
+                $source->name,
+                $source->sourceType->value,
+                $source->status->value,
+                $source->storagePath,
+                $source->originalFilename,
+                $source->mimeType,
+                $source->byteSize,
+                $source->errorMessage,
+                $this->now(),
+                $source->id,
+            ],
+        );
+    }
+
+    public function softDelete(int $id, string $deletedAt): void
+    {
+        $this->query->execute(
+            'UPDATE sources SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            [$deletedAt, $this->now(), $id],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): Source
+    {
+        return new Source(
+            name: (string) $row['name'],
+            sourceType: SourceType::from((string) $row['source_type']),
+            status: SourceStatus::from((string) $row['status']),
+            storagePath: (string) $row['storage_path'],
+            originalFilename: isset($row['original_filename']) ? (string) $row['original_filename'] : null,
+            mimeType: isset($row['mime_type']) ? (string) $row['mime_type'] : null,
+            byteSize: isset($row['byte_size']) ? (int) $row['byte_size'] : null,
+            errorMessage: isset($row['error_message']) ? (string) $row['error_message'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+            isDeleted: (bool) $row['is_deleted'],
+            deletedAt: isset($row['deleted_at']) ? (string) $row['deleted_at'] : null,
+        );
+    }
+
+    private function now(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+}

--- a/src/Source/Source.php
+++ b/src/Source/Source.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+final readonly class Source
+{
+    public function __construct(
+        public string $name,
+        public SourceType $sourceType,
+        public SourceStatus $status,
+        public string $storagePath,
+        public ?string $originalFilename = null,
+        public ?string $mimeType = null,
+        public ?int $byteSize = null,
+        public ?string $errorMessage = null,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+        public bool $isDeleted = false,
+        public ?string $deletedAt = null,
+    ) {
+    }
+}

--- a/src/Source/SourceRepositoryInterface.php
+++ b/src/Source/SourceRepositoryInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+interface SourceRepositoryInterface
+{
+    public function findById(int $id): ?Source;
+
+    /** @return list<Source> */
+    public function findAll(int $limit, int $offset): array;
+
+    public function save(Source $source): int;
+
+    public function update(Source $source): void;
+
+    public function softDelete(int $id, string $deletedAt): void;
+}

--- a/src/Source/SourceServiceProvider.php
+++ b/src/Source/SourceServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class SourceServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            SourceRepositoryInterface::class,
+            static function (ContainerInterface $container): SourceRepositoryInterface {
+                $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoSourceRepository($query);
+            },
+        );
+    }
+}

--- a/src/Source/SourceStatus.php
+++ b/src/Source/SourceStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+enum SourceStatus: string
+{
+    case Pending = 'pending';
+    case Processing = 'processing';
+    case Ready = 'ready';
+    case Failed = 'failed';
+}

--- a/src/Source/SourceType.php
+++ b/src/Source/SourceType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+enum SourceType: string
+{
+    case Pdf = 'pdf';
+    case Csv = 'csv';
+}

--- a/tests/Chunk/PdoChunkRepositoryTest.php
+++ b/tests/Chunk/PdoChunkRepositoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Chunk;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoChunkRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private int $sourceId;
+
+    private int $documentId;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+
+        $sourceRepository = new PdoSourceRepository($this->executor);
+        $this->sourceId = $sourceRepository->save(new Source(
+            name: 'Parent source',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/parent.pdf',
+        ));
+
+        $documentRepository = new PdoDocumentRepository($this->executor);
+        $this->documentId = $documentRepository->save(new Document(
+            sourceId: $this->sourceId,
+            title: 'Manual',
+            position: 0,
+        ));
+    }
+
+    public function test_save_and_find_by_id_returns_chunk(): void
+    {
+        $repository = new PdoChunkRepository($this->executor);
+        $id = $repository->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Safety instructions for equipment.',
+            chunkIndex: 0,
+            pageNumber: 3,
+            sectionLabel: 'Safety',
+            tokenCount: 12,
+        ));
+
+        $chunk = $repository->findById($id);
+
+        self::assertNotNull($chunk);
+        self::assertSame($this->documentId, $chunk->documentId);
+        self::assertSame('Safety instructions for equipment.', $chunk->content);
+        self::assertSame(3, $chunk->pageNumber);
+    }
+
+    public function test_find_by_document_id_returns_chunks_in_index_order(): void
+    {
+        $repository = new PdoChunkRepository($this->executor);
+        $repository->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Second segment',
+            chunkIndex: 1,
+        ));
+        $repository->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'First segment',
+            chunkIndex: 0,
+        ));
+
+        $chunks = $repository->findByDocumentId($this->documentId);
+
+        self::assertCount(2, $chunks);
+        self::assertSame('First segment', $chunks[0]->content);
+        self::assertSame('Second segment', $chunks[1]->content);
+    }
+}

--- a/tests/Document/PdoDocumentRepositoryTest.php
+++ b/tests/Document/PdoDocumentRepositoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Document;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDocumentRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private int $sourceId;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+
+        $sourceRepository = new PdoSourceRepository($this->executor);
+        $this->sourceId = $sourceRepository->save(new Source(
+            name: 'Parent source',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/parent.pdf',
+        ));
+    }
+
+    public function test_save_and_find_by_id_returns_document(): void
+    {
+        $repository = new PdoDocumentRepository($this->executor);
+        $id = $repository->save(new Document(
+            sourceId: $this->sourceId,
+            title: 'Chapter 1',
+            position: 1,
+            metadataJson: '{"page_count":10}',
+        ));
+
+        $document = $repository->findById($id);
+
+        self::assertNotNull($document);
+        self::assertSame($this->sourceId, $document->sourceId);
+        self::assertSame('Chapter 1', $document->title);
+        self::assertSame('{"page_count":10}', $document->metadataJson);
+    }
+
+    public function test_find_by_source_id_returns_documents_in_position_order(): void
+    {
+        $repository = new PdoDocumentRepository($this->executor);
+        $repository->save(new Document(sourceId: $this->sourceId, title: 'Second', position: 2));
+        $repository->save(new Document(sourceId: $this->sourceId, title: 'First', position: 1));
+
+        $documents = $repository->findBySourceId($this->sourceId, 10, 0);
+
+        self::assertCount(2, $documents);
+        self::assertSame('First', $documents[0]->title);
+        self::assertSame('Second', $documents[1]->title);
+    }
+
+    public function test_soft_delete_excludes_document_from_find_by_id(): void
+    {
+        $repository = new PdoDocumentRepository($this->executor);
+        $id = $repository->save(new Document(
+            sourceId: $this->sourceId,
+            title: 'Temporary',
+            position: 0,
+        ));
+
+        $repository->softDelete($id, '2026-05-25 12:00:00');
+
+        self::assertNull($repository->findById($id));
+    }
+}

--- a/tests/Source/PdoSourceRepositoryTest.php
+++ b/tests/Source/PdoSourceRepositoryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Source;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoSourceRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+    }
+
+    public function test_save_returns_new_id(): void
+    {
+        $repository = new PdoSourceRepository($this->executor);
+        $id = $repository->save(new Source(
+            name: 'Manual PDF',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Pending,
+            storagePath: 'storage/uploads/manual.pdf',
+            originalFilename: 'manual.pdf',
+            mimeType: 'application/pdf',
+            byteSize: 1024,
+        ));
+
+        self::assertSame(1, $id);
+    }
+
+    public function test_find_by_id_returns_source_when_present(): void
+    {
+        $repository = new PdoSourceRepository($this->executor);
+        $id = $repository->save(new Source(
+            name: 'Catalog CSV',
+            sourceType: SourceType::Csv,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/catalog.csv',
+        ));
+
+        $source = $repository->findById($id);
+
+        self::assertNotNull($source);
+        self::assertSame('Catalog CSV', $source->name);
+        self::assertSame(SourceType::Csv, $source->sourceType);
+        self::assertSame(SourceStatus::Ready, $source->status);
+    }
+
+    public function test_find_by_id_returns_null_when_source_is_absent(): void
+    {
+        $repository = new PdoSourceRepository($this->executor);
+
+        self::assertNull($repository->findById(99));
+    }
+
+    public function test_soft_delete_excludes_source_from_find_by_id(): void
+    {
+        $repository = new PdoSourceRepository($this->executor);
+        $id = $repository->save(new Source(
+            name: 'To delete',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Pending,
+            storagePath: 'storage/uploads/delete-me.pdf',
+        ));
+
+        $repository->softDelete($id, '2026-05-25 12:00:00');
+
+        self::assertNull($repository->findById($id));
+    }
+
+    public function test_find_all_respects_limit_and_offset(): void
+    {
+        $repository = new PdoSourceRepository($this->executor);
+
+        for ($i = 1; $i <= 3; $i++) {
+            $repository->save(new Source(
+                name: "Source {$i}",
+                sourceType: SourceType::Pdf,
+                status: SourceStatus::Pending,
+                storagePath: "storage/uploads/source-{$i}.pdf",
+            ));
+        }
+
+        $sources = $repository->findAll(1, 1);
+
+        self::assertCount(1, $sources);
+        self::assertSame('Source 2', $sources[0]->name);
+    }
+}

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use Nene2\Database\PdoDatabaseQueryExecutor;
+
+final class CorpusSchemaSetup
+{
+    public static function create(PdoDatabaseQueryExecutor $executor): void
+    {
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE sources (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    source_type TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    storage_path TEXT NOT NULL,
+                    original_filename TEXT NULL,
+                    mime_type TEXT NULL,
+                    byte_size INTEGER NULL,
+                    error_message TEXT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    is_deleted INTEGER NOT NULL DEFAULT 0,
+                    deleted_at TEXT NULL
+                )
+                SQL,
+        );
+
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE documents (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_id INTEGER NOT NULL,
+                    title TEXT NOT NULL,
+                    position INTEGER NOT NULL DEFAULT 0,
+                    metadata_json TEXT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    is_deleted INTEGER NOT NULL DEFAULT 0,
+                    deleted_at TEXT NULL,
+                    FOREIGN KEY (source_id) REFERENCES sources (id) ON DELETE CASCADE
+                )
+                SQL,
+        );
+
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE chunks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    document_id INTEGER NOT NULL,
+                    source_id INTEGER NOT NULL,
+                    chunk_index INTEGER NOT NULL DEFAULT 0,
+                    content TEXT NOT NULL,
+                    page_number INTEGER NULL,
+                    section_label TEXT NULL,
+                    token_count INTEGER NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY (document_id) REFERENCES documents (id) ON DELETE CASCADE,
+                    FOREIGN KEY (source_id) REFERENCES sources (id) ON DELETE CASCADE
+                )
+                SQL,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 P0 — corpus ingestion canonical store:

- Phinx migration: `sources`, `documents`, `chunks` (soft-delete on sources/documents)
- Schema snapshots in `database/schema/`
- Domain modules: `Source/`, `Document/`, `Chunk/` with `Pdo*Repository` + service providers
- Repository tests (SQLite `:memory:`) — 10 new tests
- Milestone `docs/milestones/2026-05-corpus-ingestion.md` + `docs/todo/current.md` update

## Test plan

- [x] `composer check` (PHPUnit, PHPStan, CS-Fixer, OpenAPI, MCP)
- [x] `composer migrations:migrate` (SQLite local)

Closes #7

Self-review: database


Made with [Cursor](https://cursor.com)