### PR TITLE
feat(ingestion): CSV アップロード API と列プレビューを追加する (#11)

### DIFF
--- a/docs/milestones/2026-05-corpus-ingestion.md
+++ b/docs/milestones/2026-05-corpus-ingestion.md
@@ -13,7 +13,7 @@ Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 1.
 - [x] Domain entities + `Pdo*Repository` adapters + service providers
 - [x] Repository tests (SQLite `:memory:`)
 - [x] Admin auth (JWT) for mutating routes (#9)
-- [ ] CSV upload API + column mapping preview
+- [x] CSV upload API + column mapping preview (#11)
 - [ ] PDF text extraction (text PDF first)
 - [ ] Admin HTTP routes + OpenAPI
 - [ ] Reindex / delete **source** operations API

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,10 +1,10 @@
 openapi: 3.1.0
 info:
   title: NeNe Corpus API
-  version: 0.2.0
+  version: 0.3.0
   description: >
     NeNe Corpus public API contract — self-hosted knowledge chat on NENE2.
-    Phase 1 adds admin auth and corpus storage foundations.
+    Phase 1 adds admin auth, CSV ingestion, and corpus storage foundations.
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -13,6 +13,8 @@ tags:
     description: Runtime health endpoints.
   - name: Admin
     description: Admin authentication for mutating routes.
+  - name: Ingestion
+    description: CSV upload and column mapping preview.
 paths:
   /health:
     get:
@@ -97,6 +99,62 @@ paths:
                     role: admin
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/ingestion/csv/preview:
+    post:
+      tags:
+        - Ingestion
+      summary: Preview CSV columns
+      description: Parse CSV headers and sample rows for column mapping UI. No database writes.
+      operationId: previewCsvIngestion
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreviewCsvIngestionRequest'
+      responses:
+        '200':
+          description: Parsed CSV preview.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreviewCsvIngestionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/sources:
+    post:
+      tags:
+        - Ingestion
+      summary: Create CSV source
+      description: Store CSV file, create source, and sync parse into documents and chunks.
+      operationId: createSource
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSourceRequest'
+      responses:
+        '201':
+          description: Source created and ingested.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateSourceResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:
@@ -209,6 +267,100 @@ components:
           format: email
         role:
           type: string
+    PreviewCsvIngestionRequest:
+      type: object
+      required:
+        - filename
+        - content
+      properties:
+        filename:
+          type: string
+        content:
+          type: string
+          description: Base64-encoded CSV bytes.
+    PreviewCsvIngestionResponse:
+      type: object
+      required:
+        - headers
+        - sample_rows
+        - detected_delimiter
+        - row_count
+      properties:
+        headers:
+          type: array
+          items:
+            type: string
+        sample_rows:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+        detected_delimiter:
+          type: string
+        row_count:
+          type: integer
+          format: int64
+    CreateSourceRequest:
+      type: object
+      required:
+        - name
+        - filename
+        - content
+        - column_mapping
+      properties:
+        name:
+          type: string
+        filename:
+          type: string
+        content:
+          type: string
+          description: Base64-encoded CSV bytes.
+        column_mapping:
+          $ref: '#/components/schemas/CsvColumnMapping'
+    CsvColumnMapping:
+      type: object
+      required:
+        - title_column
+        - content_columns
+      properties:
+        title_column:
+          type: string
+        content_columns:
+          type: array
+          items:
+            type: string
+        metadata_columns:
+          type: array
+          items:
+            type: string
+    CreateSourceResponse:
+      type: object
+      required:
+        - source_id
+        - name
+        - status
+        - document_count
+        - chunk_count
+      properties:
+        source_id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        status:
+          type: string
+          enum:
+            - pending
+            - processing
+            - ready
+            - failed
+        document_count:
+          type: integer
+          format: int64
+        chunk_count:
+          type: integer
+          format: int64
     ValidationProblemDetails:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -12,8 +12,9 @@ Last updated: 2026-05-25
 **Phase 1 — Corpus & Ingestion: 進行中（2026-05-25）**
 
 - ✅ Schema: `sources`, `documents`, `chunks`（#7）
-- ✅ Admin auth (JWT)（#9 — PR 待ち）
-- 🔜 CSV / PDF ingestion API
+- ✅ Admin auth (JWT)（#9）
+- ✅ CSV upload API（#11 — PR 待ち）
+- 🔜 PDF ingestion API
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
 
@@ -25,7 +26,7 @@ Last updated: 2026-05-25
 | --- | --- |
 | Schema: sources, documents, chunks | ✅ (#7) |
 | Admin auth (JWT) | ✅ (#9) |
-| CSV upload API | 🔜 |
+| CSV upload API | ✅ (#11) |
 | PDF text extraction | 🔜 |
 | Reindex / delete source | 🔜 |
 
@@ -52,8 +53,8 @@ Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05
 | --- | --- | --- |
 | ~~P0~~ | ~~Schema: sources, documents, chunks~~ | ✅ #7 |
 | ~~P0~~ | ~~Admin auth (JWT)~~ | ✅ #9 |
-| P0 | CSV upload API | 列マッピング preview |
-| P1 | PDF text extraction | テキスト PDF のみ（Phase 1） |
+| ~~P0~~ | ~~CSV upload API~~ | ✅ #11 |
+| P0 | PDF text extraction | テキスト PDF のみ（Phase 1） |
 | P2 | Reindex / delete source | 運用 API |
 
 詳細は [`docs/roadmap.md`](../roadmap.md)。

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -13,6 +13,9 @@ use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
 use NeneCorpus\AdminAuth\InvalidAdminCredentialsExceptionHandler;
 use NeneCorpus\Chunk\ChunkServiceProvider;
 use NeneCorpus\Document\DocumentServiceProvider;
+use NeneCorpus\Ingestion\CsvIngestionExceptionHandler;
+use NeneCorpus\Ingestion\IngestionRouteRegistrar;
+use NeneCorpus\Ingestion\IngestionServiceProvider;
 use NeneCorpus\Source\SourceServiceProvider;
 use Psr\Container\ContainerInterface;
 
@@ -29,28 +32,39 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new DocumentServiceProvider())
             ->addProvider(new ChunkServiceProvider())
             ->addProvider(new AdminAuthServiceProvider())
+            ->addProvider(new IngestionServiceProvider())
             ->set(
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {
                     $adminAuth = $container->get(AdminAuthServiceProvider::ROUTE_REGISTRAR);
+                    $ingestion = $container->get(IngestionServiceProvider::ROUTE_REGISTRAR);
 
                     if (!$adminAuth instanceof AdminAuthRouteRegistrar) {
                         throw new LogicException('Admin auth route registrar service is invalid.');
                     }
 
-                    return [$adminAuth];
+                    if (!$ingestion instanceof IngestionRouteRegistrar) {
+                        throw new LogicException('Ingestion route registrar service is invalid.');
+                    }
+
+                    return [$adminAuth, $ingestion];
                 },
             )
             ->set(
                 self::EXCEPTION_HANDLERS,
                 static function (ContainerInterface $container): array {
                     $invalidCredentials = $container->get(InvalidAdminCredentialsExceptionHandler::class);
+                    $csvIngestion = $container->get(CsvIngestionExceptionHandler::class);
 
                     if (!$invalidCredentials instanceof DomainExceptionHandlerInterface) {
                         throw new LogicException('Invalid admin credentials exception handler service is invalid.');
                     }
 
-                    return [$invalidCredentials];
+                    if (!$csvIngestion instanceof DomainExceptionHandlerInterface) {
+                        throw new LogicException('CSV ingestion exception handler service is invalid.');
+                    }
+
+                    return [$invalidCredentials, $csvIngestion];
                 },
             );
     }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -232,6 +232,12 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         [],
                         null,
                         $config->debug,
+                        [],
+                        [],
+                        ['/machine/health'],
+                        [],
+                        [],
+                        10 * 1024 * 1024,
                     );
                 },
             )

--- a/src/Ingestion/CreateCsvSourceHandler.php
+++ b/src/Ingestion/CreateCsvSourceHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateCsvSourceHandler
+{
+    public function __construct(
+        private CreateCsvSourceUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+        $name = trim((string) ($body['name'] ?? ''));
+        $filename = trim((string) ($body['filename'] ?? ''));
+        $content = trim((string) ($body['content'] ?? ''));
+        $mappingPayload = $body['column_mapping'] ?? null;
+
+        $errors = [];
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if ($filename === '') {
+            $errors[] = new ValidationError('filename', 'Filename is required.', 'required');
+        }
+
+        if ($content === '') {
+            $errors[] = new ValidationError('content', 'CSV content is required.', 'required');
+        }
+
+        if (!is_array($mappingPayload)) {
+            $errors[] = new ValidationError('column_mapping', 'Column mapping is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        /** @var array<string, mixed> $mappingPayload */
+        $output = $this->useCase->execute(new CreateCsvSourceInput(
+            name: $name,
+            filename: $filename,
+            content: $content,
+            columnMapping: CsvColumnMapping::fromArray($mappingPayload),
+        ));
+
+        return $this->response->create([
+            'source_id' => $output->sourceId,
+            'name' => $output->name,
+            'status' => $output->status->value,
+            'document_count' => $output->documentCount,
+            'chunk_count' => $output->chunkCount,
+        ], 201);
+    }
+}

--- a/src/Ingestion/CreateCsvSourceInput.php
+++ b/src/Ingestion/CreateCsvSourceInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class CreateCsvSourceInput
+{
+    public function __construct(
+        public string $name,
+        public string $filename,
+        public string $content,
+        public CsvColumnMapping $columnMapping,
+    ) {
+    }
+}

--- a/src/Ingestion/CreateCsvSourceOutput.php
+++ b/src/Ingestion/CreateCsvSourceOutput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use NeneCorpus\Source\SourceStatus;
+
+final readonly class CreateCsvSourceOutput
+{
+    public function __construct(
+        public int $sourceId,
+        public string $name,
+        public SourceStatus $status,
+        public int $documentCount,
+        public int $chunkCount,
+    ) {
+    }
+}

--- a/src/Ingestion/CreateCsvSourceUseCase.php
+++ b/src/Ingestion/CreateCsvSourceUseCase.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\DocumentRepositoryInterface;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceRepositoryInterface;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+
+final readonly class CreateCsvSourceUseCase implements CreateCsvSourceUseCaseInterface
+{
+    public function __construct(
+        private SourceRepositoryInterface $sources,
+        private DocumentRepositoryInterface $documents,
+        private ChunkRepositoryInterface $chunks,
+        private CsvUploadValidator $validator,
+        private CsvParser $parser,
+        private UploadStorage $uploadStorage,
+    ) {
+    }
+
+    public function execute(CreateCsvSourceInput $input): CreateCsvSourceOutput
+    {
+        $file = $this->validator->decode($input->content, $input->filename);
+        $rows = $this->parser->parseRows($file->bytes, $input->columnMapping);
+        $storagePath = $this->uploadStorage->store($file);
+
+        $sourceId = $this->sources->save(new Source(
+            name: $input->name,
+            sourceType: SourceType::Csv,
+            status: SourceStatus::Processing,
+            storagePath: $storagePath,
+            originalFilename: $file->originalFilename,
+            mimeType: $file->mimeType,
+            byteSize: $file->byteSize(),
+        ));
+
+        $documentCount = 0;
+        $chunkCount = 0;
+
+        try {
+            foreach ($rows as $position => $row) {
+                $documentId = $this->documents->save(new Document(
+                    sourceId: $sourceId,
+                    title: $row['title'],
+                    position: $position,
+                    metadataJson: json_encode($row['metadata'], JSON_THROW_ON_ERROR),
+                ));
+
+                ++$documentCount;
+
+                $content = $row['content'];
+                $this->chunks->save(new Chunk(
+                    documentId: $documentId,
+                    sourceId: $sourceId,
+                    content: $content,
+                    chunkIndex: 0,
+                    tokenCount: $this->estimateTokenCount($content),
+                ));
+
+                ++$chunkCount;
+            }
+
+            $this->sources->update(new Source(
+                name: $input->name,
+                sourceType: SourceType::Csv,
+                status: SourceStatus::Ready,
+                storagePath: $storagePath,
+                originalFilename: $file->originalFilename,
+                mimeType: $file->mimeType,
+                byteSize: $file->byteSize(),
+                id: $sourceId,
+            ));
+        } catch (\Throwable $exception) {
+            $this->sources->update(new Source(
+                name: $input->name,
+                sourceType: SourceType::Csv,
+                status: SourceStatus::Failed,
+                storagePath: $storagePath,
+                originalFilename: $file->originalFilename,
+                mimeType: $file->mimeType,
+                byteSize: $file->byteSize(),
+                errorMessage: $exception->getMessage(),
+                id: $sourceId,
+            ));
+
+            throw $exception;
+        }
+
+        return new CreateCsvSourceOutput(
+            sourceId: $sourceId,
+            name: $input->name,
+            status: SourceStatus::Ready,
+            documentCount: $documentCount,
+            chunkCount: $chunkCount,
+        );
+    }
+
+    private function estimateTokenCount(string $content): int
+    {
+        return (int) ceil(mb_strlen($content) / 4);
+    }
+}

--- a/src/Ingestion/CreateCsvSourceUseCaseInterface.php
+++ b/src/Ingestion/CreateCsvSourceUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+interface CreateCsvSourceUseCaseInterface
+{
+    public function execute(CreateCsvSourceInput $input): CreateCsvSourceOutput;
+}

--- a/src/Ingestion/CsvColumnMapping.php
+++ b/src/Ingestion/CsvColumnMapping.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class CsvColumnMapping
+{
+    /**
+     * @param list<string> $contentColumns
+     * @param list<string> $metadataColumns
+     */
+    public function __construct(
+        public string $titleColumn,
+        public array $contentColumns,
+        public array $metadataColumns = [],
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $titleColumn = trim((string) ($payload['title_column'] ?? ''));
+        $contentColumns = self::normalizeColumnList($payload['content_columns'] ?? []);
+        $metadataColumns = self::normalizeColumnList($payload['metadata_columns'] ?? []);
+
+        return new self($titleColumn, $contentColumns, $metadataColumns);
+    }
+
+    /**
+     * @param mixed $value
+     * @return list<string>
+     */
+    private static function normalizeColumnList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $columns = [];
+
+        foreach ($value as $column) {
+            if (!is_string($column)) {
+                continue;
+            }
+
+            $column = trim($column);
+
+            if ($column !== '') {
+                $columns[] = $column;
+            }
+        }
+
+        return $columns;
+    }
+}

--- a/src/Ingestion/CsvFilePayload.php
+++ b/src/Ingestion/CsvFilePayload.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class CsvFilePayload
+{
+    public function __construct(
+        public string $bytes,
+        public string $mimeType,
+        public string $originalFilename,
+        public string $storedFilename,
+    ) {
+    }
+
+    public function byteSize(): int
+    {
+        return strlen($this->bytes);
+    }
+}

--- a/src/Ingestion/CsvIngestionException.php
+++ b/src/Ingestion/CsvIngestionException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use DomainException;
+
+final class CsvIngestionException extends DomainException
+{
+    public function __construct(
+        string $message,
+        public readonly string $field,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/src/Ingestion/CsvIngestionExceptionHandler.php
+++ b/src/Ingestion/CsvIngestionExceptionHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class CsvIngestionExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof CsvIngestionException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        if (!$exception instanceof CsvIngestionException) {
+            throw $exception;
+        }
+
+        return $this->problemDetails->create(
+            $request,
+            'validation-failed',
+            'Validation Failed',
+            422,
+            'The request body contains invalid values.',
+            [
+                'errors' => [
+                    [
+                        'field' => $exception->field,
+                        'message' => $exception->getMessage(),
+                        'code' => 'invalid',
+                    ],
+                ],
+            ],
+        );
+    }
+}

--- a/src/Ingestion/CsvParser.php
+++ b/src/Ingestion/CsvParser.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class CsvParser
+{
+    private const SAMPLE_ROW_LIMIT = 5;
+
+    /**
+     * @return array{
+     *     headers: list<string>,
+     *     sample_rows: list<list<string>>,
+     *     detected_delimiter: string,
+     *     row_count: int
+     * }
+     */
+    public function preview(string $bytes): array
+    {
+        $rows = $this->readRows($bytes);
+
+        if ($rows === []) {
+            throw new CsvIngestionException('CSV file contains no rows.', 'content');
+        }
+
+        $headers = array_map(strval(...), array_shift($rows));
+        $headers = $this->normalizeHeaders($headers);
+
+        if ($headers === []) {
+            throw new CsvIngestionException('CSV header row is empty.', 'content');
+        }
+
+        $sampleRows = [];
+
+        foreach (array_slice($rows, 0, self::SAMPLE_ROW_LIMIT) as $row) {
+            $sampleRows[] = array_values($this->alignRow($headers, $row));
+        }
+
+        return [
+            'headers' => $headers,
+            'sample_rows' => $sampleRows,
+            'detected_delimiter' => $this->detectDelimiter($bytes),
+            'row_count' => count($rows),
+        ];
+    }
+
+    /**
+     * @return list<array{title: string, content: string, metadata: array<string, string>}>
+     */
+    public function parseRows(string $bytes, CsvColumnMapping $mapping): array
+    {
+        $preview = $this->preview($bytes);
+        $headers = $preview['headers'];
+        $this->assertMapping($mapping, $headers);
+
+        $rows = $this->readRows($bytes);
+        array_shift($rows);
+
+        $parsed = [];
+
+        foreach ($rows as $index => $row) {
+            $aligned = $this->alignRow($headers, $row);
+            $record = $this->rowToRecord($aligned, $mapping, $index + 1);
+
+            if ($record !== null) {
+                $parsed[] = $record;
+            }
+        }
+
+        if ($parsed === []) {
+            throw new CsvIngestionException('CSV file contains no ingestible data rows.', 'content');
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @param list<string> $headers
+     */
+    private function assertMapping(CsvColumnMapping $mapping, array $headers): void
+    {
+        if ($mapping->titleColumn === '') {
+            throw new CsvIngestionException('Title column is required.', 'column_mapping.title_column');
+        }
+
+        if ($mapping->contentColumns === []) {
+            throw new CsvIngestionException('At least one content column is required.', 'column_mapping.content_columns');
+        }
+
+        $missing = [];
+
+        foreach ([$mapping->titleColumn, ...$mapping->contentColumns, ...$mapping->metadataColumns] as $column) {
+            if (!in_array($column, $headers, true)) {
+                $missing[] = $column;
+            }
+        }
+
+        if ($missing !== []) {
+            throw new CsvIngestionException(
+                'Column mapping references unknown headers: ' . implode(', ', array_unique($missing)) . '.',
+                'column_mapping',
+            );
+        }
+    }
+
+    /**
+     * @param array<string, string> $row
+     * @return array{title: string, content: string, metadata: array<string, string>}|null
+     */
+    private function rowToRecord(array $row, CsvColumnMapping $mapping, int $position): ?array
+    {
+        $title = trim($row[$mapping->titleColumn] ?? '');
+
+        $contentParts = [];
+
+        foreach ($mapping->contentColumns as $column) {
+            $value = trim($row[$column] ?? '');
+
+            if ($value !== '') {
+                $contentParts[] = $column . ': ' . $value;
+            }
+        }
+
+        $content = implode("\n", $contentParts);
+
+        if ($title === '' && $content === '') {
+            return null;
+        }
+
+        if ($title === '') {
+            $title = 'Row ' . $position;
+        }
+
+        $metadata = [];
+
+        foreach ($mapping->metadataColumns as $column) {
+            $metadata[$column] = $row[$column] ?? '';
+        }
+
+        return [
+            'title' => $title,
+            'content' => $content !== '' ? $content : $title,
+            'metadata' => $metadata,
+        ];
+    }
+
+    /**
+     * @return list<list<string>>
+     */
+    private function readRows(string $bytes): array
+    {
+        $delimiter = $this->detectDelimiter($bytes);
+        $lines = preg_split('/\R/', $bytes) ?: [];
+        $rows = [];
+
+        foreach ($lines as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $row = str_getcsv($line, $delimiter, '"', '\\');
+            $normalized = array_map(static fn (mixed $value): string => trim((string) $value), $row);
+
+            if (implode('', $normalized) === '') {
+                continue;
+            }
+
+            $rows[] = $normalized;
+        }
+
+        return $rows;
+    }
+
+    private function detectDelimiter(string $bytes): string
+    {
+        $firstLine = strtok($bytes, "\r\n");
+
+        if ($firstLine === false) {
+            return ',';
+        }
+
+        $best = ',';
+        $bestCount = 0;
+
+        foreach ([',', ';', "\t"] as $delimiter) {
+            $count = substr_count($firstLine, $delimiter);
+
+            if ($count > $bestCount) {
+                $bestCount = $count;
+                $best = $delimiter;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * @param list<string> $headers
+     * @param list<string> $row
+     * @return array<string, string>
+     */
+    private function alignRow(array $headers, array $row): array
+    {
+        $aligned = [];
+
+        foreach ($headers as $index => $header) {
+            $aligned[$header] = $row[$index] ?? '';
+        }
+
+        return $aligned;
+    }
+
+    /**
+     * @param list<string> $headers
+     * @return list<string>
+     */
+    private function normalizeHeaders(array $headers): array
+    {
+        $normalized = [];
+
+        foreach ($headers as $header) {
+            $header = trim($header);
+
+            if ($header !== '') {
+                $normalized[] = $header;
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Ingestion/CsvUploadValidator.php
+++ b/src/Ingestion/CsvUploadValidator.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use finfo;
+
+final readonly class CsvUploadValidator
+{
+    public const MAX_FILE_BYTES = 5_242_880;
+
+    /** @var list<string> */
+    private const ALLOWED_MIME_TYPES = [
+        'text/plain',
+        'text/csv',
+        'application/csv',
+        'text/x-csv',
+        'application/vnd.ms-excel',
+    ];
+
+    public function decode(string $base64Content, string $filename): CsvFilePayload
+    {
+        $base64Content = trim($base64Content);
+
+        if ($base64Content === '') {
+            throw new CsvIngestionException('CSV content is required.', 'content');
+        }
+
+        $bytes = base64_decode($base64Content, true);
+
+        if ($bytes === false) {
+            throw new CsvIngestionException('CSV content must be valid base64.', 'content');
+        }
+
+        $size = strlen($bytes);
+
+        if ($size === 0) {
+            throw new CsvIngestionException('CSV file is empty.', 'content');
+        }
+
+        if ($size > self::MAX_FILE_BYTES) {
+            throw new CsvIngestionException(
+                sprintf('CSV file must be %d bytes or smaller.', self::MAX_FILE_BYTES),
+                'content',
+            );
+        }
+
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+        $mimeType = $finfo->buffer($bytes);
+
+        if (!is_string($mimeType) || !in_array($mimeType, self::ALLOWED_MIME_TYPES, true)) {
+            throw new CsvIngestionException('Uploaded file must be a CSV document.', 'content');
+        }
+
+        $sanitized = $this->sanitizeFilename($filename);
+        $storedFilename = bin2hex(random_bytes(8)) . '_' . $sanitized;
+
+        return new CsvFilePayload(
+            bytes: $bytes,
+            mimeType: $mimeType,
+            originalFilename: $sanitized,
+            storedFilename: $storedFilename,
+        );
+    }
+
+    private function sanitizeFilename(string $filename): string
+    {
+        $name = basename($filename);
+        $name = str_replace("\x00", '', $name);
+        $name = ltrim($name, '.');
+        $name = preg_replace('/[^\w\-.]/', '_', $name) ?? '_';
+
+        $extension = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+        $dangerousExtensions = ['php', 'phtml', 'phar', 'cgi', 'py', 'sh', 'exe'];
+
+        if (in_array($extension, $dangerousExtensions, true)) {
+            $base = pathinfo($name, PATHINFO_FILENAME);
+            $name = $base . '_' . $extension;
+        }
+
+        if ($name === '') {
+            return 'upload.csv';
+        }
+
+        if (!str_ends_with(strtolower($name), '.csv')) {
+            $name .= '.csv';
+        }
+
+        return $name;
+    }
+}

--- a/src/Ingestion/IngestionRouteRegistrar.php
+++ b/src/Ingestion/IngestionRouteRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class IngestionRouteRegistrar
+{
+    public function __construct(
+        private PreviewCsvIngestionHandler $previewHandler,
+        private CreateCsvSourceHandler $createSourceHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $preview = $this->previewHandler;
+        $createSource = $this->createSourceHandler;
+
+        $router->post(
+            '/admin/ingestion/csv/preview',
+            static fn (ServerRequestInterface $request) => $preview->handle($request),
+        );
+        $router->post(
+            '/admin/sources',
+            static fn (ServerRequestInterface $request) => $createSource->handle($request),
+        );
+    }
+}

--- a/src/Ingestion/IngestionServiceProvider.php
+++ b/src/Ingestion/IngestionServiceProvider.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Document\DocumentRepositoryInterface;
+use NeneCorpus\Http\RuntimeServiceProvider;
+use NeneCorpus\Source\SourceRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class IngestionServiceProvider implements ServiceProviderInterface
+{
+    public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.ingestion';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                CsvUploadValidator::class,
+                static fn (): CsvUploadValidator => new CsvUploadValidator(),
+            )
+            ->set(
+                CsvParser::class,
+                static fn (): CsvParser => new CsvParser(),
+            )
+            ->set(
+                UploadStorage::class,
+                static function (ContainerInterface $container): UploadStorage {
+                    $projectRoot = $container->get(RuntimeServiceProvider::PROJECT_ROOT);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    return new UploadStorage($projectRoot . '/storage/uploads');
+                },
+            )
+            ->set(
+                PreviewCsvIngestionUseCaseInterface::class,
+                static function (ContainerInterface $container): PreviewCsvIngestionUseCaseInterface {
+                    $validator = $container->get(CsvUploadValidator::class);
+                    $parser = $container->get(CsvParser::class);
+
+                    if (!$validator instanceof CsvUploadValidator) {
+                        throw new LogicException('CSV upload validator service is invalid.');
+                    }
+
+                    if (!$parser instanceof CsvParser) {
+                        throw new LogicException('CSV parser service is invalid.');
+                    }
+
+                    return new PreviewCsvIngestionUseCase($validator, $parser);
+                },
+            )
+            ->set(
+                CreateCsvSourceUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateCsvSourceUseCaseInterface {
+                    $sources = $container->get(SourceRepositoryInterface::class);
+                    $documents = $container->get(DocumentRepositoryInterface::class);
+                    $chunks = $container->get(ChunkRepositoryInterface::class);
+                    $validator = $container->get(CsvUploadValidator::class);
+                    $parser = $container->get(CsvParser::class);
+                    $storage = $container->get(UploadStorage::class);
+
+                    if (!$sources instanceof SourceRepositoryInterface) {
+                        throw new LogicException('Source repository service is invalid.');
+                    }
+
+                    if (!$documents instanceof DocumentRepositoryInterface) {
+                        throw new LogicException('Document repository service is invalid.');
+                    }
+
+                    if (!$chunks instanceof ChunkRepositoryInterface) {
+                        throw new LogicException('Chunk repository service is invalid.');
+                    }
+
+                    if (!$validator instanceof CsvUploadValidator) {
+                        throw new LogicException('CSV upload validator service is invalid.');
+                    }
+
+                    if (!$parser instanceof CsvParser) {
+                        throw new LogicException('CSV parser service is invalid.');
+                    }
+
+                    if (!$storage instanceof UploadStorage) {
+                        throw new LogicException('Upload storage service is invalid.');
+                    }
+
+                    return new CreateCsvSourceUseCase(
+                        $sources,
+                        $documents,
+                        $chunks,
+                        $validator,
+                        $parser,
+                        $storage,
+                    );
+                },
+            )
+            ->set(
+                PreviewCsvIngestionHandler::class,
+                static function (ContainerInterface $container): PreviewCsvIngestionHandler {
+                    $useCase = $container->get(PreviewCsvIngestionUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof PreviewCsvIngestionUseCaseInterface) {
+                        throw new LogicException('Preview CSV ingestion use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new PreviewCsvIngestionHandler($useCase, $response);
+                },
+            )
+            ->set(
+                CreateCsvSourceHandler::class,
+                static function (ContainerInterface $container): CreateCsvSourceHandler {
+                    $useCase = $container->get(CreateCsvSourceUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateCsvSourceUseCaseInterface) {
+                        throw new LogicException('Create CSV source use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateCsvSourceHandler($useCase, $response);
+                },
+            )
+            ->set(
+                CsvIngestionExceptionHandler::class,
+                static function (ContainerInterface $container): CsvIngestionExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new CsvIngestionExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                self::ROUTE_REGISTRAR,
+                static function (ContainerInterface $container): IngestionRouteRegistrar {
+                    $preview = $container->get(PreviewCsvIngestionHandler::class);
+                    $createSource = $container->get(CreateCsvSourceHandler::class);
+
+                    if (!$preview instanceof PreviewCsvIngestionHandler) {
+                        throw new LogicException('Preview CSV ingestion handler service is invalid.');
+                    }
+
+                    if (!$createSource instanceof CreateCsvSourceHandler) {
+                        throw new LogicException('Create CSV source handler service is invalid.');
+                    }
+
+                    return new IngestionRouteRegistrar($preview, $createSource);
+                },
+            );
+    }
+}

--- a/src/Ingestion/PreviewCsvIngestionHandler.php
+++ b/src/Ingestion/PreviewCsvIngestionHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class PreviewCsvIngestionHandler
+{
+    public function __construct(
+        private PreviewCsvIngestionUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+        $filename = trim((string) ($body['filename'] ?? ''));
+        $content = trim((string) ($body['content'] ?? ''));
+
+        $errors = [];
+
+        if ($filename === '') {
+            $errors[] = new ValidationError('filename', 'Filename is required.', 'required');
+        }
+
+        if ($content === '') {
+            $errors[] = new ValidationError('content', 'CSV content is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new PreviewCsvIngestionInput(
+            filename: $filename,
+            content: $content,
+        ));
+
+        return $this->response->create([
+            'headers' => $output->headers,
+            'sample_rows' => $output->sampleRows,
+            'detected_delimiter' => $output->detectedDelimiter,
+            'row_count' => $output->rowCount,
+        ]);
+    }
+}

--- a/src/Ingestion/PreviewCsvIngestionInput.php
+++ b/src/Ingestion/PreviewCsvIngestionInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class PreviewCsvIngestionInput
+{
+    public function __construct(
+        public string $filename,
+        public string $content,
+    ) {
+    }
+}

--- a/src/Ingestion/PreviewCsvIngestionOutput.php
+++ b/src/Ingestion/PreviewCsvIngestionOutput.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class PreviewCsvIngestionOutput
+{
+    /**
+     * @param list<string> $headers
+     * @param list<list<string>> $sampleRows
+     */
+    public function __construct(
+        public array $headers,
+        public array $sampleRows,
+        public string $detectedDelimiter,
+        public int $rowCount,
+    ) {
+    }
+}

--- a/src/Ingestion/PreviewCsvIngestionUseCase.php
+++ b/src/Ingestion/PreviewCsvIngestionUseCase.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class PreviewCsvIngestionUseCase implements PreviewCsvIngestionUseCaseInterface
+{
+    public function __construct(
+        private CsvUploadValidator $validator,
+        private CsvParser $parser,
+    ) {
+    }
+
+    public function execute(PreviewCsvIngestionInput $input): PreviewCsvIngestionOutput
+    {
+        $file = $this->validator->decode($input->content, $input->filename);
+        $preview = $this->parser->preview($file->bytes);
+
+        return new PreviewCsvIngestionOutput(
+            headers: $preview['headers'],
+            sampleRows: $preview['sample_rows'],
+            detectedDelimiter: $preview['detected_delimiter'],
+            rowCount: $preview['row_count'],
+        );
+    }
+}

--- a/src/Ingestion/PreviewCsvIngestionUseCaseInterface.php
+++ b/src/Ingestion/PreviewCsvIngestionUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+interface PreviewCsvIngestionUseCaseInterface
+{
+    public function execute(PreviewCsvIngestionInput $input): PreviewCsvIngestionOutput;
+}

--- a/src/Ingestion/UploadStorage.php
+++ b/src/Ingestion/UploadStorage.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class UploadStorage
+{
+    public function __construct(
+        private string $uploadDirectory,
+    ) {
+    }
+
+    public function store(CsvFilePayload $file): string
+    {
+        $this->ensureDirectoryExists();
+
+        $absolutePath = $this->uploadDirectory . '/' . $file->storedFilename;
+
+        if (file_put_contents($absolutePath, $file->bytes) === false) {
+            throw new CsvIngestionException('Failed to store uploaded CSV file.', 'content');
+        }
+
+        return 'storage/uploads/' . $file->storedFilename;
+    }
+
+    private function ensureDirectoryExists(): void
+    {
+        if (is_dir($this->uploadDirectory)) {
+            return;
+        }
+
+        if (!mkdir($this->uploadDirectory, 0775, true) && !is_dir($this->uploadDirectory)) {
+            throw new CsvIngestionException('Upload directory is not writable.', 'content');
+        }
+    }
+}

--- a/tests/Ingestion/CreateCsvSourceUseCaseTest.php
+++ b/tests/Ingestion/CreateCsvSourceUseCaseTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Ingestion;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Ingestion\CreateCsvSourceInput;
+use NeneCorpus\Ingestion\CreateCsvSourceUseCase;
+use NeneCorpus\Ingestion\CsvColumnMapping;
+use NeneCorpus\Ingestion\CsvParser;
+use NeneCorpus\Ingestion\CsvUploadValidator;
+use NeneCorpus\Ingestion\UploadStorage;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class CreateCsvSourceUseCaseTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private string $uploadDirectory;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+
+        $this->uploadDirectory = sys_get_temp_dir() . '/nene-corpus-uploads-' . uniqid('', true);
+        mkdir($this->uploadDirectory, 0775, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->uploadDirectory . '/*') ?: [] as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+
+        if (is_dir($this->uploadDirectory)) {
+            rmdir($this->uploadDirectory);
+        }
+    }
+
+    public function test_execute_persists_source_documents_and_chunks(): void
+    {
+        $csv = <<<'CSV'
+product_name,description,price
+Widget A,Great widget,100
+Widget B,Another widget,200
+CSV;
+
+        $useCase = new CreateCsvSourceUseCase(
+            new PdoSourceRepository($this->executor),
+            new PdoDocumentRepository($this->executor),
+            new PdoChunkRepository($this->executor),
+            new CsvUploadValidator(),
+            new CsvParser(),
+            new UploadStorage($this->uploadDirectory),
+        );
+
+        $output = $useCase->execute(new CreateCsvSourceInput(
+            name: 'Product catalog',
+            filename: 'catalog.csv',
+            content: base64_encode($csv),
+            columnMapping: new CsvColumnMapping(
+                titleColumn: 'product_name',
+                contentColumns: ['description'],
+                metadataColumns: ['price'],
+            ),
+        ));
+
+        self::assertSame(SourceStatus::Ready, $output->status);
+        self::assertSame(2, $output->documentCount);
+        self::assertSame(2, $output->chunkCount);
+
+        $source = (new PdoSourceRepository($this->executor))->findById($output->sourceId);
+        self::assertNotNull($source);
+        self::assertSame('csv', $source->sourceType->value);
+        self::assertSame('ready', $source->status->value);
+        self::assertStringStartsWith('storage/uploads/', $source->storagePath);
+
+        $documents = (new PdoDocumentRepository($this->executor))->findBySourceId($output->sourceId, 10, 0);
+        self::assertCount(2, $documents);
+        self::assertSame('Widget A', $documents[0]->title);
+    }
+}

--- a/tests/Ingestion/CsvIngestionHttpTest.php
+++ b/tests/Ingestion/CsvIngestionHttpTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Ingestion;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class CsvIngestionHttpTest extends TestCase
+{
+    private const JWT_SECRET = 'test-admin-jwt-secret';
+
+    private string $databasePath;
+
+    /** @var list<string> */
+    private array $uploadedFiles = [];
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-csv-ingestion-' . uniqid('', true) . '.sqlite';
+
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_ENV['DB_ADAPTER'] = 'sqlite';
+        $_ENV['DB_NAME'] = $this->databasePath;
+        $_SERVER['DB_ADAPTER'] = 'sqlite';
+        $_SERVER['DB_NAME'] = $this->databasePath;
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        AdminHttpTestSupport::seedCorpusSchema($executor);
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        unset(
+            $_ENV['DB_ADAPTER'],
+            $_SERVER['DB_ADAPTER'],
+            $_ENV['DB_NAME'],
+            $_SERVER['DB_NAME'],
+        );
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+
+        $projectRoot = dirname(__DIR__, 2);
+
+        foreach ($this->uploadedFiles as $relativePath) {
+            $absolutePath = $projectRoot . '/' . $relativePath;
+
+            if (is_file($absolutePath)) {
+                unlink($absolutePath);
+            }
+        }
+    }
+
+    public function test_preview_returns_headers_and_sample_rows(): void
+    {
+        $csv = <<<'CSV'
+product_name,description,price
+Widget A,Great widget,100
+CSV;
+
+        $response = $this->authorizedPost('/admin/ingestion/csv/preview', [
+            'filename' => 'catalog.csv',
+            'content' => base64_encode($csv),
+        ]);
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(['product_name', 'description', 'price'], $payload['headers']);
+        self::assertSame(1, $payload['row_count']);
+        self::assertSame(',', $payload['detected_delimiter']);
+    }
+
+    public function test_create_source_persists_corpus_rows(): void
+    {
+        $csv = <<<'CSV'
+product_name,description,price
+Widget A,Great widget,100
+Widget B,Another widget,200
+CSV;
+
+        $response = $this->authorizedPost('/admin/sources', [
+            'name' => 'Product catalog',
+            'filename' => 'catalog.csv',
+            'content' => base64_encode($csv),
+            'column_mapping' => [
+                'title_column' => 'product_name',
+                'content_columns' => ['description'],
+                'metadata_columns' => ['price'],
+            ],
+        ]);
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(201, $response->getStatusCode());
+        self::assertSame('ready', $payload['status']);
+        self::assertSame(2, $payload['document_count']);
+        self::assertSame(2, $payload['chunk_count']);
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        $source = $executor->fetchOne('SELECT storage_path FROM sources WHERE id = ?', [$payload['source_id']]);
+        self::assertIsArray($source);
+        $this->uploadedFiles[] = (string) $source['storage_path'];
+    }
+
+    public function test_preview_requires_bearer_token(): void
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/ingestion/csv/preview')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream('{}')),
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function authorizedPost(string $path, array $body): ResponseInterface
+    {
+        $token = $this->loginToken();
+
+        return $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test' . $path)
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('Authorization', 'Bearer ' . $token)
+                ->withBody($this->factory()->createStream(json_encode($body, JSON_THROW_ON_ERROR))),
+        );
+    }
+
+    private function loginToken(): string
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/auth/login')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream(json_encode([
+                    'email' => 'admin@example.com',
+                    'password' => 'secret-password',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        $payload = $this->decodeJson($response);
+
+        return (string) $payload['access_token'];
+    }
+
+    private function application(): RequestHandlerInterface
+    {
+        $container = (new RuntimeContainerFactory())->create();
+        $application = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        return $application;
+    }
+
+    private function factory(): Psr17Factory
+    {
+        return new Psr17Factory();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Ingestion/CsvParserTest.php
+++ b/tests/Ingestion/CsvParserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Ingestion;
+
+use NeneCorpus\Ingestion\CsvColumnMapping;
+use NeneCorpus\Ingestion\CsvParser;
+use PHPUnit\Framework\TestCase;
+
+final class CsvParserTest extends TestCase
+{
+    private CsvParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new CsvParser();
+    }
+
+    public function test_preview_returns_headers_and_sample_rows(): void
+    {
+        $csv = <<<'CSV'
+product_name,description,price
+Widget A,Great widget,100
+Widget B,Another widget,200
+CSV;
+
+        $preview = $this->parser->preview($csv);
+
+        self::assertSame(['product_name', 'description', 'price'], $preview['headers']);
+        self::assertSame(',', $preview['detected_delimiter']);
+        self::assertSame(2, $preview['row_count']);
+        self::assertSame([
+            ['Widget A', 'Great widget', '100'],
+            ['Widget B', 'Another widget', '200'],
+        ], $preview['sample_rows']);
+    }
+
+    public function test_parse_rows_builds_documents_from_mapping(): void
+    {
+        $csv = <<<'CSV'
+product_name,description,price
+Widget A,Great widget,100
+CSV;
+
+        $rows = $this->parser->parseRows($csv, new CsvColumnMapping(
+            titleColumn: 'product_name',
+            contentColumns: ['description'],
+            metadataColumns: ['price'],
+        ));
+
+        self::assertCount(1, $rows);
+        self::assertSame('Widget A', $rows[0]['title']);
+        self::assertSame('description: Great widget', $rows[0]['content']);
+        self::assertSame(['price' => '100'], $rows[0]['metadata']);
+    }
+}

--- a/tests/Support/AdminHttpTestSupport.php
+++ b/tests/Support/AdminHttpTestSupport.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use Nene2\Database\PdoDatabaseQueryExecutor;
+
+final class AdminHttpTestSupport
+{
+    public static function seedCorpusSchema(PdoDatabaseQueryExecutor $executor): void
+    {
+        CorpusSchemaSetup::create($executor);
+        CorpusSchemaSetup::createAdminUsers($executor);
+
+        $hash = password_hash('secret-password', PASSWORD_ARGON2ID);
+        $now = gmdate('Y-m-d H:i:s');
+        $executor->execute(
+            'INSERT INTO admin_users (email, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?)',
+            ['admin@example.com', $hash, $now, $now],
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `Ingestion/` モジュールを新設（base64 CSV 検証、パース、ファイル保存）
- `POST /admin/ingestion/csv/preview` — ヘッダー・サンプル行・区切り文字（DB 書き込みなし）
- `POST /admin/sources` — column mapping 付き CSV 取り込み → sources / documents / chunks
- `requestMaxBodyBytes` を 10 MiB に引き上げ
- OpenAPI v0.3.0 + PHPUnit（parser / use case / HTTP）

Closes #11

Self-review: backend-api, openapi-contract, middleware-security

## Test plan

- [x] `composer check`
- [x] `CsvParserTest` / `CreateCsvSourceUseCaseTest` / `CsvIngestionHttpTest`


Made with [Cursor](https://cursor.com)