### PR TITLE
feat(source): source の reindex / delete API を追加する (#15)

### DIFF
--- a/database/migrations/20260525140000_add_source_ingestion_config.php
+++ b/database/migrations/20260525140000_add_source_ingestion_config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddSourceIngestionConfig extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('sources')
+            ->addColumn('ingestion_config_json', 'text', ['null' => true])
+            ->update();
+    }
+}

--- a/database/schema/sources.sql
+++ b/database/schema/sources.sql
@@ -9,6 +9,7 @@ CREATE TABLE sources (
     mime_type VARCHAR(127) NULL,
     byte_size BIGINT UNSIGNED NULL,
     error_message TEXT NULL,
+    ingestion_config_json TEXT NULL,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT 0,

--- a/docs/milestones/2026-05-corpus-ingestion.md
+++ b/docs/milestones/2026-05-corpus-ingestion.md
@@ -2,7 +2,7 @@
 
 Goal: store **sources**, **documents**, and **chunks** — the canonical ingestion model for Phase 1.
 
-**Status: in progress**
+**Status: complete (2026-05-25)**
 
 Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 1.
 
@@ -15,8 +15,8 @@ Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 1.
 - [x] Admin auth (JWT) for mutating routes (#9)
 - [x] CSV upload API + column mapping preview (#11)
 - [x] PDF text extraction (text PDF first) (#13)
-- [ ] Admin HTTP routes + OpenAPI
-- [ ] Reindex / delete **source** operations API
+- [x] Admin HTTP routes + OpenAPI
+- [x] Reindex / delete **source** operations API (#15)
 
 ## Verification
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,10 +1,10 @@
 openapi: 3.1.0
 info:
   title: NeNe Corpus API
-  version: 0.4.0
+  version: 0.5.0
   description: >
     NeNe Corpus public API contract — self-hosted knowledge chat on NENE2.
-    Phase 1 adds admin auth, CSV/PDF ingestion, and corpus storage foundations.
+    Phase 1 adds admin auth, CSV/PDF ingestion, source operations, and corpus storage foundations.
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -185,6 +185,68 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /admin/sources/{id}:
+    delete:
+      tags:
+        - Ingestion
+      summary: Delete source
+      description: Soft delete a source and its documents; remove associated chunks.
+      operationId: deleteSourceById
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: Source deleted.
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/SourceNotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/sources/{id}/reindex:
+    post:
+      tags:
+        - Ingestion
+      summary: Reindex source
+      description: Rebuild documents and chunks from the stored upload file. CSV sources may optionally override column mapping.
+      operationId: reindexSourceById
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReindexSourceRequest'
+      responses:
+        '200':
+          description: Source reindexed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateSourceResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/SourceNotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   securitySchemes:
     bearerAuth:
@@ -238,6 +300,20 @@ components:
                   - field: email
                     message: Email is required.
                     code: required
+    SourceNotFound:
+      description: Source not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            sourceNotFound:
+              value:
+                type: https://nene-corpus.dev/problems/source-not-found
+                title: Not Found
+                status: 404
+                detail: The requested source was not found.
+                instance: /admin/sources/999
   schemas:
     HealthResponse:
       type: object
@@ -374,6 +450,12 @@ components:
           format: int64
         sample_text:
           type: string
+    ReindexSourceRequest:
+      type: object
+      properties:
+        column_mapping:
+          $ref: '#/components/schemas/CsvColumnMapping'
+          description: Optional override for CSV sources.
     CsvColumnMapping:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -9,12 +9,13 @@ Last updated: 2026-05-25
 
 ## 状態サマリー
 
-**Phase 1 — Corpus & Ingestion: 進行中（2026-05-25）**
+**Phase 1 — Corpus & Ingestion: 完了（2026-05-25）**
 
 - ✅ Schema: `sources`, `documents`, `chunks`（#7）
 - ✅ Admin auth (JWT)（#9）
 - ✅ CSV upload API（#11）
-- ✅ PDF text extraction（#13 — PR 待ち）
+- ✅ PDF text extraction（#13）
+- ✅ Reindex / delete source（#15）
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
 
@@ -28,7 +29,7 @@ Last updated: 2026-05-25
 | Admin auth (JWT) | ✅ (#9) |
 | CSV upload API | ✅ (#11) |
 | PDF text extraction | ✅ (#13) |
-| Reindex / delete source | 🔜 |
+| Reindex / delete source | ✅ (#15) |
 
 Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05-corpus-ingestion.md)
 
@@ -55,7 +56,7 @@ Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05
 | ~~P0~~ | ~~Admin auth (JWT)~~ | ✅ #9 |
 | ~~P0~~ | ~~CSV upload API~~ | ✅ #11 |
 | ~~P0~~ | ~~PDF text extraction~~ | ✅ #13 |
-| P2 | Reindex / delete source | 運用 API |
+| ~~P2~~ | ~~Reindex / delete source~~ | ✅ #15 |
 
 詳細は [`docs/roadmap.md`](../roadmap.md)。
 

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -16,6 +16,8 @@ use NeneCorpus\Document\DocumentServiceProvider;
 use NeneCorpus\Ingestion\CsvIngestionExceptionHandler;
 use NeneCorpus\Ingestion\IngestionRouteRegistrar;
 use NeneCorpus\Ingestion\IngestionServiceProvider;
+use NeneCorpus\Source\SourceNotFoundExceptionHandler;
+use NeneCorpus\Source\SourceRouteRegistrar;
 use NeneCorpus\Source\SourceServiceProvider;
 use Psr\Container\ContainerInterface;
 
@@ -38,6 +40,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 static function (ContainerInterface $container): array {
                     $adminAuth = $container->get(AdminAuthServiceProvider::ROUTE_REGISTRAR);
                     $ingestion = $container->get(IngestionServiceProvider::ROUTE_REGISTRAR);
+                    $source = $container->get(SourceServiceProvider::ROUTE_REGISTRAR);
 
                     if (!$adminAuth instanceof AdminAuthRouteRegistrar) {
                         throw new LogicException('Admin auth route registrar service is invalid.');
@@ -47,7 +50,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Ingestion route registrar service is invalid.');
                     }
 
-                    return [$adminAuth, $ingestion];
+                    if (!$source instanceof SourceRouteRegistrar) {
+                        throw new LogicException('Source route registrar service is invalid.');
+                    }
+
+                    return [$adminAuth, $ingestion, $source];
                 },
             )
             ->set(
@@ -55,6 +62,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                 static function (ContainerInterface $container): array {
                     $invalidCredentials = $container->get(InvalidAdminCredentialsExceptionHandler::class);
                     $csvIngestion = $container->get(CsvIngestionExceptionHandler::class);
+                    $sourceNotFound = $container->get(SourceNotFoundExceptionHandler::class);
 
                     if (!$invalidCredentials instanceof DomainExceptionHandlerInterface) {
                         throw new LogicException('Invalid admin credentials exception handler service is invalid.');
@@ -64,7 +72,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('CSV ingestion exception handler service is invalid.');
                     }
 
-                    return [$invalidCredentials, $csvIngestion];
+                    if (!$sourceNotFound instanceof DomainExceptionHandlerInterface) {
+                        throw new LogicException('Source not found exception handler service is invalid.');
+                    }
+
+                    return [$invalidCredentials, $csvIngestion, $sourceNotFound];
                 },
             );
     }

--- a/src/Chunk/ChunkRepositoryInterface.php
+++ b/src/Chunk/ChunkRepositoryInterface.php
@@ -12,4 +12,6 @@ interface ChunkRepositoryInterface
     public function findByDocumentId(int $documentId): array;
 
     public function save(Chunk $chunk): int;
+
+    public function deleteBySourceId(int $sourceId): void;
 }

--- a/src/Chunk/PdoChunkRepository.php
+++ b/src/Chunk/PdoChunkRepository.php
@@ -66,6 +66,11 @@ final readonly class PdoChunkRepository implements ChunkRepositoryInterface
         return $this->query->lastInsertId();
     }
 
+    public function deleteBySourceId(int $sourceId): void
+    {
+        $this->query->execute('DELETE FROM chunks WHERE source_id = ?', [$sourceId]);
+    }
+
     /**
      * @param array<string, mixed> $row
      */

--- a/src/Ingestion/CreateCsvSourceUseCase.php
+++ b/src/Ingestion/CreateCsvSourceUseCase.php
@@ -30,6 +30,7 @@ final readonly class CreateCsvSourceUseCase implements CreateCsvSourceUseCaseInt
         $file = $this->validator->decode($input->content, $input->filename);
         $rows = $this->parser->parseRows($file->bytes, $input->columnMapping);
         $storagePath = $this->uploadStorage->store($file);
+        $ingestionConfigJson = IngestionConfigJson::encodeCsvMapping($input->columnMapping);
 
         $sourceId = $this->sources->save(new Source(
             name: $input->name,
@@ -39,6 +40,7 @@ final readonly class CreateCsvSourceUseCase implements CreateCsvSourceUseCaseInt
             originalFilename: $file->originalFilename,
             mimeType: $file->mimeType,
             byteSize: $file->byteSize(),
+            ingestionConfigJson: $ingestionConfigJson,
         ));
 
         $documentCount = 0;
@@ -75,6 +77,7 @@ final readonly class CreateCsvSourceUseCase implements CreateCsvSourceUseCaseInt
                 originalFilename: $file->originalFilename,
                 mimeType: $file->mimeType,
                 byteSize: $file->byteSize(),
+                ingestionConfigJson: $ingestionConfigJson,
                 id: $sourceId,
             ));
         } catch (\Throwable $exception) {
@@ -87,6 +90,7 @@ final readonly class CreateCsvSourceUseCase implements CreateCsvSourceUseCaseInt
                 mimeType: $file->mimeType,
                 byteSize: $file->byteSize(),
                 errorMessage: $exception->getMessage(),
+                ingestionConfigJson: $ingestionConfigJson,
                 id: $sourceId,
             ));
 

--- a/src/Ingestion/IngestionConfigJson.php
+++ b/src/Ingestion/IngestionConfigJson.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class IngestionConfigJson
+{
+    public static function encodeCsvMapping(CsvColumnMapping $mapping): string
+    {
+        return json_encode([
+            'column_mapping' => [
+                'title_column' => $mapping->titleColumn,
+                'content_columns' => $mapping->contentColumns,
+                'metadata_columns' => $mapping->metadataColumns,
+            ],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    public static function decodeCsvMapping(?string $json): CsvColumnMapping
+    {
+        if ($json === null || trim($json) === '') {
+            throw new CsvIngestionException('CSV column mapping is not stored for this source.', 'column_mapping');
+        }
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $mapping = $decoded['column_mapping'] ?? null;
+
+        if (!is_array($mapping)) {
+            throw new CsvIngestionException('CSV column mapping is not stored for this source.', 'column_mapping');
+        }
+
+        return CsvColumnMapping::fromArray($mapping);
+    }
+}

--- a/src/Ingestion/IngestionRouteRegistrar.php
+++ b/src/Ingestion/IngestionRouteRegistrar.php
@@ -13,6 +13,7 @@ final readonly class IngestionRouteRegistrar
         private PreviewCsvIngestionHandler $previewCsvHandler,
         private PreviewPdfIngestionHandler $previewPdfHandler,
         private CreateSourceHandler $createSourceHandler,
+        private ReindexSourceHandler $reindexSourceHandler,
     ) {
     }
 
@@ -21,6 +22,7 @@ final readonly class IngestionRouteRegistrar
         $previewCsv = $this->previewCsvHandler;
         $previewPdf = $this->previewPdfHandler;
         $createSource = $this->createSourceHandler;
+        $reindexSource = $this->reindexSourceHandler;
 
         $router->post(
             '/admin/ingestion/csv/preview',
@@ -33,6 +35,10 @@ final readonly class IngestionRouteRegistrar
         $router->post(
             '/admin/sources',
             static fn (ServerRequestInterface $request) => $createSource->handle($request),
+        );
+        $router->post(
+            '/admin/sources/{id}/reindex',
+            static fn (ServerRequestInterface $request) => $reindexSource->handle($request),
         );
     }
 }

--- a/src/Ingestion/IngestionServiceProvider.php
+++ b/src/Ingestion/IngestionServiceProvider.php
@@ -71,6 +71,27 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
                 },
             )
             ->set(
+                StoredFileReader::class,
+                static function (ContainerInterface $container): StoredFileReader {
+                    $projectRoot = $container->get(RuntimeServiceProvider::PROJECT_ROOT);
+
+                    if (!is_string($projectRoot) || $projectRoot === '') {
+                        throw new LogicException('Project root service is invalid.');
+                    }
+
+                    return new StoredFileReader($projectRoot);
+                },
+            )
+            ->set(
+                SourceCorpusCleaner::class,
+                static function (ContainerInterface $container): SourceCorpusCleaner {
+                    return new SourceCorpusCleaner(
+                        self::documentRepository($container),
+                        self::chunkRepository($container),
+                    );
+                },
+            )
+            ->set(
                 PreviewCsvIngestionUseCaseInterface::class,
                 static function (ContainerInterface $container): PreviewCsvIngestionUseCaseInterface {
                     $validator = $container->get(CsvUploadValidator::class);
@@ -131,6 +152,20 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
                 },
             )
             ->set(
+                ReindexSourceUseCaseInterface::class,
+                static function (ContainerInterface $container): ReindexSourceUseCaseInterface {
+                    return new ReindexSourceUseCase(
+                        self::sourceRepository($container),
+                        self::documentRepository($container),
+                        self::chunkRepository($container),
+                        self::csvParser($container),
+                        self::pdfExtractor($container),
+                        self::storedFileReader($container),
+                        self::sourceCorpusCleaner($container),
+                    );
+                },
+            )
+            ->set(
                 PreviewCsvIngestionHandler::class,
                 static fn (ContainerInterface $container): PreviewCsvIngestionHandler => new PreviewCsvIngestionHandler(
                     self::previewCsvUseCase($container),
@@ -153,6 +188,13 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
                 ),
             )
             ->set(
+                ReindexSourceHandler::class,
+                static fn (ContainerInterface $container): ReindexSourceHandler => new ReindexSourceHandler(
+                    self::reindexSourceUseCase($container),
+                    self::jsonResponse($container),
+                ),
+            )
+            ->set(
                 CsvIngestionExceptionHandler::class,
                 static function (ContainerInterface $container): CsvIngestionExceptionHandler {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
@@ -170,6 +212,7 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
                     $previewCsv = $container->get(PreviewCsvIngestionHandler::class);
                     $previewPdf = $container->get(PreviewPdfIngestionHandler::class);
                     $createSource = $container->get(CreateSourceHandler::class);
+                    $reindexSource = $container->get(ReindexSourceHandler::class);
 
                     if (!$previewCsv instanceof PreviewCsvIngestionHandler) {
                         throw new LogicException('Preview CSV ingestion handler service is invalid.');
@@ -183,7 +226,11 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Create source handler service is invalid.');
                     }
 
-                    return new IngestionRouteRegistrar($previewCsv, $previewPdf, $createSource);
+                    if (!$reindexSource instanceof ReindexSourceHandler) {
+                        throw new LogicException('Reindex source handler service is invalid.');
+                    }
+
+                    return new IngestionRouteRegistrar($previewCsv, $previewPdf, $createSource, $reindexSource);
                 },
             );
     }
@@ -318,6 +365,39 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
         }
 
         return $useCase;
+    }
+
+    private static function reindexSourceUseCase(ContainerInterface $container): ReindexSourceUseCaseInterface
+    {
+        $useCase = $container->get(ReindexSourceUseCaseInterface::class);
+
+        if (!$useCase instanceof ReindexSourceUseCaseInterface) {
+            throw new LogicException('Reindex source use case service is invalid.');
+        }
+
+        return $useCase;
+    }
+
+    private static function storedFileReader(ContainerInterface $container): StoredFileReader
+    {
+        $reader = $container->get(StoredFileReader::class);
+
+        if (!$reader instanceof StoredFileReader) {
+            throw new LogicException('Stored file reader service is invalid.');
+        }
+
+        return $reader;
+    }
+
+    private static function sourceCorpusCleaner(ContainerInterface $container): SourceCorpusCleaner
+    {
+        $cleaner = $container->get(SourceCorpusCleaner::class);
+
+        if (!$cleaner instanceof SourceCorpusCleaner) {
+            throw new LogicException('Source corpus cleaner service is invalid.');
+        }
+
+        return $cleaner;
     }
 
     private static function jsonResponse(ContainerInterface $container): JsonResponseFactory

--- a/src/Ingestion/ReindexSourceHandler.php
+++ b/src/Ingestion/ReindexSourceHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use NeneCorpus\Source\SourceNotFoundException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ReindexSourceHandler
+{
+    public function __construct(
+        private ReindexSourceUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $sourceId = (int) ($parameters['id'] ?? 0);
+
+        if ($sourceId <= 0) {
+            throw new SourceNotFoundException($sourceId);
+        }
+
+        $body = JsonRequestBodyParser::parse($request);
+        $mappingPayload = $body['column_mapping'] ?? null;
+        $columnMappingOverride = is_array($mappingPayload)
+            ? CsvColumnMapping::fromArray($mappingPayload)
+            : null;
+
+        $output = $this->useCase->execute(new ReindexSourceInput(
+            sourceId: $sourceId,
+            columnMappingOverride: $columnMappingOverride,
+        ));
+
+        return $this->response->create([
+            'source_id' => $output->sourceId,
+            'name' => $output->name,
+            'status' => $output->status->value,
+            'document_count' => $output->documentCount,
+            'chunk_count' => $output->chunkCount,
+        ]);
+    }
+}

--- a/src/Ingestion/ReindexSourceInput.php
+++ b/src/Ingestion/ReindexSourceInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class ReindexSourceInput
+{
+    public function __construct(
+        public int $sourceId,
+        public ?CsvColumnMapping $columnMappingOverride = null,
+    ) {
+    }
+}

--- a/src/Ingestion/ReindexSourceUseCase.php
+++ b/src/Ingestion/ReindexSourceUseCase.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\DocumentRepositoryInterface;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceNotFoundException;
+use NeneCorpus\Source\SourceRepositoryInterface;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+
+final readonly class ReindexSourceUseCase implements ReindexSourceUseCaseInterface
+{
+    public function __construct(
+        private SourceRepositoryInterface $sources,
+        private DocumentRepositoryInterface $documents,
+        private ChunkRepositoryInterface $chunks,
+        private CsvParser $csvParser,
+        private PdfTextExtractor $pdfExtractor,
+        private StoredFileReader $storedFiles,
+        private SourceCorpusCleaner $corpusCleaner,
+    ) {
+    }
+
+    public function execute(ReindexSourceInput $input): CreateSourceOutput
+    {
+        $source = $this->sources->findById($input->sourceId);
+
+        if ($source === null || $source->id === null) {
+            throw new SourceNotFoundException($input->sourceId);
+        }
+
+        $bytes = $this->storedFiles->read($source->storagePath);
+
+        $this->sources->update($this->processingSource($source));
+        $this->corpusCleaner->clear($source->id);
+
+        try {
+            $result = match ($source->sourceType) {
+                SourceType::Csv => $this->reindexCsv($source, $bytes, $input->columnMappingOverride),
+                SourceType::Pdf => $this->reindexPdf($source, $bytes),
+            };
+
+            $this->sources->update(new Source(
+                name: $source->name,
+                sourceType: $source->sourceType,
+                status: SourceStatus::Ready,
+                storagePath: $source->storagePath,
+                originalFilename: $source->originalFilename,
+                mimeType: $source->mimeType,
+                byteSize: $source->byteSize,
+                ingestionConfigJson: $source->ingestionConfigJson,
+                id: $source->id,
+            ));
+
+            return new CreateSourceOutput(
+                sourceId: $source->id,
+                name: $source->name,
+                status: SourceStatus::Ready,
+                documentCount: $result['document_count'],
+                chunkCount: $result['chunk_count'],
+            );
+        } catch (\Throwable $exception) {
+            $this->sources->update(new Source(
+                name: $source->name,
+                sourceType: $source->sourceType,
+                status: SourceStatus::Failed,
+                storagePath: $source->storagePath,
+                originalFilename: $source->originalFilename,
+                mimeType: $source->mimeType,
+                byteSize: $source->byteSize,
+                errorMessage: $exception->getMessage(),
+                ingestionConfigJson: $source->ingestionConfigJson,
+                id: $source->id,
+            ));
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @return array{document_count: int, chunk_count: int}
+     */
+    private function reindexCsv(Source $source, string $bytes, ?CsvColumnMapping $override): array
+    {
+        if ($source->id === null) {
+            throw new CsvIngestionException('Source id is missing.', 'source_id');
+        }
+
+        $mapping = $override ?? IngestionConfigJson::decodeCsvMapping($source->ingestionConfigJson);
+        $rows = $this->csvParser->parseRows($bytes, $mapping);
+
+        $documentCount = 0;
+        $chunkCount = 0;
+
+        foreach ($rows as $position => $row) {
+            $documentId = $this->documents->save(new Document(
+                sourceId: $source->id,
+                title: $row['title'],
+                position: $position,
+                metadataJson: json_encode($row['metadata'], JSON_THROW_ON_ERROR),
+            ));
+
+            ++$documentCount;
+
+            $content = $row['content'];
+            $this->chunks->save(new Chunk(
+                documentId: $documentId,
+                sourceId: $source->id,
+                content: $content,
+                chunkIndex: 0,
+                tokenCount: $this->estimateTokenCount($content),
+            ));
+
+            ++$chunkCount;
+        }
+
+        return [
+            'document_count' => $documentCount,
+            'chunk_count' => $chunkCount,
+        ];
+    }
+
+    /**
+     * @return array{document_count: int, chunk_count: int}
+     */
+    private function reindexPdf(Source $source, string $bytes): array
+    {
+        if ($source->id === null) {
+            throw new CsvIngestionException('Source id is missing.', 'source_id');
+        }
+
+        $pages = $this->pdfExtractor->extractPages($bytes);
+
+        $documentId = $this->documents->save(new Document(
+            sourceId: $source->id,
+            title: $source->name,
+            position: 0,
+            metadataJson: json_encode(['page_count' => count($pages)], JSON_THROW_ON_ERROR),
+        ));
+
+        foreach ($pages as $index => $page) {
+            $content = $page['text'];
+            $this->chunks->save(new Chunk(
+                documentId: $documentId,
+                sourceId: $source->id,
+                content: $content,
+                chunkIndex: $index,
+                pageNumber: $page['page_number'],
+                tokenCount: $this->estimateTokenCount($content),
+            ));
+        }
+
+        return [
+            'document_count' => 1,
+            'chunk_count' => count($pages),
+        ];
+    }
+
+    private function processingSource(Source $source): Source
+    {
+        return new Source(
+            name: $source->name,
+            sourceType: $source->sourceType,
+            status: SourceStatus::Processing,
+            storagePath: $source->storagePath,
+            originalFilename: $source->originalFilename,
+            mimeType: $source->mimeType,
+            byteSize: $source->byteSize,
+            ingestionConfigJson: $source->ingestionConfigJson,
+            id: $source->id,
+        );
+    }
+
+    private function estimateTokenCount(string $content): int
+    {
+        return (int) ceil(mb_strlen($content) / 4);
+    }
+}

--- a/src/Ingestion/ReindexSourceUseCaseInterface.php
+++ b/src/Ingestion/ReindexSourceUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+interface ReindexSourceUseCaseInterface
+{
+    public function execute(ReindexSourceInput $input): CreateSourceOutput;
+}

--- a/src/Ingestion/SourceCorpusCleaner.php
+++ b/src/Ingestion/SourceCorpusCleaner.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Document\DocumentRepositoryInterface;
+
+final readonly class SourceCorpusCleaner
+{
+    public function __construct(
+        private DocumentRepositoryInterface $documents,
+        private ChunkRepositoryInterface $chunks,
+    ) {
+    }
+
+    public function clear(int $sourceId): void
+    {
+        $this->chunks->deleteBySourceId($sourceId);
+
+        $deletedAt = gmdate('Y-m-d H:i:s');
+
+        foreach ($this->documents->findBySourceId($sourceId, 100_000, 0) as $document) {
+            if ($document->id !== null) {
+                $this->documents->softDelete($document->id, $deletedAt);
+            }
+        }
+    }
+}

--- a/src/Ingestion/StoredFileReader.php
+++ b/src/Ingestion/StoredFileReader.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class StoredFileReader
+{
+    public function __construct(
+        private string $projectRoot,
+    ) {
+    }
+
+    public function read(string $storagePath): string
+    {
+        $absolutePath = $this->projectRoot . '/' . ltrim($storagePath, '/');
+
+        if (!is_file($absolutePath)) {
+            throw new CsvIngestionException('Stored source file is missing.', 'storage_path');
+        }
+
+        $bytes = file_get_contents($absolutePath);
+
+        if ($bytes === false) {
+            throw new CsvIngestionException('Stored source file could not be read.', 'storage_path');
+        }
+
+        return $bytes;
+    }
+}

--- a/src/Source/DeleteSourceHandler.php
+++ b/src/Source/DeleteSourceHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteSourceHandler
+{
+    public function __construct(
+        private DeleteSourceUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $id = (int) ($parameters['id'] ?? 0);
+
+        if ($id <= 0) {
+            throw new SourceNotFoundException($id);
+        }
+
+        $this->useCase->execute($id);
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/Source/DeleteSourceUseCase.php
+++ b/src/Source/DeleteSourceUseCase.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Document\DocumentRepositoryInterface;
+
+final readonly class DeleteSourceUseCase implements DeleteSourceUseCaseInterface
+{
+    public function __construct(
+        private SourceRepositoryInterface $sources,
+        private DocumentRepositoryInterface $documents,
+        private ChunkRepositoryInterface $chunks,
+    ) {
+    }
+
+    public function execute(int $sourceId): void
+    {
+        $source = $this->sources->findById($sourceId);
+
+        if ($source === null) {
+            throw new SourceNotFoundException($sourceId);
+        }
+
+        $deletedAt = gmdate('Y-m-d H:i:s');
+
+        foreach ($this->documents->findBySourceId($sourceId, 100_000, 0) as $document) {
+            if ($document->id !== null) {
+                $this->documents->softDelete($document->id, $deletedAt);
+            }
+        }
+
+        $this->chunks->deleteBySourceId($sourceId);
+        $this->sources->softDelete($sourceId, $deletedAt);
+    }
+}

--- a/src/Source/DeleteSourceUseCaseInterface.php
+++ b/src/Source/DeleteSourceUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+interface DeleteSourceUseCaseInterface
+{
+    public function execute(int $sourceId): void;
+}

--- a/src/Source/PdoSourceRepository.php
+++ b/src/Source/PdoSourceRepository.php
@@ -11,7 +11,7 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
 {
     private const SELECT_COLUMNS = <<<'SQL'
         id, name, source_type, status, storage_path, original_filename, mime_type,
-        byte_size, error_message, created_at, updated_at, is_deleted, deleted_at
+        byte_size, error_message, ingestion_config_json, created_at, updated_at, is_deleted, deleted_at
         SQL;
 
     public function __construct(
@@ -48,8 +48,9 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
             <<<'SQL'
                 INSERT INTO sources (
                     name, source_type, status, storage_path, original_filename, mime_type,
-                    byte_size, error_message, created_at, updated_at, is_deleted, deleted_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
+                    byte_size, error_message, ingestion_config_json, created_at, updated_at,
+                    is_deleted, deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
                 SQL,
             [
                 $source->name,
@@ -60,6 +61,7 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
                 $source->mimeType,
                 $source->byteSize,
                 $source->errorMessage,
+                $source->ingestionConfigJson,
                 $now,
                 $now,
             ],
@@ -79,7 +81,7 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
                 UPDATE sources SET
                     name = ?, source_type = ?, status = ?, storage_path = ?,
                     original_filename = ?, mime_type = ?, byte_size = ?, error_message = ?,
-                    updated_at = ?
+                    ingestion_config_json = ?, updated_at = ?
                 WHERE id = ? AND is_deleted = 0
                 SQL,
             [
@@ -91,6 +93,7 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
                 $source->mimeType,
                 $source->byteSize,
                 $source->errorMessage,
+                $source->ingestionConfigJson,
                 $this->now(),
                 $source->id,
             ],
@@ -119,6 +122,7 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
             mimeType: isset($row['mime_type']) ? (string) $row['mime_type'] : null,
             byteSize: isset($row['byte_size']) ? (int) $row['byte_size'] : null,
             errorMessage: isset($row['error_message']) ? (string) $row['error_message'] : null,
+            ingestionConfigJson: isset($row['ingestion_config_json']) ? (string) $row['ingestion_config_json'] : null,
             id: (int) $row['id'],
             createdAt: (string) $row['created_at'],
             updatedAt: (string) $row['updated_at'],

--- a/src/Source/Source.php
+++ b/src/Source/Source.php
@@ -15,6 +15,7 @@ final readonly class Source
         public ?string $mimeType = null,
         public ?int $byteSize = null,
         public ?string $errorMessage = null,
+        public ?string $ingestionConfigJson = null,
         public ?int $id = null,
         public ?string $createdAt = null,
         public ?string $updatedAt = null,

--- a/src/Source/SourceNotFoundException.php
+++ b/src/Source/SourceNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use RuntimeException;
+
+final class SourceNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Source with id {$id} was not found.");
+    }
+}

--- a/src/Source/SourceNotFoundExceptionHandler.php
+++ b/src/Source/SourceNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class SourceNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof SourceNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'source-not-found',
+            'Not Found',
+            404,
+            'The requested source was not found.',
+        );
+    }
+}

--- a/src/Source/SourceRouteRegistrar.php
+++ b/src/Source/SourceRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class SourceRouteRegistrar
+{
+    public function __construct(
+        private DeleteSourceHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $delete = $this->deleteHandler;
+
+        $router->delete(
+            '/admin/sources/{id}',
+            static fn (ServerRequestInterface $request) => $delete->handle($request),
+        );
+    }
+}

--- a/src/Source/SourceServiceProvider.php
+++ b/src/Source/SourceServiceProvider.php
@@ -8,23 +8,93 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Document\DocumentRepositoryInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 
 final readonly class SourceServiceProvider implements ServiceProviderInterface
 {
+    public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.source';
+
     public function register(ContainerBuilder $builder): void
     {
-        $builder->set(
-            SourceRepositoryInterface::class,
-            static function (ContainerInterface $container): SourceRepositoryInterface {
-                $query = $container->get(DatabaseQueryExecutorInterface::class);
+        $builder
+            ->set(
+                SourceRepositoryInterface::class,
+                static function (ContainerInterface $container): SourceRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
 
-                if (!$query instanceof DatabaseQueryExecutorInterface) {
-                    throw new LogicException('Database query executor service is invalid.');
-                }
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
 
-                return new PdoSourceRepository($query);
-            },
-        );
+                    return new PdoSourceRepository($query);
+                },
+            )
+            ->set(
+                DeleteSourceUseCaseInterface::class,
+                static function (ContainerInterface $container): DeleteSourceUseCaseInterface {
+                    $sources = $container->get(SourceRepositoryInterface::class);
+                    $documents = $container->get(DocumentRepositoryInterface::class);
+                    $chunks = $container->get(ChunkRepositoryInterface::class);
+
+                    if (!$sources instanceof SourceRepositoryInterface) {
+                        throw new LogicException('Source repository service is invalid.');
+                    }
+
+                    if (!$documents instanceof DocumentRepositoryInterface) {
+                        throw new LogicException('Document repository service is invalid.');
+                    }
+
+                    if (!$chunks instanceof ChunkRepositoryInterface) {
+                        throw new LogicException('Chunk repository service is invalid.');
+                    }
+
+                    return new DeleteSourceUseCase($sources, $documents, $chunks);
+                },
+            )
+            ->set(
+                DeleteSourceHandler::class,
+                static function (ContainerInterface $container): DeleteSourceHandler {
+                    $useCase = $container->get(DeleteSourceUseCaseInterface::class);
+                    $responseFactory = $container->get(ResponseFactoryInterface::class);
+
+                    if (!$useCase instanceof DeleteSourceUseCaseInterface) {
+                        throw new LogicException('Delete source use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteSourceHandler($useCase, $responseFactory);
+                },
+            )
+            ->set(
+                SourceNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): SourceNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new SourceNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                self::ROUTE_REGISTRAR,
+                static function (ContainerInterface $container): SourceRouteRegistrar {
+                    $delete = $container->get(DeleteSourceHandler::class);
+
+                    if (!$delete instanceof DeleteSourceHandler) {
+                        throw new LogicException('Delete source handler service is invalid.');
+                    }
+
+                    return new SourceRouteRegistrar($delete);
+                },
+            );
     }
 }

--- a/tests/Ingestion/ReindexSourceUseCaseTest.php
+++ b/tests/Ingestion/ReindexSourceUseCaseTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Ingestion;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Ingestion\CsvParser;
+use NeneCorpus\Ingestion\PdfTextExtractor;
+use NeneCorpus\Ingestion\ReindexSourceInput;
+use NeneCorpus\Ingestion\ReindexSourceUseCase;
+use NeneCorpus\Ingestion\SourceCorpusCleaner;
+use NeneCorpus\Ingestion\StoredFileReader;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\SampleTextPdf;
+use PHPUnit\Framework\TestCase;
+
+final class ReindexSourceUseCaseTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/nene-corpus-reindex-' . uniqid('', true);
+        mkdir($this->projectRoot . '/storage/uploads', 0775, true);
+
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->projectRoot);
+    }
+
+    public function test_execute_rebuilds_pdf_chunks_from_stored_file(): void
+    {
+        $storedFilename = 'sample-text.pdf';
+        $storagePath = 'storage/uploads/' . $storedFilename;
+        file_put_contents($this->projectRoot . '/' . $storagePath, SampleTextPdf::bytes());
+
+        $sources = new PdoSourceRepository($this->executor);
+        $documents = new PdoDocumentRepository($this->executor);
+        $chunks = new PdoChunkRepository($this->executor);
+
+        $sourceId = $sources->save(new Source(
+            name: 'Sample manual',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: $storagePath,
+            originalFilename: 'sample-text.pdf',
+            mimeType: 'application/pdf',
+        ));
+
+        $documentId = $documents->save(new \NeneCorpus\Document\Document(
+            sourceId: $sourceId,
+            title: 'Old title',
+        ));
+
+        $chunks->save(new \NeneCorpus\Chunk\Chunk(
+            documentId: $documentId,
+            sourceId: $sourceId,
+            content: 'stale content',
+        ));
+
+        $useCase = new ReindexSourceUseCase(
+            $sources,
+            $documents,
+            $chunks,
+            new CsvParser(),
+            new PdfTextExtractor(),
+            new StoredFileReader($this->projectRoot),
+            new SourceCorpusCleaner($documents, $chunks),
+        );
+
+        $output = $useCase->execute(new ReindexSourceInput(sourceId: $sourceId));
+
+        self::assertSame(SourceStatus::Ready, $output->status);
+        self::assertSame(1, $output->documentCount);
+        self::assertSame(1, $output->chunkCount);
+
+        $activeDocuments = $documents->findBySourceId($sourceId, 10, 0);
+        self::assertCount(1, $activeDocuments);
+        self::assertSame('Sample manual', $activeDocuments[0]->title);
+
+        $activeChunks = $chunks->findByDocumentId($activeDocuments[0]->id ?? 0);
+        self::assertCount(1, $activeChunks);
+        self::assertStringContainsString('Sample PDF', $activeChunks[0]->content);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (scandir($directory) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $directory . '/' . $entry;
+
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Source/DeleteSourceUseCaseTest.php
+++ b/tests/Source/DeleteSourceUseCaseTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Source;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Source\DeleteSourceUseCase;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceNotFoundException;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteSourceUseCaseTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+    }
+
+    public function test_execute_soft_deletes_source_and_removes_chunks(): void
+    {
+        $sources = new PdoSourceRepository($this->executor);
+        $documents = new PdoDocumentRepository($this->executor);
+        $chunks = new PdoChunkRepository($this->executor);
+
+        $sourceId = $sources->save(new Source(
+            name: 'Manual',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/manual.pdf',
+        ));
+
+        $documentId = $documents->save(new \NeneCorpus\Document\Document(
+            sourceId: $sourceId,
+            title: 'Manual',
+        ));
+
+        $chunks->save(new \NeneCorpus\Chunk\Chunk(
+            documentId: $documentId,
+            sourceId: $sourceId,
+            content: 'Sample text',
+        ));
+
+        (new DeleteSourceUseCase($sources, $documents, $chunks))->execute($sourceId);
+
+        self::assertNull($sources->findById($sourceId));
+        self::assertSame([], $chunks->findByDocumentId($documentId));
+        self::assertSame([], $documents->findBySourceId($sourceId, 10, 0));
+    }
+
+    public function test_execute_throws_when_source_is_missing(): void
+    {
+        $this->expectException(SourceNotFoundException::class);
+
+        (new DeleteSourceUseCase(
+            new PdoSourceRepository($this->executor),
+            new PdoDocumentRepository($this->executor),
+            new PdoChunkRepository($this->executor),
+        ))->execute(999);
+    }
+}

--- a/tests/Source/SourceAdminHttpTest.php
+++ b/tests/Source/SourceAdminHttpTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Source;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
+use NeneCorpus\Tests\Support\SampleTextPdf;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class SourceAdminHttpTest extends TestCase
+{
+    private const JWT_SECRET = 'test-admin-jwt-secret';
+
+    private string $databasePath;
+
+    /** @var list<string> */
+    private array $uploadedFiles = [];
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-source-admin-' . uniqid('', true) . '.sqlite';
+
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_ENV['DB_ADAPTER'] = 'sqlite';
+        $_ENV['DB_NAME'] = $this->databasePath;
+        $_SERVER['DB_ADAPTER'] = 'sqlite';
+        $_SERVER['DB_NAME'] = $this->databasePath;
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        AdminHttpTestSupport::seedCorpusSchema($executor);
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        unset(
+            $_ENV['DB_ADAPTER'],
+            $_SERVER['DB_ADAPTER'],
+            $_ENV['DB_NAME'],
+            $_SERVER['DB_NAME'],
+        );
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+
+        $projectRoot = dirname(__DIR__, 2);
+
+        foreach ($this->uploadedFiles as $relativePath) {
+            $absolutePath = $projectRoot . '/' . $relativePath;
+
+            if (is_file($absolutePath)) {
+                unlink($absolutePath);
+            }
+        }
+    }
+
+    public function test_delete_source_returns_204(): void
+    {
+        $sourceId = $this->createPdfSource();
+
+        $response = $this->authorizedRequest('DELETE', '/admin/sources/' . $sourceId);
+
+        self::assertSame(204, $response->getStatusCode());
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        $source = $executor->fetchOne('SELECT is_deleted FROM sources WHERE id = ?', [$sourceId]);
+        self::assertIsArray($source);
+        self::assertSame(1, (int) $source['is_deleted']);
+    }
+
+    public function test_reindex_source_rebuilds_chunks(): void
+    {
+        $sourceId = $this->createPdfSource();
+
+        $response = $this->authorizedRequest(
+            'POST',
+            '/admin/sources/' . $sourceId . '/reindex',
+            '{}',
+        );
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('ready', $payload['status']);
+        self::assertSame(1, $payload['chunk_count']);
+    }
+
+    public function test_delete_missing_source_returns_404(): void
+    {
+        $response = $this->authorizedRequest('DELETE', '/admin/sources/9999');
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    private function createPdfSource(): int
+    {
+        $response = $this->authorizedRequest('POST', '/admin/sources', json_encode([
+            'source_type' => 'pdf',
+            'name' => 'Sample manual',
+            'filename' => 'sample-text.pdf',
+            'content' => SampleTextPdf::base64(),
+        ], JSON_THROW_ON_ERROR));
+
+        $payload = $this->decodeJson($response);
+        self::assertSame(201, $response->getStatusCode());
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        $source = $executor->fetchOne('SELECT storage_path FROM sources WHERE id = ?', [$payload['source_id']]);
+        self::assertIsArray($source);
+        $this->uploadedFiles[] = (string) $source['storage_path'];
+
+        return (int) $payload['source_id'];
+    }
+
+    private function authorizedRequest(string $method, string $path, string $body = '{}'): ResponseInterface
+    {
+        $token = $this->loginToken();
+
+        return $this->application()->handle(
+            $this->factory()->createServerRequest($method, 'https://example.test' . $path)
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('Authorization', 'Bearer ' . $token)
+                ->withBody($this->factory()->createStream($body)),
+        );
+    }
+
+    private function loginToken(): string
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/auth/login')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream(json_encode([
+                    'email' => 'admin@example.com',
+                    'password' => 'secret-password',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        $payload = $this->decodeJson($response);
+
+        return (string) $payload['access_token'];
+    }
+
+    private function application(): RequestHandlerInterface
+    {
+        $container = (new RuntimeContainerFactory())->create();
+        $application = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        return $application;
+    }
+
+    private function factory(): Psr17Factory
+    {
+        return new Psr17Factory();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -22,6 +22,7 @@ final class CorpusSchemaSetup
                     mime_type TEXT NULL,
                     byte_size INTEGER NULL,
                     error_message TEXT NULL,
+                    ingestion_config_json TEXT NULL,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL,
                     is_deleted INTEGER NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary

- `DELETE /admin/sources/{id}` — soft delete source + documents, remove chunks (204)
- `POST /admin/sources/{id}/reindex` — rebuild corpus from stored file (CSV/PDF)
- `sources.ingestion_config_json` migration — persist CSV column mapping for reindex
- `SourceNotFoundException` → 404 `source-not-found`
- OpenAPI v0.5.0; Phase 1 milestone complete

Closes #15

Self-review: backend-api, openapi-contract, database

## Test plan

- [x] `composer check`（34 tests）
- [x] `DeleteSourceUseCaseTest` / `ReindexSourceUseCaseTest` / `SourceAdminHttpTest`


Made with [Cursor](https://cursor.com)