### PR TITLE
feat(auth): 管理 API 向け JWT 認証を追加する (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ APP_NAME="NeNe Corpus"
 NENE2_MACHINE_API_KEY=
 PROBLEM_DETAILS_BASE_URL=https://nene-corpus.dev/problems/
 
+# --- Admin auth (Phase 1+) — never commit real secrets ---
+NENE2_LOCAL_JWT_SECRET=
+
 # --- LLM (Phase 2+) — never commit real keys ---
 ANTHROPIC_API_KEY=
 

--- a/database/migrations/20260525130000_create_admin_users_table.php
+++ b/database/migrations/20260525130000_create_admin_users_table.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateAdminUsersTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('admin_users')
+            ->addColumn('email', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('password_hash', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['email'], ['unique' => true, 'name' => 'uniq_admin_users_email'])
+            ->create();
+    }
+}

--- a/database/schema/admin_users.sql
+++ b/database/schema/admin_users.sql
@@ -1,0 +1,10 @@
+-- Snapshot: admin_users (admin auth)
+CREATE TABLE admin_users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+
+CREATE UNIQUE INDEX uniq_admin_users_email ON admin_users (email);

--- a/docs/milestones/2026-05-corpus-ingestion.md
+++ b/docs/milestones/2026-05-corpus-ingestion.md
@@ -12,7 +12,7 @@ Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 1.
 - [x] Schema snapshots in `database/schema/`
 - [x] Domain entities + `Pdo*Repository` adapters + service providers
 - [x] Repository tests (SQLite `:memory:`)
-- [ ] Admin auth (JWT) for mutating routes
+- [x] Admin auth (JWT) for mutating routes (#9)
 - [ ] CSV upload API + column mapping preview
 - [ ] PDF text extraction (text PDF first)
 - [ ] Admin HTTP routes + OpenAPI

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,16 +1,18 @@
 openapi: 3.1.0
 info:
   title: NeNe Corpus API
-  version: 0.1.0
+  version: 0.2.0
   description: >
     NeNe Corpus public API contract — self-hosted knowledge chat on NENE2.
-    Phase 0 exposes system health; ingestion and chat endpoints follow in later phases.
+    Phase 1 adds admin auth and corpus storage foundations.
 servers:
   - url: http://localhost:8080
     description: Local development server
 tags:
   - name: System
     description: Runtime health endpoints.
+  - name: Admin
+    description: Admin authentication for mutating routes.
 paths:
   /health:
     get:
@@ -34,7 +36,76 @@ paths:
                     service: NENE2
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /admin/auth/login:
+    post:
+      tags:
+        - Admin
+      summary: Admin login
+      description: Issue a Bearer JWT for admin routes. Requires `NENE2_LOCAL_JWT_SECRET` on the server.
+      operationId: loginAdmin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginAdminRequest'
+            examples:
+              valid:
+                value:
+                  email: admin@example.com
+                  password: secret-password
+      responses:
+        '200':
+          description: Access token issued.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginAdminResponse'
+              examples:
+                ok:
+                  value:
+                    access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.example
+                    token_type: Bearer
+                    expires_at: '2026-05-25T13:00:00+00:00'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/auth/me:
+    get:
+      tags:
+        - Admin
+      summary: Current admin profile
+      description: Returns JWT claims for the authenticated admin.
+      operationId: getAdminMe
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Admin profile from JWT claims.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminMeResponse'
+              examples:
+                ok:
+                  value:
+                    id: 1
+                    email: admin@example.com
+                    role: admin
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: HS256 admin JWT from `POST /admin/auth/login`.
   responses:
     InternalServerError:
       description: Internal server error.
@@ -50,6 +121,37 @@ components:
                 status: 500
                 detail: An unexpected error occurred.
                 instance: /health
+    Unauthorized:
+      description: Missing or invalid Bearer token, or invalid credentials.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            unauthorized:
+              value:
+                type: https://nene-corpus.dev/problems/unauthorized
+                title: Unauthorized
+                status: 401
+                detail: Invalid email or password.
+                instance: /admin/auth/login
+    ValidationFailed:
+      description: Request validation failed.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ValidationProblemDetails'
+          examples:
+            validationFailed:
+              value:
+                type: https://nene-corpus.dev/problems/validation-failed
+                title: Validation Failed
+                status: 422
+                detail: The request body contains invalid values.
+                errors:
+                  - field: email
+                    message: Email is required.
+                    code: required
   schemas:
     HealthResponse:
       type: object
@@ -63,6 +165,86 @@ components:
             - ok
             - degraded
         service:
+          type: string
+    LoginAdminRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+          format: password
+    LoginAdminResponse:
+      type: object
+      required:
+        - access_token
+        - token_type
+        - expires_at
+      properties:
+        access_token:
+          type: string
+        token_type:
+          type: string
+          enum:
+            - Bearer
+        expires_at:
+          type: string
+          format: date-time
+    AdminMeResponse:
+      type: object
+      required:
+        - id
+        - email
+        - role
+      properties:
+        id:
+          type: integer
+          format: int64
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+    ValidationProblemDetails:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - instance
+        - errors
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      type: object
+      required:
+        - field
+        - message
+        - code
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+        code:
           type: string
     ProblemDetails:
       type: object

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,7 +12,7 @@ Last updated: 2026-05-25
 **Phase 1 — Corpus & Ingestion: 進行中（2026-05-25）**
 
 - ✅ Schema: `sources`, `documents`, `chunks`（#7）
-- 🔜 Admin auth (JWT)
+- ✅ Admin auth (JWT)（#9 — PR 待ち）
 - 🔜 CSV / PDF ingestion API
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
@@ -24,7 +24,7 @@ Last updated: 2026-05-25
 | 項目 | 状態 |
 | --- | --- |
 | Schema: sources, documents, chunks | ✅ (#7) |
-| Admin auth (JWT) | 🔜 |
+| Admin auth (JWT) | ✅ (#9) |
 | CSV upload API | 🔜 |
 | PDF text extraction | 🔜 |
 | Reindex / delete source | 🔜 |
@@ -51,8 +51,8 @@ Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05
 | 優先 | 項目 | 説明 |
 | --- | --- | --- |
 | ~~P0~~ | ~~Schema: sources, documents, chunks~~ | ✅ #7 |
-| P0 | Admin auth (JWT) | 管理 API 保護 |
-| P1 | CSV upload API | 列マッピング preview |
+| ~~P0~~ | ~~Admin auth (JWT)~~ | ✅ #9 |
+| P0 | CSV upload API | 列マッピング preview |
 | P1 | PDF text extraction | テキスト PDF のみ（Phase 1） |
 | P2 | Reindex / delete source | 運用 API |
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-  bootstrap="vendor/autoload.php"
+  bootstrap="tests/bootstrap.php"
   colors="true"
   cacheDirectory=".phpunit.cache"
 >

--- a/src/AdminAuth/AdminAuthRouteRegistrar.php
+++ b/src/AdminAuth/AdminAuthRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AdminAuthRouteRegistrar
+{
+    public function __construct(
+        private LoginAdminHandler $loginHandler,
+        private GetAdminMeHandler $meHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $login = $this->loginHandler;
+        $me = $this->meHandler;
+
+        $router->post('/admin/auth/login', static fn (ServerRequestInterface $request) => $login->handle($request));
+        $router->get('/admin/auth/me', static fn (ServerRequestInterface $request) => $me->handle($request));
+    }
+}

--- a/src/AdminAuth/AdminAuthServiceProvider.php
+++ b/src/AdminAuth/AdminAuthServiceProvider.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use LogicException;
+use Nene2\Auth\BearerTokenMiddleware;
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Config\AppConfig;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+final readonly class AdminAuthServiceProvider implements ServiceProviderInterface
+{
+    public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.admin_auth';
+
+    public const AUTH_MIDDLEWARE = 'nene-corpus.middleware.admin_auth';
+
+    public const TOKEN_ISSUER = 'nene-corpus.admin_auth.token_issuer';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                AdminUserRepositoryInterface::class,
+                static function (ContainerInterface $container): AdminUserRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoAdminUserRepository($query);
+                },
+            )
+            ->set(
+                self::TOKEN_ISSUER,
+                static function (ContainerInterface $container): ?TokenIssuerInterface {
+                    $config = $container->get(AppConfig::class);
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    if ($config->localJwtSecret === null) {
+                        return null;
+                    }
+
+                    return new LocalBearerTokenVerifier($config->localJwtSecret);
+                },
+            )
+            ->set(
+                LoginAdminUseCaseInterface::class,
+                static function (ContainerInterface $container): LoginAdminUseCaseInterface {
+                    $users = $container->get(AdminUserRepositoryInterface::class);
+                    $issuer = $container->get(self::TOKEN_ISSUER);
+
+                    if (!$users instanceof AdminUserRepositoryInterface) {
+                        throw new LogicException('Admin user repository service is invalid.');
+                    }
+
+                    if (!$issuer instanceof TokenIssuerInterface) {
+                        throw new LogicException('Admin JWT secret is not configured (set NENE2_LOCAL_JWT_SECRET).');
+                    }
+
+                    return new LoginAdminUseCase($users, $issuer);
+                },
+            )
+            ->set(
+                LoginAdminHandler::class,
+                static function (ContainerInterface $container): LoginAdminHandler {
+                    $useCase = $container->get(LoginAdminUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof LoginAdminUseCaseInterface) {
+                        throw new LogicException('Login admin use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new LoginAdminHandler($useCase, $response);
+                },
+            )
+            ->set(
+                GetAdminMeHandler::class,
+                static function (ContainerInterface $container): GetAdminMeHandler {
+                    $response = $container->get(JsonResponseFactory::class);
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new GetAdminMeHandler($response, $problemDetails);
+                },
+            )
+            ->set(
+                InvalidAdminCredentialsExceptionHandler::class,
+                static function (ContainerInterface $container): InvalidAdminCredentialsExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new InvalidAdminCredentialsExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                self::ROUTE_REGISTRAR,
+                static function (ContainerInterface $container): AdminAuthRouteRegistrar {
+                    $login = $container->get(LoginAdminHandler::class);
+                    $me = $container->get(GetAdminMeHandler::class);
+
+                    if (!$login instanceof LoginAdminHandler) {
+                        throw new LogicException('Login admin handler service is invalid.');
+                    }
+
+                    if (!$me instanceof GetAdminMeHandler) {
+                        throw new LogicException('Get admin me handler service is invalid.');
+                    }
+
+                    return new AdminAuthRouteRegistrar($login, $me);
+                },
+            )
+            ->set(
+                self::AUTH_MIDDLEWARE,
+                static function (ContainerInterface $container): ?AdminBearerTokenMiddleware {
+                    $config = $container->get(AppConfig::class);
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$config instanceof AppConfig) {
+                        throw new LogicException('Application config service is invalid.');
+                    }
+
+                    if ($config->localJwtSecret === null) {
+                        return null;
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    $bearer = new BearerTokenMiddleware(
+                        $problemDetails,
+                        new LocalBearerTokenVerifier($config->localJwtSecret),
+                    );
+
+                    return new AdminBearerTokenMiddleware($bearer);
+                },
+            );
+    }
+}

--- a/src/AdminAuth/AdminBearerTokenMiddleware.php
+++ b/src/AdminAuth/AdminBearerTokenMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Auth\BearerTokenMiddleware;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Applies Bearer JWT verification to /admin/* routes except public auth endpoints.
+ */
+final readonly class AdminBearerTokenMiddleware implements MiddlewareInterface
+{
+    /** @var list<string> */
+    private const PUBLIC_PATHS = [
+        '/admin/auth/login',
+    ];
+
+    public function __construct(
+        private BearerTokenMiddleware $bearer,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $path = $request->getUri()->getPath() ?: '/';
+
+        if (!str_starts_with($path, '/admin/') || in_array($path, self::PUBLIC_PATHS, true)) {
+            return $handler->handle($request);
+        }
+
+        return $this->bearer->process($request, $handler);
+    }
+}

--- a/src/AdminAuth/AdminUser.php
+++ b/src/AdminAuth/AdminUser.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+final readonly class AdminUser
+{
+    public function __construct(
+        public string $email,
+        public string $passwordHash,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/AdminAuth/AdminUserRepositoryInterface.php
+++ b/src/AdminAuth/AdminUserRepositoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+interface AdminUserRepositoryInterface
+{
+    public function findByEmail(string $email): ?AdminUser;
+}

--- a/src/AdminAuth/GetAdminMeHandler.php
+++ b/src/AdminAuth/GetAdminMeHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetAdminMeHandler
+{
+    public function __construct(
+        private JsonResponseFactory $response,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        /** @var array<string, mixed>|null $claims */
+        $claims = $request->getAttribute('nene2.auth.claims');
+
+        if (!is_array($claims)) {
+            return $this->problemDetails->create($request, 'unauthorized', 'Unauthorized', 401);
+        }
+
+        return $this->response->create([
+            'id' => $claims['sub'] ?? null,
+            'email' => $claims['email'] ?? null,
+            'role' => $claims['role'] ?? null,
+        ]);
+    }
+}

--- a/src/AdminAuth/InvalidAdminCredentialsException.php
+++ b/src/AdminAuth/InvalidAdminCredentialsException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use RuntimeException;
+
+final class InvalidAdminCredentialsException extends RuntimeException
+{
+}

--- a/src/AdminAuth/InvalidAdminCredentialsExceptionHandler.php
+++ b/src/AdminAuth/InvalidAdminCredentialsExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class InvalidAdminCredentialsExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof InvalidAdminCredentialsException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'invalid-credentials',
+            'Unauthorized',
+            401,
+            'Invalid email or password.',
+        );
+    }
+}

--- a/src/AdminAuth/LoginAdminHandler.php
+++ b/src/AdminAuth/LoginAdminHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class LoginAdminHandler
+{
+    public function __construct(
+        private LoginAdminUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $email = strtolower(trim((string) ($body['email'] ?? '')));
+        $password = (string) ($body['password'] ?? '');
+
+        $errors = [];
+
+        if ($email === '') {
+            $errors[] = new ValidationError('email', 'Email is required.', 'required');
+        }
+
+        if ($password === '') {
+            $errors[] = new ValidationError('password', 'Password is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new LoginAdminInput(email: $email, password: $password));
+
+        return $this->response->create([
+            'access_token' => $output->accessToken,
+            'token_type' => $output->tokenType,
+            'expires_at' => $output->expiresAt,
+        ]);
+    }
+}

--- a/src/AdminAuth/LoginAdminInput.php
+++ b/src/AdminAuth/LoginAdminInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+final readonly class LoginAdminInput
+{
+    public function __construct(
+        public string $email,
+        public string $password,
+    ) {
+    }
+}

--- a/src/AdminAuth/LoginAdminOutput.php
+++ b/src/AdminAuth/LoginAdminOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+final readonly class LoginAdminOutput
+{
+    public function __construct(
+        public string $accessToken,
+        public string $tokenType,
+        public string $expiresAt,
+    ) {
+    }
+}

--- a/src/AdminAuth/LoginAdminUseCase.php
+++ b/src/AdminAuth/LoginAdminUseCase.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Auth\TokenIssuerInterface;
+
+final readonly class LoginAdminUseCase implements LoginAdminUseCaseInterface
+{
+    private const TOKEN_TTL_SECONDS = 3600;
+
+    /** @see NENE2 password-hashing howto — dummy hash for timing-safe failed login */
+    private const DUMMY_PASSWORD_HASH = '$argon2id$v=19$m=65536,t=4,p=1$bEhwVzk4d25rVlFUY0ZaVQ$umHX1oSI/6PmkVI2S35tkDoB6/UL6fXJkTIfqBHe2a0';
+
+    public function __construct(
+        private AdminUserRepositoryInterface $adminUsers,
+        private TokenIssuerInterface $tokenIssuer,
+    ) {
+    }
+
+    public function execute(LoginAdminInput $input): LoginAdminOutput
+    {
+        $user = $this->adminUsers->findByEmail($input->email);
+        $hash = $user !== null ? $user->passwordHash : self::DUMMY_PASSWORD_HASH;
+
+        if ($user === null || !password_verify($input->password, $hash)) {
+            throw new InvalidAdminCredentialsException('Invalid email or password.');
+        }
+
+        $now = time();
+        $expiresAt = $now + self::TOKEN_TTL_SECONDS;
+
+        $token = $this->tokenIssuer->issue([
+            'sub' => $user->id,
+            'email' => $user->email,
+            'role' => 'admin',
+            'iat' => $now,
+            'exp' => $expiresAt,
+        ]);
+
+        return new LoginAdminOutput(
+            accessToken: $token,
+            tokenType: 'Bearer',
+            expiresAt: gmdate('c', $expiresAt),
+        );
+    }
+}

--- a/src/AdminAuth/LoginAdminUseCaseInterface.php
+++ b/src/AdminAuth/LoginAdminUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+interface LoginAdminUseCaseInterface
+{
+    public function execute(LoginAdminInput $input): LoginAdminOutput;
+}

--- a/src/AdminAuth/PdoAdminUserRepository.php
+++ b/src/AdminAuth/PdoAdminUserRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findByEmail(string $email): ?AdminUser
+    {
+        $row = $this->query->fetchOne(
+            'SELECT id, email, password_hash, created_at, updated_at FROM admin_users WHERE email = ?',
+            [$email],
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        return new AdminUser(
+            email: (string) $row['email'],
+            passwordHash: (string) $row['password_hash'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace NeneCorpus;
 
+use LogicException;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\DomainExceptionHandlerInterface;
+use NeneCorpus\AdminAuth\AdminAuthRouteRegistrar;
+use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
+use NeneCorpus\AdminAuth\InvalidAdminCredentialsExceptionHandler;
 use NeneCorpus\Chunk\ChunkServiceProvider;
 use NeneCorpus\Document\DocumentServiceProvider;
 use NeneCorpus\Source\SourceServiceProvider;
@@ -24,17 +28,29 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new SourceServiceProvider())
             ->addProvider(new DocumentServiceProvider())
             ->addProvider(new ChunkServiceProvider())
+            ->addProvider(new AdminAuthServiceProvider())
             ->set(
                 self::ROUTE_REGISTRARS,
-                static fn (ContainerInterface $container): array => [],
+                static function (ContainerInterface $container): array {
+                    $adminAuth = $container->get(AdminAuthServiceProvider::ROUTE_REGISTRAR);
+
+                    if (!$adminAuth instanceof AdminAuthRouteRegistrar) {
+                        throw new LogicException('Admin auth route registrar service is invalid.');
+                    }
+
+                    return [$adminAuth];
+                },
             )
             ->set(
                 self::EXCEPTION_HANDLERS,
                 static function (ContainerInterface $container): array {
-                    /** @var list<DomainExceptionHandlerInterface> $handlers */
-                    $handlers = [];
+                    $invalidCredentials = $container->get(InvalidAdminCredentialsExceptionHandler::class);
 
-                    return $handlers;
+                    if (!$invalidCredentials instanceof DomainExceptionHandlerInterface) {
+                        throw new LogicException('Invalid admin credentials exception handler service is invalid.');
+                    }
+
+                    return [$invalidCredentials];
                 },
             );
     }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -21,6 +21,8 @@ use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
 use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
+use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
+use NeneCorpus\AdminAuth\AdminBearerTokenMiddleware;
 use NeneCorpus\ApplicationServiceProvider;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
@@ -212,6 +214,12 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('RequestIdHolder service is invalid.');
                     }
 
+                    $authMiddleware = $container->get(AdminAuthServiceProvider::AUTH_MIDDLEWARE);
+
+                    if ($authMiddleware !== null && !$authMiddleware instanceof AdminBearerTokenMiddleware) {
+                        throw new LogicException('Admin auth middleware service is invalid.');
+                    }
+
                     return new RuntimeApplicationFactory(
                         $responseFactory,
                         $streamFactory,
@@ -220,7 +228,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         $exceptionHandlers,
                         $requestIdHolder,
                         $routeRegistrars,
-                        [],
+                        $authMiddleware,
                         [],
                         null,
                         $config->debug,

--- a/tests/AdminAuth/AdminAuthHttpTest.php
+++ b/tests/AdminAuth/AdminAuthHttpTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\AdminAuth;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AdminAuthHttpTest extends TestCase
+{
+    private const JWT_SECRET = 'test-admin-jwt-secret';
+
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-admin-auth-' . uniqid('', true) . '.sqlite';
+
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_ENV['DB_ADAPTER'] = 'sqlite';
+        $_ENV['DB_NAME'] = $this->databasePath;
+        $_SERVER['DB_ADAPTER'] = 'sqlite';
+        $_SERVER['DB_NAME'] = $this->databasePath;
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        CorpusSchemaSetup::createAdminUsers($executor);
+
+        $hash = password_hash('secret-password', PASSWORD_ARGON2ID);
+        $now = gmdate('Y-m-d H:i:s');
+        $executor->execute(
+            'INSERT INTO admin_users (email, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?)',
+            ['admin@example.com', $hash, $now, $now],
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        unset(
+            $_ENV['DB_ADAPTER'],
+            $_SERVER['DB_ADAPTER'],
+            $_ENV['DB_NAME'],
+            $_SERVER['DB_NAME'],
+        );
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+    }
+
+    public function test_login_returns_bearer_token(): void
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/auth/login')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream(json_encode([
+                    'email' => 'admin@example.com',
+                    'password' => 'secret-password',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('Bearer', $payload['token_type']);
+        self::assertNotEmpty($payload['access_token']);
+        self::assertNotEmpty($payload['expires_at']);
+    }
+
+    public function test_me_requires_bearer_token(): void
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('GET', 'https://example.test/admin/auth/me'),
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_me_returns_admin_profile_with_valid_token(): void
+    {
+        $loginResponse = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/auth/login')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream(json_encode([
+                    'email' => 'admin@example.com',
+                    'password' => 'secret-password',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        $loginPayload = $this->decodeJson($loginResponse);
+
+        $meResponse = $this->application()->handle(
+            $this->factory()->createServerRequest('GET', 'https://example.test/admin/auth/me')
+                ->withHeader('Authorization', 'Bearer ' . $loginPayload['access_token']),
+        );
+
+        $mePayload = $this->decodeJson($meResponse);
+
+        self::assertSame(200, $meResponse->getStatusCode());
+        self::assertSame(1, $mePayload['id']);
+        self::assertSame('admin@example.com', $mePayload['email']);
+        self::assertSame('admin', $mePayload['role']);
+    }
+
+    public function test_login_returns_401_for_invalid_credentials(): void
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/auth/login')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream(json_encode([
+                    'email' => 'admin@example.com',
+                    'password' => 'wrong-password',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    private function application(): RequestHandlerInterface
+    {
+        $container = (new RuntimeContainerFactory())->create();
+        $application = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        return $application;
+    }
+
+    private function factory(): Psr17Factory
+    {
+        return new Psr17Factory();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/AdminAuth/LoginAdminUseCaseTest.php
+++ b/tests/AdminAuth/LoginAdminUseCaseTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\AdminAuth;
+
+use Nene2\Auth\LocalBearerTokenVerifier;
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\AdminAuth\LoginAdminInput;
+use NeneCorpus\AdminAuth\LoginAdminUseCase;
+use NeneCorpus\AdminAuth\PdoAdminUserRepository;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class LoginAdminUseCaseTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::createAdminUsers($this->executor);
+
+        $hash = password_hash('secret-password', PASSWORD_ARGON2ID);
+        $now = gmdate('Y-m-d H:i:s');
+        $this->executor->execute(
+            'INSERT INTO admin_users (email, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?)',
+            ['admin@example.com', $hash, $now, $now],
+        );
+    }
+
+    public function test_execute_returns_access_token_for_valid_credentials(): void
+    {
+        $useCase = new LoginAdminUseCase(
+            new PdoAdminUserRepository($this->executor),
+            new LocalBearerTokenVerifier('test-jwt-secret'),
+        );
+
+        $output = $useCase->execute(new LoginAdminInput(
+            email: 'admin@example.com',
+            password: 'secret-password',
+        ));
+
+        self::assertSame('Bearer', $output->tokenType);
+        self::assertNotSame('', $output->accessToken);
+        self::assertNotSame('', $output->expiresAt);
+    }
+
+    public function test_execute_throws_for_invalid_password(): void
+    {
+        $useCase = new LoginAdminUseCase(
+            new PdoAdminUserRepository($this->executor),
+            new LocalBearerTokenVerifier('test-jwt-secret'),
+        );
+
+        $this->expectException(\NeneCorpus\AdminAuth\InvalidAdminCredentialsException::class);
+
+        $useCase->execute(new LoginAdminInput(
+            email: 'admin@example.com',
+            password: 'wrong-password',
+        ));
+    }
+}

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -66,4 +66,21 @@ final class CorpusSchemaSetup
                 SQL,
         );
     }
+
+    public static function createAdminUsers(PdoDatabaseQueryExecutor $executor): void
+    {
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE admin_users (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email TEXT NOT NULL,
+                    password_hash TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                SQL,
+        );
+
+        $executor->execute('CREATE UNIQUE INDEX uniq_admin_users_email ON admin_users (email)');
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+if (!isset($_ENV['NENE2_LOCAL_JWT_SECRET']) && !isset($_SERVER['NENE2_LOCAL_JWT_SECRET'])) {
+    $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+    $_SERVER['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+}


### PR DESCRIPTION
## Summary

- `admin_users` テーブル（Phinx migration + schema snapshot）と `AdminAuth` ドメインを追加
- `POST /admin/auth/login` / `GET /admin/auth/me`、Bearer JWT ミドルウェア（`/admin/*` 保護、login のみ除外）
- OpenAPI 契約（Admin tag、`bearerAuth`、401/422 responses）と PHPUnit テスト

Closes #9

Self-review: middleware-security, backend-api, openapi-contract

## Test plan

- [x] `composer check`（PHPUnit / PHPStan / CS-Fixer / OpenAPI / MCP）
- [x] `LoginAdminUseCaseTest` — 正常ログイン / 不正パスワード
- [x] `AdminAuthHttpTest` — login / me / 401 系
- [ ] migration 適用後に手動 login 確認（任意）


Made with [Cursor](https://cursor.com)