### PR TITLE
feat(chat): chat_sessions / chat_messages スキーマとリポジトリを追加する (#17)

### DIFF
--- a/database/migrations/20260525150000_create_chat_tables.php
+++ b/database/migrations/20260525150000_create_chat_tables.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateChatTables extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('chat_sessions')
+            ->addColumn('public_token', 'string', ['limit' => 64, 'null' => false])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['public_token'], ['unique' => true, 'name' => 'uniq_chat_sessions_public_token'])
+            ->create();
+
+        $this->table('chat_messages')
+            ->addColumn('session_id', 'biginteger', ['null' => false, 'signed' => false])
+            ->addColumn('role', 'string', ['limit' => 32, 'null' => false])
+            ->addColumn('content', 'text', ['null' => false])
+            ->addColumn('citations_json', 'text', ['null' => true])
+            ->addColumn('created_at', 'datetime', ['null' => false])
+            ->addColumn('updated_at', 'datetime', ['null' => false])
+            ->addIndex(['session_id'], ['name' => 'idx_chat_messages_session_id'])
+            ->addForeignKey('session_id', 'chat_sessions', 'id', ['delete' => 'CASCADE', 'update' => 'CASCADE'])
+            ->create();
+    }
+}

--- a/database/schema/chat_messages.sql
+++ b/database/schema/chat_messages.sql
@@ -1,0 +1,13 @@
+-- Snapshot: chat_messages (consumer chat turn)
+CREATE TABLE chat_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id INTEGER NOT NULL,
+    role VARCHAR(32) NOT NULL,
+    content TEXT NOT NULL,
+    citations_json TEXT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES chat_sessions (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_chat_messages_session_id ON chat_messages (session_id);

--- a/database/schema/chat_sessions.sql
+++ b/database/schema/chat_sessions.sql
@@ -1,0 +1,9 @@
+-- Snapshot: chat_sessions (consumer chat session)
+CREATE TABLE chat_sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    public_token VARCHAR(64) NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+);
+
+CREATE UNIQUE INDEX uniq_chat_sessions_public_token ON chat_sessions (public_token);

--- a/docs/milestones/2026-05-chat-and-citations.md
+++ b/docs/milestones/2026-05-chat-and-citations.md
@@ -1,0 +1,32 @@
+# Milestone: Chat & Citations (2026-05)
+
+Goal: grounded consumer Q&A with cited responses via **sync JSON chat**.
+
+**Status: in progress**
+
+Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 2.
+
+## Acceptance Criteria
+
+- [x] Phinx migration for `chat_sessions`, `chat_messages` (#17)
+- [x] Schema snapshots in `database/schema/`
+- [x] Domain entities + `Pdo*Repository` adapters + service providers
+- [x] Repository tests (SQLite `:memory:`)
+- [ ] Full-text chunk search
+- [ ] Claude tool_use orchestration (server-side)
+- [ ] **sync JSON chat** endpoint + OpenAPI
+- [ ] **Citation** payload in responses
+- [ ] Rate limiting (session / IP)
+
+## Verification
+
+```bash
+composer migrations:migrate
+composer check
+```
+
+## Related
+
+- Issue #17 — chat session/message schema
+- [`docs/explanation/glossary.md`](../explanation/glossary.md) — sync JSON chat, citation, consumer session token
+- ADR 0003 — sync JSON chat as Tier A/B default

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -4,18 +4,19 @@ Last updated: 2026-05-25
 
 ## 最近の docs 更新
 
-- ADR 0003: デュアルデプロイ（Tier A 共用ホスティング / Tier B Docker）、同期 JSON チャット、1行 embed — Issue #3
-- 命名規則 + 用語集（`naming-conventions.md`, `glossary.md`）— Issue #5
+- Phase 1 完了 — corpus ingestion milestone (#7–#15)
+- Phase 2 開始 — chat sessions/messages schema (#17)
 
 ## 状態サマリー
 
 **Phase 1 — Corpus & Ingestion: 完了（2026-05-25）**
 
-- ✅ Schema: `sources`, `documents`, `chunks`（#7）
-- ✅ Admin auth (JWT)（#9）
-- ✅ CSV upload API（#11）
-- ✅ PDF text extraction（#13）
-- ✅ Reindex / delete source（#15）
+- ✅ Schema, Admin auth, CSV/PDF ingestion, Reindex/delete
+
+**Phase 2 — Chat & Citations: 進行中（2026-05-25）**
+
+- 🔜 Sessions + messages schema（#17 — PR 待ち）
+- 🔜 Chunk search / sync JSON chat
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
 
@@ -32,6 +33,20 @@ Last updated: 2026-05-25
 | Reindex / delete source | ✅ (#15) |
 
 Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05-corpus-ingestion.md)
+
+---
+
+## Phase 2 進捗
+
+| 項目 | 状態 |
+| --- | --- |
+| Schema: chat_sessions, chat_messages | 🔜 (#17) |
+| Chunk search (full-text) | 🔜 |
+| Claude tool_use + citations | 🔜 |
+| Sync JSON chat API | 🔜 |
+| Rate limiting | 🔜 |
+
+Milestone: [`docs/milestones/2026-05-chat-and-citations.md`](../milestones/2026-05-chat-and-citations.md)
 
 ---
 
@@ -66,7 +81,7 @@ Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05
 
 | 優先 | 項目 | 説明 |
 | --- | --- | --- |
-| P0 | Sessions + messages | 会話永続化 |
+| P0 | Sessions + messages | 会話永続化（#17 進行中） |
 | P0 | Chunk search | full-text |
 | P0 | Claude tool_use + citations | サーバー側のみ |
 | P0 | Sync JSON chat API | Tier A/B 共通デフォルト（ADR 0003） — 用語: **sync JSON chat** |

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -16,6 +16,8 @@ use NeneCorpus\Document\DocumentServiceProvider;
 use NeneCorpus\Ingestion\CsvIngestionExceptionHandler;
 use NeneCorpus\Ingestion\IngestionRouteRegistrar;
 use NeneCorpus\Ingestion\IngestionServiceProvider;
+use NeneCorpus\Message\MessageServiceProvider;
+use NeneCorpus\Session\SessionServiceProvider;
 use NeneCorpus\Source\SourceNotFoundExceptionHandler;
 use NeneCorpus\Source\SourceRouteRegistrar;
 use NeneCorpus\Source\SourceServiceProvider;
@@ -33,6 +35,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new SourceServiceProvider())
             ->addProvider(new DocumentServiceProvider())
             ->addProvider(new ChunkServiceProvider())
+            ->addProvider(new SessionServiceProvider())
+            ->addProvider(new MessageServiceProvider())
             ->addProvider(new AdminAuthServiceProvider())
             ->addProvider(new IngestionServiceProvider())
             ->set(

--- a/src/Message/ChatMessage.php
+++ b/src/Message/ChatMessage.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+final readonly class ChatMessage
+{
+    public function __construct(
+        public int $sessionId,
+        public MessageRole $role,
+        public string $content,
+        public ?string $citationsJson = null,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Message/ChatMessageRepositoryInterface.php
+++ b/src/Message/ChatMessageRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+interface ChatMessageRepositoryInterface
+{
+    public function findById(int $id): ?ChatMessage;
+
+    /** @return list<ChatMessage> */
+    public function findBySessionId(int $sessionId, int $limit, int $offset): array;
+
+    public function save(ChatMessage $message): int;
+}

--- a/src/Message/MessageRole.php
+++ b/src/Message/MessageRole.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+enum MessageRole: string
+{
+    case User = 'user';
+    case Assistant = 'assistant';
+}

--- a/src/Message/MessageServiceProvider.php
+++ b/src/Message/MessageServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class MessageServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            ChatMessageRepositoryInterface::class,
+            static function (ContainerInterface $container): ChatMessageRepositoryInterface {
+                $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoChatMessageRepository($query);
+            },
+        );
+    }
+}

--- a/src/Message/PdoChatMessageRepository.php
+++ b/src/Message/PdoChatMessageRepository.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoChatMessageRepository implements ChatMessageRepositoryInterface
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        id, session_id, role, content, citations_json, created_at, updated_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?ChatMessage
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_messages WHERE id = ?',
+            [$id],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    /** @return list<ChatMessage> */
+    public function findBySessionId(int $sessionId, int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_messages WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$sessionId, $limit, $offset],
+        );
+
+        return array_map(fn (array $row): ChatMessage => $this->mapRow($row), $rows);
+    }
+
+    public function save(ChatMessage $message): int
+    {
+        $now = $this->now();
+
+        $this->query->execute(
+            <<<'SQL'
+                INSERT INTO chat_messages (
+                    session_id, role, content, citations_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                SQL,
+            [
+                $message->sessionId,
+                $message->role->value,
+                $message->content,
+                $message->citationsJson,
+                $now,
+                $now,
+            ],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): ChatMessage
+    {
+        return new ChatMessage(
+            sessionId: (int) $row['session_id'],
+            role: MessageRole::from((string) $row['role']),
+            content: (string) $row['content'],
+            citationsJson: isset($row['citations_json']) ? (string) $row['citations_json'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+
+    private function now(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+}

--- a/src/Session/ChatSession.php
+++ b/src/Session/ChatSession.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+final readonly class ChatSession
+{
+    public function __construct(
+        public string $publicToken,
+        public ?int $id = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Session/ChatSessionRepositoryInterface.php
+++ b/src/Session/ChatSessionRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+interface ChatSessionRepositoryInterface
+{
+    public function findById(int $id): ?ChatSession;
+
+    public function findByPublicToken(string $publicToken): ?ChatSession;
+
+    public function save(ChatSession $session): int;
+
+    public function update(ChatSession $session): void;
+}

--- a/src/Session/PdoChatSessionRepository.php
+++ b/src/Session/PdoChatSessionRepository.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+use InvalidArgumentException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoChatSessionRepository implements ChatSessionRepositoryInterface
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        id, public_token, created_at, updated_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?ChatSession
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_sessions WHERE id = ?',
+            [$id],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    public function findByPublicToken(string $publicToken): ?ChatSession
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_sessions WHERE public_token = ?',
+            [$publicToken],
+        );
+
+        return $row === null ? null : $this->mapRow($row);
+    }
+
+    public function save(ChatSession $session): int
+    {
+        $now = $this->now();
+
+        $this->query->execute(
+            'INSERT INTO chat_sessions (public_token, created_at, updated_at) VALUES (?, ?, ?)',
+            [$session->publicToken, $now, $now],
+        );
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(ChatSession $session): void
+    {
+        if ($session->id === null) {
+            throw new InvalidArgumentException('Chat session id is required for update.');
+        }
+
+        $this->query->execute(
+            'UPDATE chat_sessions SET public_token = ?, updated_at = ? WHERE id = ?',
+            [$session->publicToken, $this->now(), $session->id],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): ChatSession
+    {
+        return new ChatSession(
+            publicToken: (string) $row['public_token'],
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+
+    private function now(): string
+    {
+        return gmdate('Y-m-d H:i:s');
+    }
+}

--- a/src/Session/SessionServiceProvider.php
+++ b/src/Session/SessionServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class SessionServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder->set(
+            ChatSessionRepositoryInterface::class,
+            static function (ContainerInterface $container): ChatSessionRepositoryInterface {
+                $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                if (!$query instanceof DatabaseQueryExecutorInterface) {
+                    throw new LogicException('Database query executor service is invalid.');
+                }
+
+                return new PdoChatSessionRepository($query);
+            },
+        );
+    }
+}

--- a/tests/Message/PdoChatMessageRepositoryTest.php
+++ b/tests/Message/PdoChatMessageRepositoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Message;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Message\ChatMessage;
+use NeneCorpus\Message\MessageRole;
+use NeneCorpus\Message\PdoChatMessageRepository;
+use NeneCorpus\Session\ChatSession;
+use NeneCorpus\Session\PdoChatSessionRepository;
+use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoChatMessageRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        ChatSchemaSetup::create($this->executor);
+    }
+
+    public function test_save_and_find_by_session_id(): void
+    {
+        $sessions = new PdoChatSessionRepository($this->executor);
+        $messages = new PdoChatMessageRepository($this->executor);
+
+        $sessionId = $sessions->save(new ChatSession(publicToken: 'chat-token'));
+
+        $messages->save(new ChatMessage(
+            sessionId: $sessionId,
+            role: MessageRole::User,
+            content: 'What is the return policy?',
+        ));
+
+        $messageId = $messages->save(new ChatMessage(
+            sessionId: $sessionId,
+            role: MessageRole::Assistant,
+            content: 'Returns are accepted within 30 days.',
+            citationsJson: json_encode([['chunk_id' => 1, 'source_id' => 1]], JSON_THROW_ON_ERROR),
+        ));
+
+        $found = $messages->findBySessionId($sessionId, 10, 0);
+
+        self::assertCount(2, $found);
+        self::assertSame(MessageRole::User, $found[0]->role);
+        self::assertSame(MessageRole::Assistant, $found[1]->role);
+
+        $byId = $messages->findById($messageId);
+        self::assertNotNull($byId);
+        self::assertStringContainsString('chunk_id', (string) $byId->citationsJson);
+    }
+}

--- a/tests/Session/PdoChatSessionRepositoryTest.php
+++ b/tests/Session/PdoChatSessionRepositoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Session;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Session\ChatSession;
+use NeneCorpus\Session\PdoChatSessionRepository;
+use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoChatSessionRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        ChatSchemaSetup::create($this->executor);
+    }
+
+    public function test_save_and_find_by_public_token(): void
+    {
+        $repository = new PdoChatSessionRepository($this->executor);
+        $id = $repository->save(new ChatSession(publicToken: 'abc123token'));
+
+        $session = $repository->findByPublicToken('abc123token');
+
+        self::assertNotNull($session);
+        self::assertSame($id, $session->id);
+        self::assertSame('abc123token', $session->publicToken);
+    }
+
+    public function test_find_by_id_returns_saved_session(): void
+    {
+        $repository = new PdoChatSessionRepository($this->executor);
+        $id = $repository->save(new ChatSession(publicToken: 'session-token'));
+
+        $session = $repository->findById($id);
+
+        self::assertNotNull($session);
+        self::assertSame('session-token', $session->publicToken);
+    }
+}

--- a/tests/Support/ChatSchemaSetup.php
+++ b/tests/Support/ChatSchemaSetup.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use Nene2\Database\PdoDatabaseQueryExecutor;
+
+final class ChatSchemaSetup
+{
+    public static function create(PdoDatabaseQueryExecutor $executor): void
+    {
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE chat_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    public_token TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                SQL,
+        );
+
+        $executor->execute('CREATE UNIQUE INDEX uniq_chat_sessions_public_token ON chat_sessions (public_token)');
+
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE chat_messages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id INTEGER NOT NULL,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    citations_json TEXT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY (session_id) REFERENCES chat_sessions (id) ON DELETE CASCADE
+                )
+                SQL,
+        );
+
+        $executor->execute('CREATE INDEX idx_chat_messages_session_id ON chat_messages (session_id)');
+    }
+}


### PR DESCRIPTION
## Summary

- Phinx migration + schema snapshots: `chat_sessions`, `chat_messages`
- `Session/` module: `ChatSession`, `PdoChatSessionRepository`
- `Message/` module: `ChatMessage`, `MessageRole`, `PdoChatMessageRepository`
- Repository tests + Phase 2 milestone doc

Closes #17

Self-review: database

## Test plan

- [x] `composer check`（37 tests）
- [x] `PdoChatSessionRepositoryTest` / `PdoChatMessageRepositoryTest`


Made with [Cursor](https://cursor.com)