### PR TITLE
feat(search): チャンク全文検索モジュール (#19)

### DIFF
--- a/docs/milestones/2026-05-chat-and-citations.md
+++ b/docs/milestones/2026-05-chat-and-citations.md
@@ -12,7 +12,7 @@ Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 2.
 - [x] Schema snapshots in `database/schema/`
 - [x] Domain entities + `Pdo*Repository` adapters + service providers
 - [x] Repository tests (SQLite `:memory:`)
-- [ ] Full-text chunk search
+- [ ] Full-text chunk search (#19)
 - [ ] Claude tool_use orchestration (server-side)
 - [ ] **sync JSON chat** endpoint + OpenAPI
 - [ ] **Citation** payload in responses
@@ -28,5 +28,6 @@ composer check
 ## Related
 
 - Issue #17 — chat session/message schema
+- Issue #19 — chunk full-text search
 - [`docs/explanation/glossary.md`](../explanation/glossary.md) — sync JSON chat, citation, consumer session token
 - ADR 0003 — sync JSON chat as Tier A/B default

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -5,7 +5,7 @@ Last updated: 2026-05-25
 ## 最近の docs 更新
 
 - Phase 1 完了 — corpus ingestion milestone (#7–#15)
-- Phase 2 開始 — chat sessions/messages schema (#17)
+- Phase 2 開始 — chat sessions/messages schema (#17), chunk search (#19)
 
 ## 状態サマリー
 
@@ -15,8 +15,9 @@ Last updated: 2026-05-25
 
 **Phase 2 — Chat & Citations: 進行中（2026-05-25）**
 
-- 🔜 Sessions + messages schema（#17 — PR 待ち）
-- 🔜 Chunk search / sync JSON chat
+- ✅ Sessions + messages schema（#17）
+- 🔜 Chunk search（#19 — PR 待ち）
+- 🔜 Sync JSON chat
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
 
@@ -40,8 +41,8 @@ Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05
 
 | 項目 | 状態 |
 | --- | --- |
-| Schema: chat_sessions, chat_messages | 🔜 (#17) |
-| Chunk search (full-text) | 🔜 |
+| Schema: chat_sessions, chat_messages | ✅ (#17) |
+| Chunk search (full-text) | 🔜 (#19) |
 | Claude tool_use + citations | 🔜 |
 | Sync JSON chat API | 🔜 |
 | Rate limiting | 🔜 |
@@ -81,8 +82,8 @@ Milestone: [`docs/milestones/2026-05-chat-and-citations.md`](../milestones/2026-
 
 | 優先 | 項目 | 説明 |
 | --- | --- | --- |
-| P0 | Sessions + messages | 会話永続化（#17 進行中） |
-| P0 | Chunk search | full-text |
+| ~~P0~~ | ~~Sessions + messages~~ | ✅ #17 |
+| P0 | Chunk search | full-text（#19 進行中） |
 | P0 | Claude tool_use + citations | サーバー側のみ |
 | P0 | Sync JSON chat API | Tier A/B 共通デフォルト（ADR 0003） — 用語: **sync JSON chat** |
 | P1 | Rate limiting | session / IP — 用語: **rate limit** |

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -17,6 +17,7 @@ use NeneCorpus\Ingestion\CsvIngestionExceptionHandler;
 use NeneCorpus\Ingestion\IngestionRouteRegistrar;
 use NeneCorpus\Ingestion\IngestionServiceProvider;
 use NeneCorpus\Message\MessageServiceProvider;
+use NeneCorpus\Search\SearchServiceProvider;
 use NeneCorpus\Session\SessionServiceProvider;
 use NeneCorpus\Source\SourceNotFoundExceptionHandler;
 use NeneCorpus\Source\SourceRouteRegistrar;
@@ -37,6 +38,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new ChunkServiceProvider())
             ->addProvider(new SessionServiceProvider())
             ->addProvider(new MessageServiceProvider())
+            ->addProvider(new SearchServiceProvider())
             ->addProvider(new AdminAuthServiceProvider())
             ->addProvider(new IngestionServiceProvider())
             ->set(

--- a/src/Search/ChunkSearchRepositoryInterface.php
+++ b/src/Search/ChunkSearchRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+interface ChunkSearchRepositoryInterface
+{
+    /**
+     * @return list<ChunkSearchResult>
+     */
+    public function search(string $query, int $limit): array;
+}

--- a/src/Search/ChunkSearchResult.php
+++ b/src/Search/ChunkSearchResult.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+use NeneCorpus\Chunk\Chunk;
+
+final readonly class ChunkSearchResult
+{
+    public function __construct(
+        public Chunk $chunk,
+        public int $score,
+    ) {
+    }
+}

--- a/src/Search/PdoChunkSearchRepository.php
+++ b/src/Search/PdoChunkSearchRepository.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Chunk\Chunk;
+
+final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryInterface
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        c.id, c.document_id, c.source_id, c.chunk_index, c.content, c.page_number, c.section_label,
+        c.token_count, c.created_at, c.updated_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function search(string $query, int $limit): array
+    {
+        $terms = $this->tokenize($query);
+
+        if ($terms === []) {
+            return [];
+        }
+
+        $scoreParts = [];
+        $whereParts = [];
+        $params = [];
+
+        foreach ($terms as $term) {
+            $pattern = '%' . $this->escapeLike($term) . '%';
+            $scoreParts[] = 'CASE WHEN c.content LIKE ? ESCAPE \'\\\' THEN 1 ELSE 0 END';
+            $whereParts[] = 'c.content LIKE ? ESCAPE \'\\\'';
+            $params[] = $pattern;
+        }
+
+        foreach ($terms as $term) {
+            $params[] = '%' . $this->escapeLike($term) . '%';
+        }
+
+        $params[] = $limit;
+
+        $scoreExpression = implode(' + ', $scoreParts);
+        $whereExpression = implode(' OR ', $whereParts);
+
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ', (' . $scoreExpression . ') AS relevance_score '
+            . 'FROM chunks c '
+            . 'INNER JOIN sources s ON s.id = c.source_id AND s.is_deleted = 0 '
+            . 'INNER JOIN documents d ON d.id = c.document_id AND d.is_deleted = 0 '
+            . 'WHERE ' . $whereExpression . ' '
+            . 'ORDER BY relevance_score DESC, c.id ASC '
+            . 'LIMIT ?',
+            $params,
+        );
+
+        return array_map(
+            fn (array $row): ChunkSearchResult => new ChunkSearchResult(
+                chunk: $this->mapRow($row),
+                score: (int) $row['relevance_score'],
+            ),
+            $rows,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function tokenize(string $query): array
+    {
+        $parts = preg_split('/\s+/u', trim($query), -1, PREG_SPLIT_NO_EMPTY);
+
+        if ($parts === false) {
+            return [];
+        }
+
+        return array_values(array_unique($parts));
+    }
+
+    private function escapeLike(string $value): string
+    {
+        return str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $value);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): Chunk
+    {
+        return new Chunk(
+            documentId: (int) $row['document_id'],
+            sourceId: (int) $row['source_id'],
+            content: (string) $row['content'],
+            chunkIndex: (int) $row['chunk_index'],
+            pageNumber: isset($row['page_number']) ? (int) $row['page_number'] : null,
+            sectionLabel: isset($row['section_label']) ? (string) $row['section_label'] : null,
+            tokenCount: isset($row['token_count']) ? (int) $row['token_count'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Search/SearchChunksInput.php
+++ b/src/Search/SearchChunksInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+final readonly class SearchChunksInput
+{
+    public function __construct(
+        public string $query,
+        public int $limit = 10,
+    ) {
+    }
+}

--- a/src/Search/SearchChunksUseCase.php
+++ b/src/Search/SearchChunksUseCase.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+final readonly class SearchChunksUseCase implements SearchChunksUseCaseInterface
+{
+    private const MAX_LIMIT = 50;
+
+    public function __construct(
+        private ChunkSearchRepositoryInterface $search,
+    ) {
+    }
+
+    public function execute(SearchChunksInput $input): array
+    {
+        $query = trim($input->query);
+
+        if ($query === '') {
+            return [];
+        }
+
+        $limit = max(1, min(self::MAX_LIMIT, $input->limit));
+
+        return $this->search->search($query, $limit);
+    }
+}

--- a/src/Search/SearchChunksUseCaseInterface.php
+++ b/src/Search/SearchChunksUseCaseInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+interface SearchChunksUseCaseInterface
+{
+    /**
+     * @return list<ChunkSearchResult>
+     */
+    public function execute(SearchChunksInput $input): array;
+}

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class SearchServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                ChunkSearchRepositoryInterface::class,
+                static function (ContainerInterface $container): ChunkSearchRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoChunkSearchRepository($query);
+                },
+            )
+            ->set(
+                SearchChunksUseCaseInterface::class,
+                static function (ContainerInterface $container): SearchChunksUseCaseInterface {
+                    $search = $container->get(ChunkSearchRepositoryInterface::class);
+
+                    if (!$search instanceof ChunkSearchRepositoryInterface) {
+                        throw new LogicException('Chunk search repository service is invalid.');
+                    }
+
+                    return new SearchChunksUseCase($search);
+                },
+            );
+    }
+}

--- a/tests/Search/PdoChunkSearchRepositoryTest.php
+++ b/tests/Search/PdoChunkSearchRepositoryTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Search;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Search\PdoChunkSearchRepository;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoChunkSearchRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private PdoChunkRepository $chunks;
+
+    private int $sourceId;
+
+    private int $documentId;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+
+        $sourceRepository = new PdoSourceRepository($this->executor);
+        $this->sourceId = $sourceRepository->save(new Source(
+            name: 'Manual',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/manual.pdf',
+        ));
+
+        $documentRepository = new PdoDocumentRepository($this->executor);
+        $this->documentId = $documentRepository->save(new Document(
+            sourceId: $this->sourceId,
+            title: 'Safety guide',
+            position: 0,
+        ));
+
+        $this->chunks = new PdoChunkRepository($this->executor);
+    }
+
+    public function test_search_returns_chunks_matching_single_term(): void
+    {
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Equipment safety instructions for operators.',
+            chunkIndex: 0,
+        ));
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Unrelated maintenance schedule.',
+            chunkIndex: 1,
+        ));
+
+        $results = (new PdoChunkSearchRepository($this->executor))->search('safety', 10);
+
+        self::assertCount(1, $results);
+        self::assertSame('Equipment safety instructions for operators.', $results[0]->chunk->content);
+        self::assertSame(1, $results[0]->score);
+    }
+
+    public function test_search_ranks_chunks_by_matching_term_count(): void
+    {
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Safety overview for operators.',
+            chunkIndex: 0,
+        ));
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Equipment safety instructions for operators.',
+            chunkIndex: 1,
+        ));
+
+        $results = (new PdoChunkSearchRepository($this->executor))->search('equipment safety', 10);
+
+        self::assertCount(2, $results);
+        self::assertSame('Equipment safety instructions for operators.', $results[0]->chunk->content);
+        self::assertSame(2, $results[0]->score);
+        self::assertSame('Safety overview for operators.', $results[1]->chunk->content);
+        self::assertSame(1, $results[1]->score);
+    }
+
+    public function test_search_excludes_soft_deleted_source(): void
+    {
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Safety instructions for archived source.',
+            chunkIndex: 0,
+        ));
+
+        (new PdoSourceRepository($this->executor))->softDelete($this->sourceId, '2026-05-25 12:00:00');
+
+        $results = (new PdoChunkSearchRepository($this->executor))->search('safety', 10);
+
+        self::assertSame([], $results);
+    }
+
+    public function test_search_excludes_soft_deleted_document(): void
+    {
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Safety instructions for archived document.',
+            chunkIndex: 0,
+        ));
+
+        (new PdoDocumentRepository($this->executor))->softDelete($this->documentId, '2026-05-25 12:00:00');
+
+        $results = (new PdoChunkSearchRepository($this->executor))->search('safety', 10);
+
+        self::assertSame([], $results);
+    }
+}

--- a/tests/Search/SearchChunksUseCaseTest.php
+++ b/tests/Search/SearchChunksUseCaseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Search;
+
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Search\ChunkSearchRepositoryInterface;
+use NeneCorpus\Search\ChunkSearchResult;
+use NeneCorpus\Search\SearchChunksInput;
+use NeneCorpus\Search\SearchChunksUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class SearchChunksUseCaseTest extends TestCase
+{
+    public function test_execute_returns_empty_for_blank_query(): void
+    {
+        $search = $this->createMock(ChunkSearchRepositoryInterface::class);
+        $search->expects(self::never())->method('search');
+
+        $results = (new SearchChunksUseCase($search))->execute(new SearchChunksInput(query: '   '));
+
+        self::assertSame([], $results);
+    }
+
+    public function test_execute_clamps_limit_before_search(): void
+    {
+        $chunk = new Chunk(
+            documentId: 1,
+            sourceId: 1,
+            content: 'Safety instructions.',
+        );
+
+        $search = $this->createMock(ChunkSearchRepositoryInterface::class);
+        $search->expects(self::once())
+            ->method('search')
+            ->with('safety', 50)
+            ->willReturn([new ChunkSearchResult(chunk: $chunk, score: 1)]);
+
+        $results = (new SearchChunksUseCase($search))->execute(new SearchChunksInput(query: 'safety', limit: 999));
+
+        self::assertCount(1, $results);
+    }
+}


### PR DESCRIPTION
## Summary

- `Search/` モジュール: `PdoChunkSearchRepository` + `SearchChunksUseCase`
- トークン化 LIKE 検索、マッチ語数による relevance スコア、ソフト削除済み source/document 除外
- SQLite / MySQL 両対応の初期実装（FTS インデックスは後続）
- Repository / UseCase テスト追加（43 tests）

## Test plan

- [x] `composer check` ローカル green
- [ ] CI green
- [ ] merge 後 milestone / todo 更新

Closes #19

## Self-review checklist

- [x] Issue-driven branch naming
- [x] Handler なし（HTTP は後続 Issue）— UseCase / Repository のみ
- [x] 秘密情報なし
- [x] `composer check` 実行済み

Made with [Cursor](https://cursor.com)