### PR TITLE
feat(chat): sync JSON chat API + Claude tool_use (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ NENE2_LOCAL_JWT_SECRET=
 
 # --- LLM (Phase 2+) — never commit real keys ---
 ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=claude-3-5-haiku-20241022
 
 # --- Optional upstream CMS (Phase 4) ---
 NENE_RECORDS_API_BASE_URL=

--- a/docs/milestones/2026-05-chat-and-citations.md
+++ b/docs/milestones/2026-05-chat-and-citations.md
@@ -13,9 +13,9 @@ Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 2.
 - [x] Domain entities + `Pdo*Repository` adapters + service providers
 - [x] Repository tests (SQLite `:memory:`)
 - [x] Full-text chunk search (#19)
-- [ ] Claude tool_use orchestration (server-side)
-- [ ] **sync JSON chat** endpoint + OpenAPI
-- [ ] **Citation** payload in responses
+- [ ] Claude tool_use orchestration (server-side) (#25)
+- [ ] **sync JSON chat** endpoint + OpenAPI (#25)
+- [ ] **Citation** payload in responses (#25)
 - [ ] Rate limiting (session / IP)
 
 ## Verification
@@ -29,5 +29,6 @@ composer check
 
 - Issue #17 — chat session/message schema
 - Issue #19 — chunk full-text search
+- Issue #25 — sync JSON chat + Claude tool_use
 - [`docs/explanation/glossary.md`](../explanation/glossary.md) — sync JSON chat, citation, consumer session token
 - ADR 0003 — sync JSON chat as Tier A/B default

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,10 +1,10 @@
 openapi: 3.1.0
 info:
   title: NeNe Corpus API
-  version: 0.5.0
+  version: 0.6.0
   description: >
     NeNe Corpus public API contract — self-hosted knowledge chat on NENE2.
-    Phase 1 adds admin auth, CSV/PDF ingestion, source operations, and corpus storage foundations.
+    Phase 2 adds consumer sync JSON chat with citations.
 servers:
   - url: http://localhost:8080
     description: Local development server
@@ -15,6 +15,8 @@ tags:
     description: Admin authentication for mutating routes.
   - name: Ingestion
     description: CSV and PDF upload, preview, and ingestion.
+  - name: Chat
+    description: Consumer sync JSON chat with citations.
 paths:
   /health:
     get:
@@ -247,6 +249,80 @@ paths:
           $ref: '#/components/responses/ValidationFailed'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /chat/sessions:
+    post:
+      tags:
+        - Chat
+      summary: Create chat session
+      description: Issue a consumer session token for sync JSON chat. Never use admin JWT.
+      operationId: createChatSession
+      responses:
+        '201':
+          description: Chat session created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateChatSessionResponse'
+              examples:
+                ok:
+                  value:
+                    session_id: 1
+                    session_token: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /chat/messages:
+    post:
+      tags:
+        - Chat
+      summary: Send chat message
+      description: >
+        Sync JSON chat — POST a user message and receive the full assistant reply with citations.
+        Requires `X-Session-Token` from `POST /chat/sessions`.
+      operationId: sendChatMessage
+      parameters:
+        - name: X-Session-Token
+          in: header
+          required: true
+          schema:
+            type: string
+          description: Consumer session token (`session_token` from session creation).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SendChatMessageRequest'
+            examples:
+              question:
+                value:
+                  content: Which products pair well with seafood?
+      responses:
+        '200':
+          description: Assistant reply with citations.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SendChatMessageResponse'
+              examples:
+                ok:
+                  value:
+                    message_id: 2
+                    session_id: 1
+                    role: assistant
+                    content: Here is an answer grounded in the corpus search results.
+                    citations:
+                      - chunk_id: 10
+                        document_id: 3
+                        source_id: 1
+                        excerpt: Pairing guide for dry ginjo and white fish.
+                        page_number: 2
+                        section_label: Pairings
+        '404':
+          $ref: '#/components/responses/ChatSessionNotFound'
+        '422':
+          $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 components:
   securitySchemes:
     bearerAuth:
@@ -254,6 +330,11 @@ components:
       scheme: bearer
       bearerFormat: JWT
       description: HS256 admin JWT from `POST /admin/auth/login`.
+    sessionTokenAuth:
+      type: apiKey
+      in: header
+      name: X-Session-Token
+      description: Consumer session token from `POST /chat/sessions`. Not admin JWT.
   responses:
     InternalServerError:
       description: Internal server error.
@@ -314,6 +395,20 @@ components:
                 status: 404
                 detail: The requested source was not found.
                 instance: /admin/sources/999
+    ChatSessionNotFound:
+      description: Chat session not found.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'
+          examples:
+            chatSessionNotFound:
+              value:
+                type: https://nene-corpus.dev/problems/chat-session-not-found
+                title: Not Found
+                status: 404
+                detail: The requested chat session was not found.
+                instance: /chat/messages
   schemas:
     HealthResponse:
       type: object
@@ -499,6 +594,75 @@ components:
         chunk_count:
           type: integer
           format: int64
+    CreateChatSessionResponse:
+      type: object
+      required:
+        - session_id
+        - session_token
+      properties:
+        session_id:
+          type: integer
+          format: int64
+        session_token:
+          type: string
+          description: Consumer session token for `X-Session-Token` header.
+    SendChatMessageRequest:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          type: string
+          description: End-user message text.
+    SendChatMessageResponse:
+      type: object
+      required:
+        - message_id
+        - session_id
+        - role
+        - content
+        - citations
+      properties:
+        message_id:
+          type: integer
+          format: int64
+        session_id:
+          type: integer
+          format: int64
+        role:
+          type: string
+          enum:
+            - assistant
+        content:
+          type: string
+        citations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Citation'
+    Citation:
+      type: object
+      required:
+        - chunk_id
+        - document_id
+        - source_id
+        - excerpt
+      properties:
+        chunk_id:
+          type: integer
+          format: int64
+        document_id:
+          type: integer
+          format: int64
+        source_id:
+          type: integer
+          format: int64
+        excerpt:
+          type: string
+        page_number:
+          type: integer
+          format: int64
+        section_label:
+          type: string
     ValidationProblemDetails:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -7,6 +7,7 @@ Last updated: 2026-05-25
 - Phase 1 完了 — corpus ingestion milestone (#7–#15)
 - Phase 2 開始 — chat sessions/messages schema (#17), chunk search (#19)
 - Primary persona と公開 corpus 訴求を product vision に追記 (#23)
+- sync JSON chat API + Claude tool_use (#25)
 
 ## 状態サマリー
 
@@ -17,8 +18,8 @@ Last updated: 2026-05-25
 **Phase 2 — Chat & Citations: 進行中（2026-05-25）**
 
 - ✅ Sessions + messages schema（#17）
-- 🔜 Chunk search（#19）
-- 🔜 Sync JSON chat
+- ✅ Chunk search（#19）
+- 🔜 Sync JSON chat（#25 — PR 待ち）
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
 
@@ -44,8 +45,8 @@ Milestone: [`docs/milestones/2026-05-corpus-ingestion.md`](../milestones/2026-05
 | --- | --- |
 | Schema: chat_sessions, chat_messages | ✅ (#17) |
 | Chunk search (full-text) | ✅ (#19) |
-| Claude tool_use + citations | 🔜 |
-| Sync JSON chat API | 🔜 |
+| Claude tool_use + citations | 🔜 (#25) |
+| Sync JSON chat API | 🔜 (#25) |
 | Rate limiting | 🔜 |
 
 Milestone: [`docs/milestones/2026-05-chat-and-citations.md`](../milestones/2026-05-chat-and-citations.md)
@@ -85,8 +86,8 @@ Milestone: [`docs/milestones/2026-05-chat-and-citations.md`](../milestones/2026-
 | --- | --- | --- |
 | ~~P0~~ | ~~Sessions + messages~~ | ✅ #17 |
 | ~~P0~~ | ~~Chunk search~~ | ✅ #19 |
-| P0 | Claude tool_use + citations | サーバー側のみ |
-| P0 | Sync JSON chat API | Tier A/B 共通デフォルト（ADR 0003） — 用語: **sync JSON chat** |
+| P0 | Claude tool_use + citations | #25 進行中 |
+| P0 | Sync JSON chat API | #25 進行中 |
 | P1 | Rate limiting | session / IP — 用語: **rate limit** |
 | P2 | SSE streaming | Tier B 任意 — 用語: **SSE streaming** |
 

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -11,11 +11,15 @@ use Nene2\Error\DomainExceptionHandlerInterface;
 use NeneCorpus\AdminAuth\AdminAuthRouteRegistrar;
 use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
 use NeneCorpus\AdminAuth\InvalidAdminCredentialsExceptionHandler;
+use NeneCorpus\Chat\ChatRouteRegistrar;
+use NeneCorpus\Chat\ChatServiceProvider;
+use NeneCorpus\Chat\ChatSessionNotFoundExceptionHandler;
 use NeneCorpus\Chunk\ChunkServiceProvider;
 use NeneCorpus\Document\DocumentServiceProvider;
 use NeneCorpus\Ingestion\CsvIngestionExceptionHandler;
 use NeneCorpus\Ingestion\IngestionRouteRegistrar;
 use NeneCorpus\Ingestion\IngestionServiceProvider;
+use NeneCorpus\Llm\LlmServiceProvider;
 use NeneCorpus\Message\MessageServiceProvider;
 use NeneCorpus\Search\SearchServiceProvider;
 use NeneCorpus\Session\SessionServiceProvider;
@@ -39,17 +43,24 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new SessionServiceProvider())
             ->addProvider(new MessageServiceProvider())
             ->addProvider(new SearchServiceProvider())
+            ->addProvider(new LlmServiceProvider())
+            ->addProvider(new ChatServiceProvider())
             ->addProvider(new AdminAuthServiceProvider())
             ->addProvider(new IngestionServiceProvider())
             ->set(
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {
                     $adminAuth = $container->get(AdminAuthServiceProvider::ROUTE_REGISTRAR);
+                    $chat = $container->get(ChatServiceProvider::ROUTE_REGISTRAR);
                     $ingestion = $container->get(IngestionServiceProvider::ROUTE_REGISTRAR);
                     $source = $container->get(SourceServiceProvider::ROUTE_REGISTRAR);
 
                     if (!$adminAuth instanceof AdminAuthRouteRegistrar) {
                         throw new LogicException('Admin auth route registrar service is invalid.');
+                    }
+
+                    if (!$chat instanceof ChatRouteRegistrar) {
+                        throw new LogicException('Chat route registrar service is invalid.');
                     }
 
                     if (!$ingestion instanceof IngestionRouteRegistrar) {
@@ -60,18 +71,23 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Source route registrar service is invalid.');
                     }
 
-                    return [$adminAuth, $ingestion, $source];
+                    return [$adminAuth, $chat, $ingestion, $source];
                 },
             )
             ->set(
                 self::EXCEPTION_HANDLERS,
                 static function (ContainerInterface $container): array {
                     $invalidCredentials = $container->get(InvalidAdminCredentialsExceptionHandler::class);
+                    $chatSessionNotFound = $container->get(ChatSessionNotFoundExceptionHandler::class);
                     $csvIngestion = $container->get(CsvIngestionExceptionHandler::class);
                     $sourceNotFound = $container->get(SourceNotFoundExceptionHandler::class);
 
                     if (!$invalidCredentials instanceof DomainExceptionHandlerInterface) {
                         throw new LogicException('Invalid admin credentials exception handler service is invalid.');
+                    }
+
+                    if (!$chatSessionNotFound instanceof DomainExceptionHandlerInterface) {
+                        throw new LogicException('Chat session not found exception handler service is invalid.');
                     }
 
                     if (!$csvIngestion instanceof DomainExceptionHandlerInterface) {
@@ -82,7 +98,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Source not found exception handler service is invalid.');
                     }
 
-                    return [$invalidCredentials, $csvIngestion, $sourceNotFound];
+                    return [$invalidCredentials, $chatSessionNotFound, $csvIngestion, $sourceNotFound];
                 },
             );
     }

--- a/src/Chat/ChatRouteRegistrar.php
+++ b/src/Chat/ChatRouteRegistrar.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ChatRouteRegistrar
+{
+    public function __construct(
+        private CreateChatSessionHandler $createSessionHandler,
+        private SendChatMessageHandler $sendMessageHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $createSession = $this->createSessionHandler;
+        $sendMessage = $this->sendMessageHandler;
+
+        $router->post('/chat/sessions', static fn (ServerRequestInterface $request) => $createSession->handle($request));
+        $router->post('/chat/messages', static fn (ServerRequestInterface $request) => $sendMessage->handle($request));
+    }
+}

--- a/src/Chat/ChatServiceProvider.php
+++ b/src/Chat/ChatServiceProvider.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
+use NeneCorpus\Llm\GenerateChatReplyUseCaseInterface;
+use NeneCorpus\Message\ChatMessageRepositoryInterface;
+use NeneCorpus\Session\ChatSessionRepositoryInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class ChatServiceProvider implements ServiceProviderInterface
+{
+    public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.chat';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                CreateChatSessionUseCaseInterface::class,
+                static function (ContainerInterface $container): CreateChatSessionUseCaseInterface {
+                    $sessions = $container->get(ChatSessionRepositoryInterface::class);
+
+                    if (!$sessions instanceof ChatSessionRepositoryInterface) {
+                        throw new LogicException('Chat session repository service is invalid.');
+                    }
+
+                    return new CreateChatSessionUseCase($sessions);
+                },
+            )
+            ->set(
+                SendChatMessageUseCaseInterface::class,
+                static function (ContainerInterface $container): SendChatMessageUseCaseInterface {
+                    $sessions = $container->get(ChatSessionRepositoryInterface::class);
+                    $messages = $container->get(ChatMessageRepositoryInterface::class);
+                    $generateReply = $container->get(GenerateChatReplyUseCaseInterface::class);
+
+                    if (!$sessions instanceof ChatSessionRepositoryInterface) {
+                        throw new LogicException('Chat session repository service is invalid.');
+                    }
+
+                    if (!$messages instanceof ChatMessageRepositoryInterface) {
+                        throw new LogicException('Chat message repository service is invalid.');
+                    }
+
+                    if (!$generateReply instanceof GenerateChatReplyUseCaseInterface) {
+                        throw new LogicException('Generate chat reply use case service is invalid.');
+                    }
+
+                    return new SendChatMessageUseCase($sessions, $messages, $generateReply);
+                },
+            )
+            ->set(
+                CreateChatSessionHandler::class,
+                static function (ContainerInterface $container): CreateChatSessionHandler {
+                    $useCase = $container->get(CreateChatSessionUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof CreateChatSessionUseCaseInterface) {
+                        throw new LogicException('Create chat session use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateChatSessionHandler($useCase, $response);
+                },
+            )
+            ->set(
+                SendChatMessageHandler::class,
+                static function (ContainerInterface $container): SendChatMessageHandler {
+                    $useCase = $container->get(SendChatMessageUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof SendChatMessageUseCaseInterface) {
+                        throw new LogicException('Send chat message use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new SendChatMessageHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ChatSessionNotFoundExceptionHandler::class,
+                static function (ContainerInterface $container): ChatSessionNotFoundExceptionHandler {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new ChatSessionNotFoundExceptionHandler($problemDetails);
+                },
+            )
+            ->set(
+                self::ROUTE_REGISTRAR,
+                static function (ContainerInterface $container): ChatRouteRegistrar {
+                    $createSession = $container->get(CreateChatSessionHandler::class);
+                    $sendMessage = $container->get(SendChatMessageHandler::class);
+
+                    if (!$createSession instanceof CreateChatSessionHandler) {
+                        throw new LogicException('Create chat session handler service is invalid.');
+                    }
+
+                    if (!$sendMessage instanceof SendChatMessageHandler) {
+                        throw new LogicException('Send chat message handler service is invalid.');
+                    }
+
+                    return new ChatRouteRegistrar($createSession, $sendMessage);
+                },
+            );
+    }
+}

--- a/src/Chat/ChatSessionNotFoundException.php
+++ b/src/Chat/ChatSessionNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use RuntimeException;
+
+final class ChatSessionNotFoundException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Chat session was not found.');
+    }
+}

--- a/src/Chat/ChatSessionNotFoundExceptionHandler.php
+++ b/src/Chat/ChatSessionNotFoundExceptionHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use Nene2\Error\DomainExceptionHandlerInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+final readonly class ChatSessionNotFoundExceptionHandler implements DomainExceptionHandlerInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function supports(Throwable $exception): bool
+    {
+        return $exception instanceof ChatSessionNotFoundException;
+    }
+
+    public function handle(Throwable $exception, ServerRequestInterface $request): ResponseInterface
+    {
+        return $this->problemDetails->create(
+            $request,
+            'chat-session-not-found',
+            'Not Found',
+            404,
+            'The requested chat session was not found.',
+        );
+    }
+}

--- a/src/Chat/CreateChatSessionHandler.php
+++ b/src/Chat/CreateChatSessionHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateChatSessionHandler
+{
+    public function __construct(
+        private CreateChatSessionUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute();
+
+        return $this->response->create([
+            'session_id' => $output->sessionId,
+            'session_token' => $output->sessionToken,
+        ], 201);
+    }
+}

--- a/src/Chat/CreateChatSessionOutput.php
+++ b/src/Chat/CreateChatSessionOutput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+final readonly class CreateChatSessionOutput
+{
+    public function __construct(
+        public int $sessionId,
+        public string $sessionToken,
+    ) {
+    }
+}

--- a/src/Chat/CreateChatSessionUseCase.php
+++ b/src/Chat/CreateChatSessionUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use NeneCorpus\Session\ChatSession;
+use NeneCorpus\Session\ChatSessionRepositoryInterface;
+
+final readonly class CreateChatSessionUseCase implements CreateChatSessionUseCaseInterface
+{
+    public function __construct(
+        private ChatSessionRepositoryInterface $sessions,
+    ) {
+    }
+
+    public function execute(): CreateChatSessionOutput
+    {
+        $sessionId = $this->sessions->save(new ChatSession(
+            publicToken: bin2hex(random_bytes(32)),
+        ));
+
+        $session = $this->sessions->findById($sessionId);
+
+        if ($session === null || $session->id === null) {
+            throw new \RuntimeException('Failed to load chat session after creation.');
+        }
+
+        return new CreateChatSessionOutput(
+            sessionId: $session->id,
+            sessionToken: $session->publicToken,
+        );
+    }
+}

--- a/src/Chat/CreateChatSessionUseCaseInterface.php
+++ b/src/Chat/CreateChatSessionUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+interface CreateChatSessionUseCaseInterface
+{
+    public function execute(): CreateChatSessionOutput;
+}

--- a/src/Chat/SendChatMessageHandler.php
+++ b/src/Chat/SendChatMessageHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class SendChatMessageHandler
+{
+    public const SESSION_TOKEN_HEADER = 'X-Session-Token';
+
+    public function __construct(
+        private SendChatMessageUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $sessionToken = trim($request->getHeaderLine(self::SESSION_TOKEN_HEADER));
+        $body = JsonRequestBodyParser::parse($request);
+        $content = trim((string) ($body['content'] ?? ''));
+
+        $errors = [];
+
+        if ($sessionToken === '') {
+            $errors[] = new ValidationError(
+                self::SESSION_TOKEN_HEADER,
+                'Session token header is required.',
+                'required',
+            );
+        }
+
+        if ($content === '') {
+            $errors[] = new ValidationError('content', 'Message content is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new SendChatMessageInput(
+            sessionToken: $sessionToken,
+            content: $content,
+        ));
+
+        return $this->response->create([
+            'message_id' => $output->messageId,
+            'session_id' => $output->sessionId,
+            'role' => $output->role,
+            'content' => $output->content,
+            'citations' => array_map(
+                static fn ($citation) => $citation->toArray(),
+                $output->citations,
+            ),
+        ]);
+    }
+}

--- a/src/Chat/SendChatMessageInput.php
+++ b/src/Chat/SendChatMessageInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+final readonly class SendChatMessageInput
+{
+    public function __construct(
+        public string $sessionToken,
+        public string $content,
+    ) {
+    }
+}

--- a/src/Chat/SendChatMessageOutput.php
+++ b/src/Chat/SendChatMessageOutput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use NeneCorpus\Llm\Citation;
+
+final readonly class SendChatMessageOutput
+{
+    /**
+     * @param list<Citation> $citations
+     */
+    public function __construct(
+        public int $messageId,
+        public int $sessionId,
+        public string $role,
+        public string $content,
+        public array $citations,
+    ) {
+    }
+}

--- a/src/Chat/SendChatMessageUseCase.php
+++ b/src/Chat/SendChatMessageUseCase.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+use NeneCorpus\Llm\ConversationTurn;
+use NeneCorpus\Llm\GenerateChatReplyInput;
+use NeneCorpus\Llm\GenerateChatReplyUseCaseInterface;
+use NeneCorpus\Message\ChatMessage;
+use NeneCorpus\Message\ChatMessageRepositoryInterface;
+use NeneCorpus\Message\MessageRole;
+use NeneCorpus\Session\ChatSessionRepositoryInterface;
+
+final readonly class SendChatMessageUseCase implements SendChatMessageUseCaseInterface
+{
+    private const HISTORY_LIMIT = 20;
+
+    public function __construct(
+        private ChatSessionRepositoryInterface $sessions,
+        private ChatMessageRepositoryInterface $messages,
+        private GenerateChatReplyUseCaseInterface $generateReply,
+    ) {
+    }
+
+    public function execute(SendChatMessageInput $input): SendChatMessageOutput
+    {
+        $session = $this->sessions->findByPublicToken($input->sessionToken);
+
+        if ($session === null || $session->id === null) {
+            throw new ChatSessionNotFoundException();
+        }
+
+        $content = trim($input->content);
+
+        if ($content === '') {
+            throw new \InvalidArgumentException('Message content is required.');
+        }
+
+        $this->messages->save(new ChatMessage(
+            sessionId: $session->id,
+            role: MessageRole::User,
+            content: $content,
+        ));
+
+        $history = $this->buildHistory($session->id);
+        $reply = $this->generateReply->execute(new GenerateChatReplyInput(
+            userMessage: $content,
+            history: $history,
+        ));
+
+        $citationsJson = json_encode(
+            array_map(static fn ($citation) => $citation->toArray(), $reply->citations),
+            JSON_THROW_ON_ERROR,
+        );
+
+        $assistantMessageId = $this->messages->save(new ChatMessage(
+            sessionId: $session->id,
+            role: MessageRole::Assistant,
+            content: $reply->content,
+            citationsJson: $citationsJson,
+        ));
+
+        return new SendChatMessageOutput(
+            messageId: $assistantMessageId,
+            sessionId: $session->id,
+            role: MessageRole::Assistant->value,
+            content: $reply->content,
+            citations: $reply->citations,
+        );
+    }
+
+    /**
+     * @return list<ConversationTurn>
+     */
+    private function buildHistory(int $sessionId): array
+    {
+        $stored = $this->messages->findBySessionId($sessionId, self::HISTORY_LIMIT, 0);
+        $history = [];
+
+        foreach ($stored as $message) {
+            if ($message->role === MessageRole::Assistant) {
+                $history[] = new ConversationTurn(
+                    role: 'assistant',
+                    content: $message->content,
+                );
+                continue;
+            }
+
+            $history[] = new ConversationTurn(
+                role: 'user',
+                content: $message->content,
+            );
+        }
+
+        if ($history === []) {
+            return [];
+        }
+
+        array_pop($history);
+
+        return $history;
+    }
+}

--- a/src/Chat/SendChatMessageUseCaseInterface.php
+++ b/src/Chat/SendChatMessageUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chat;
+
+interface SendChatMessageUseCaseInterface
+{
+    public function execute(SendChatMessageInput $input): SendChatMessageOutput;
+}

--- a/src/Llm/AnthropicConfig.php
+++ b/src/Llm/AnthropicConfig.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class AnthropicConfig
+{
+    private const DEFAULT_MODEL = 'claude-3-5-haiku-20241022';
+
+    private const DEFAULT_MAX_TOKENS = 1024;
+
+    public function __construct(
+        public ?string $apiKey,
+        public string $model = self::DEFAULT_MODEL,
+        public int $maxTokens = self::DEFAULT_MAX_TOKENS,
+    ) {
+    }
+
+    public static function fromEnvironment(): self
+    {
+        $apiKey = self::readEnv('ANTHROPIC_API_KEY');
+        $model = self::readEnv('ANTHROPIC_MODEL') ?? self::DEFAULT_MODEL;
+        $maxTokensRaw = self::readEnv('ANTHROPIC_MAX_TOKENS');
+        $maxTokens = $maxTokensRaw !== null && $maxTokensRaw !== ''
+            ? max(1, (int) $maxTokensRaw)
+            : self::DEFAULT_MAX_TOKENS;
+
+        return new self(
+            apiKey: $apiKey !== '' ? $apiKey : null,
+            model: $model,
+            maxTokens: $maxTokens,
+        );
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->apiKey !== null && $this->apiKey !== '';
+    }
+
+    private static function readEnv(string $key): ?string
+    {
+        $value = $_ENV[$key] ?? $_SERVER[$key] ?? null;
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return trim($value);
+    }
+}

--- a/src/Llm/Citation.php
+++ b/src/Llm/Citation.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class Citation
+{
+    public function __construct(
+        public int $chunkId,
+        public int $documentId,
+        public int $sourceId,
+        public string $excerpt,
+        public ?int $pageNumber = null,
+        public ?string $sectionLabel = null,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     chunk_id: int,
+     *     document_id: int,
+     *     source_id: int,
+     *     excerpt: string,
+     *     page_number?: int,
+     *     section_label?: string
+     * }
+     */
+    public function toArray(): array
+    {
+        $payload = [
+            'chunk_id' => $this->chunkId,
+            'document_id' => $this->documentId,
+            'source_id' => $this->sourceId,
+            'excerpt' => $this->excerpt,
+        ];
+
+        if ($this->pageNumber !== null) {
+            $payload['page_number'] = $this->pageNumber;
+        }
+
+        if ($this->sectionLabel !== null && $this->sectionLabel !== '') {
+            $payload['section_label'] = $this->sectionLabel;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Llm/ClaudeMessageResponse.php
+++ b/src/Llm/ClaudeMessageResponse.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class ClaudeMessageResponse
+{
+    /**
+     * @param list<array<string, mixed>> $contentBlocks
+     */
+    public function __construct(
+        public string $stopReason,
+        public array $contentBlocks,
+    ) {
+    }
+
+    public function text(): ?string
+    {
+        $parts = [];
+
+        foreach ($this->contentBlocks as $block) {
+            if (($block['type'] ?? '') === 'text' && is_string($block['text'] ?? null)) {
+                $parts[] = $block['text'];
+            }
+        }
+
+        if ($parts === []) {
+            return null;
+        }
+
+        return implode("\n", $parts);
+    }
+
+    /**
+     * @return list<ClaudeToolUseBlock>
+     */
+    public function toolUses(): array
+    {
+        $uses = [];
+
+        foreach ($this->contentBlocks as $block) {
+            if (($block['type'] ?? '') !== 'tool_use') {
+                continue;
+            }
+
+            if (!is_string($block['id'] ?? null) || !is_string($block['name'] ?? null)) {
+                continue;
+            }
+
+            $input = $block['input'] ?? [];
+            if (!is_array($input)) {
+                $input = [];
+            }
+
+            $uses[] = new ClaudeToolUseBlock(
+                id: $block['id'],
+                name: $block['name'],
+                input: $input,
+            );
+        }
+
+        return $uses;
+    }
+}

--- a/src/Llm/ClaudeMessagesClientInterface.php
+++ b/src/Llm/ClaudeMessagesClientInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+interface ClaudeMessagesClientInterface
+{
+    /**
+     * @param list<array<string, mixed>> $messages
+     * @param list<array<string, mixed>> $tools
+     */
+    public function createMessage(string $system, array $messages, array $tools): ClaudeMessageResponse;
+}

--- a/src/Llm/ClaudeToolUseBlock.php
+++ b/src/Llm/ClaudeToolUseBlock.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class ClaudeToolUseBlock
+{
+    /**
+     * @param array<string, mixed> $input
+     */
+    public function __construct(
+        public string $id,
+        public string $name,
+        public array $input,
+    ) {
+    }
+}

--- a/src/Llm/ConversationTurn.php
+++ b/src/Llm/ConversationTurn.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class ConversationTurn
+{
+    public function __construct(
+        public string $role,
+        public string $content,
+    ) {
+    }
+}

--- a/src/Llm/CorpusSearchToolDefinition.php
+++ b/src/Llm/CorpusSearchToolDefinition.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class CorpusSearchToolDefinition
+{
+    public const NAME = 'search_corpus';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function schema(): array
+    {
+        return [
+            'name' => self::NAME,
+            'description' => 'Search ingested corpus chunks for passages relevant to the user question.',
+            'input_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'query' => [
+                        'type' => 'string',
+                        'description' => 'Search query derived from the user question.',
+                    ],
+                ],
+                'required' => ['query'],
+            ],
+        ];
+    }
+}

--- a/src/Llm/CorpusSearchToolHandler.php
+++ b/src/Llm/CorpusSearchToolHandler.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+use NeneCorpus\Search\ChunkSearchResult;
+use NeneCorpus\Search\SearchChunksInput;
+use NeneCorpus\Search\SearchChunksUseCaseInterface;
+
+final readonly class CorpusSearchToolHandler
+{
+    private const EXCERPT_MAX_LENGTH = 240;
+
+    private const SEARCH_LIMIT = 5;
+
+    public function __construct(
+        private SearchChunksUseCaseInterface $search,
+    ) {
+    }
+
+    /**
+     * @return array{tool_result: string, citations: list<Citation>}
+     */
+    public function execute(string $query): array
+    {
+        $results = $this->search->execute(new SearchChunksInput(query: $query, limit: self::SEARCH_LIMIT));
+
+        if ($results === []) {
+            return [
+                'tool_result' => 'No matching corpus chunks were found.',
+                'citations' => [],
+            ];
+        }
+
+        $citations = array_map(
+            fn (ChunkSearchResult $result): Citation => $this->toCitation($result),
+            $results,
+        );
+
+        $lines = array_map(
+            static fn (Citation $citation): string => sprintf(
+                '- chunk_id=%d document_id=%d source_id=%d excerpt=%s',
+                $citation->chunkId,
+                $citation->documentId,
+                $citation->sourceId,
+                $citation->excerpt,
+            ),
+            $citations,
+        );
+
+        return [
+            'tool_result' => "Corpus search results:\n" . implode("\n", $lines),
+            'citations' => $citations,
+        ];
+    }
+
+    private function toCitation(ChunkSearchResult $result): Citation
+    {
+        $chunk = $result->chunk;
+
+        if ($chunk->id === null) {
+            throw new \LogicException('Search result chunk id is required.');
+        }
+
+        return new Citation(
+            chunkId: $chunk->id,
+            documentId: $chunk->documentId,
+            sourceId: $chunk->sourceId,
+            excerpt: $this->excerpt($chunk->content),
+            pageNumber: $chunk->pageNumber,
+            sectionLabel: $chunk->sectionLabel,
+        );
+    }
+
+    private function excerpt(string $content): string
+    {
+        if (mb_strlen($content) <= self::EXCERPT_MAX_LENGTH) {
+            return $content;
+        }
+
+        return mb_substr($content, 0, self::EXCERPT_MAX_LENGTH - 1) . '…';
+    }
+}

--- a/src/Llm/GenerateChatReplyInput.php
+++ b/src/Llm/GenerateChatReplyInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class GenerateChatReplyInput
+{
+    /**
+     * @param list<ConversationTurn> $history
+     */
+    public function __construct(
+        public string $userMessage,
+        public array $history = [],
+    ) {
+    }
+}

--- a/src/Llm/GenerateChatReplyOutput.php
+++ b/src/Llm/GenerateChatReplyOutput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final readonly class GenerateChatReplyOutput
+{
+    /**
+     * @param list<Citation> $citations
+     */
+    public function __construct(
+        public string $content,
+        public array $citations,
+    ) {
+    }
+}

--- a/src/Llm/GenerateChatReplyUseCase.php
+++ b/src/Llm/GenerateChatReplyUseCase.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+use RuntimeException;
+
+final readonly class GenerateChatReplyUseCase implements GenerateChatReplyUseCaseInterface
+{
+    private const MAX_TOOL_ROUNDS = 3;
+
+    private const SYSTEM_PROMPT = <<<'PROMPT'
+        You are a helpful assistant for a company website knowledge chat.
+        Use the search_corpus tool to find relevant passages before answering.
+        Ground every answer in retrieved corpus chunks. If search returns no relevant results, say you do not know.
+        Do not invent product facts or policies that are not supported by search results.
+        PROMPT;
+
+    public function __construct(
+        private ClaudeMessagesClientInterface $client,
+        private CorpusSearchToolHandler $searchTool,
+    ) {
+    }
+
+    public function execute(GenerateChatReplyInput $input): GenerateChatReplyOutput
+    {
+        $messages = $this->toAnthropicMessages($input->history, $input->userMessage);
+        $tools = [CorpusSearchToolDefinition::schema()];
+        $citations = [];
+
+        for ($round = 0; $round < self::MAX_TOOL_ROUNDS; ++$round) {
+            $response = $this->client->createMessage(self::SYSTEM_PROMPT, $messages, $tools);
+
+            if ($response->stopReason !== 'tool_use') {
+                $text = $response->text();
+
+                if ($text === null || trim($text) === '') {
+                    throw new RuntimeException('Claude response did not contain assistant text.');
+                }
+
+                return new GenerateChatReplyOutput(
+                    content: trim($text),
+                    citations: $this->uniqueCitations($citations),
+                );
+            }
+
+            $toolUses = $response->toolUses();
+
+            if ($toolUses === []) {
+                throw new RuntimeException('Claude requested tool_use without tool blocks.');
+            }
+
+            $messages[] = [
+                'role' => 'assistant',
+                'content' => $response->contentBlocks,
+            ];
+
+            $toolResults = [];
+
+            foreach ($toolUses as $toolUse) {
+                if ($toolUse->name !== CorpusSearchToolDefinition::NAME) {
+                    throw new RuntimeException('Unexpected tool requested: ' . $toolUse->name);
+                }
+
+                $query = is_string($toolUse->input['query'] ?? null)
+                    ? trim((string) $toolUse->input['query'])
+                    : $input->userMessage;
+
+                $searchResult = $this->searchTool->execute($query);
+                $citations = [...$citations, ...$searchResult['citations']];
+
+                $toolResults[] = [
+                    'type' => 'tool_result',
+                    'tool_use_id' => $toolUse->id,
+                    'content' => $searchResult['tool_result'],
+                ];
+            }
+
+            $messages[] = [
+                'role' => 'user',
+                'content' => $toolResults,
+            ];
+        }
+
+        throw new RuntimeException('Exceeded maximum Claude tool_use rounds.');
+    }
+
+    /**
+     * @param list<ConversationTurn> $history
+     * @return list<array<string, mixed>>
+     */
+    private function toAnthropicMessages(array $history, string $userMessage): array
+    {
+        $messages = [];
+
+        foreach ($history as $turn) {
+            $messages[] = [
+                'role' => $turn->role,
+                'content' => $turn->content,
+            ];
+        }
+
+        $messages[] = [
+            'role' => 'user',
+            'content' => $userMessage,
+        ];
+
+        return $messages;
+    }
+
+    /**
+     * @param list<Citation> $citations
+     * @return list<Citation>
+     */
+    private function uniqueCitations(array $citations): array
+    {
+        $unique = [];
+        $seen = [];
+
+        foreach ($citations as $citation) {
+            if (isset($seen[$citation->chunkId])) {
+                continue;
+            }
+
+            $seen[$citation->chunkId] = true;
+            $unique[] = $citation;
+        }
+
+        return $unique;
+    }
+}

--- a/src/Llm/GenerateChatReplyUseCaseInterface.php
+++ b/src/Llm/GenerateChatReplyUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+interface GenerateChatReplyUseCaseInterface
+{
+    public function execute(GenerateChatReplyInput $input): GenerateChatReplyOutput;
+}

--- a/src/Llm/HttpClaudeMessagesClient.php
+++ b/src/Llm/HttpClaudeMessagesClient.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+use RuntimeException;
+
+final readonly class HttpClaudeMessagesClient implements ClaudeMessagesClientInterface
+{
+    private const API_URL = 'https://api.anthropic.com/v1/messages';
+
+    private const API_VERSION = '2023-06-01';
+
+    public function __construct(
+        private AnthropicConfig $config,
+    ) {
+    }
+
+    public function createMessage(string $system, array $messages, array $tools): ClaudeMessageResponse
+    {
+        if (!$this->config->isConfigured()) {
+            throw new LlmNotConfiguredException();
+        }
+
+        $payload = [
+            'model' => $this->config->model,
+            'max_tokens' => $this->config->maxTokens,
+            'system' => $system,
+            'messages' => $messages,
+        ];
+
+        if ($tools !== []) {
+            $payload['tools'] = $tools;
+        }
+
+        $body = json_encode($payload, JSON_THROW_ON_ERROR);
+
+        $handle = curl_init(self::API_URL);
+        if ($handle === false) {
+            throw new RuntimeException('Failed to initialize Anthropic HTTP client.');
+        }
+
+        curl_setopt_array($handle, [
+            CURLOPT_POST => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'x-api-key: ' . $this->config->apiKey,
+                'anthropic-version: ' . self::API_VERSION,
+            ],
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_TIMEOUT => 120,
+        ]);
+
+        $responseBody = curl_exec($handle);
+        $statusCode = (int) curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
+        $curlError = curl_error($handle);
+        curl_close($handle);
+
+        if (!is_string($responseBody)) {
+            throw new RuntimeException('Anthropic API request failed: ' . $curlError);
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new RuntimeException('Anthropic API returned HTTP ' . $statusCode . '.');
+        }
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+
+        $stopReason = is_string($decoded['stop_reason'] ?? null) ? $decoded['stop_reason'] : 'end_turn';
+        $content = $decoded['content'] ?? [];
+        if (!is_array($content)) {
+            $content = [];
+        }
+
+        /** @var list<array<string, mixed>> $contentBlocks */
+        $contentBlocks = array_values(array_filter($content, is_array(...)));
+
+        return new ClaudeMessageResponse(
+            stopReason: $stopReason,
+            contentBlocks: $contentBlocks,
+        );
+    }
+}

--- a/src/Llm/LlmNotConfiguredException.php
+++ b/src/Llm/LlmNotConfiguredException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+use RuntimeException;
+
+final class LlmNotConfiguredException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('Anthropic API key is not configured.');
+    }
+}

--- a/src/Llm/LlmServiceProvider.php
+++ b/src/Llm/LlmServiceProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneCorpus\Search\SearchChunksUseCaseInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class LlmServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                AnthropicConfig::class,
+                static fn (ContainerInterface $container): AnthropicConfig => AnthropicConfig::fromEnvironment(),
+            )
+            ->set(
+                CorpusSearchToolHandler::class,
+                static function (ContainerInterface $container): CorpusSearchToolHandler {
+                    $search = $container->get(SearchChunksUseCaseInterface::class);
+
+                    if (!$search instanceof SearchChunksUseCaseInterface) {
+                        throw new LogicException('Search chunks use case service is invalid.');
+                    }
+
+                    return new CorpusSearchToolHandler($search);
+                },
+            )
+            ->set(
+                ClaudeMessagesClientInterface::class,
+                static function (ContainerInterface $container): ClaudeMessagesClientInterface {
+                    $config = $container->get(AnthropicConfig::class);
+
+                    if (!$config instanceof AnthropicConfig) {
+                        throw new LogicException('Anthropic config service is invalid.');
+                    }
+
+                    if ($config->isConfigured()) {
+                        return new HttpClaudeMessagesClient($config);
+                    }
+
+                    return new StubClaudeMessagesClient();
+                },
+            )
+            ->set(
+                GenerateChatReplyUseCaseInterface::class,
+                static function (ContainerInterface $container): GenerateChatReplyUseCaseInterface {
+                    $client = $container->get(ClaudeMessagesClientInterface::class);
+                    $searchTool = $container->get(CorpusSearchToolHandler::class);
+
+                    if (!$client instanceof ClaudeMessagesClientInterface) {
+                        throw new LogicException('Claude messages client service is invalid.');
+                    }
+
+                    if (!$searchTool instanceof CorpusSearchToolHandler) {
+                        throw new LogicException('Corpus search tool handler service is invalid.');
+                    }
+
+                    return new GenerateChatReplyUseCase($client, $searchTool);
+                },
+            );
+    }
+}

--- a/src/Llm/StubClaudeMessagesClient.php
+++ b/src/Llm/StubClaudeMessagesClient.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Llm;
+
+final class StubClaudeMessagesClient implements ClaudeMessagesClientInterface
+{
+    private int $callCount = 0;
+
+    public function createMessage(string $system, array $messages, array $tools): ClaudeMessageResponse
+    {
+        ++$this->callCount;
+
+        if ($tools !== [] && $this->callCount % 2 === 1) {
+            $query = $this->extractLastUserMessage($messages);
+
+            return new ClaudeMessageResponse(
+                stopReason: 'tool_use',
+                contentBlocks: [[
+                    'type' => 'tool_use',
+                    'id' => 'toolu_stub_search',
+                    'name' => CorpusSearchToolDefinition::NAME,
+                    'input' => ['query' => $query],
+                ]],
+            );
+        }
+
+        return new ClaudeMessageResponse(
+            stopReason: 'end_turn',
+            contentBlocks: [[
+                'type' => 'text',
+                'text' => 'Here is an answer grounded in the corpus search results.',
+            ]],
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $messages
+     */
+    private function extractLastUserMessage(array $messages): string
+    {
+        for ($index = count($messages) - 1; $index >= 0; --$index) {
+            $message = $messages[$index];
+            if (($message['role'] ?? '') !== 'user') {
+                continue;
+            }
+
+            $content = $message['content'] ?? '';
+            if (is_string($content)) {
+                return $content;
+            }
+        }
+
+        return '';
+    }
+}

--- a/tests/Chat/ChatHttpTest.php
+++ b/tests/Chat/ChatHttpTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Chat;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ChatHttpTest extends TestCase
+{
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-chat-' . uniqid('', true) . '.sqlite';
+
+        $_ENV['DB_ADAPTER'] = 'sqlite';
+        $_ENV['DB_NAME'] = $this->databasePath;
+        $_SERVER['DB_ADAPTER'] = 'sqlite';
+        $_SERVER['DB_NAME'] = $this->databasePath;
+        $_ENV['ANTHROPIC_API_KEY'] = '';
+        $_SERVER['ANTHROPIC_API_KEY'] = '';
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        CorpusSchemaSetup::create($executor);
+        ChatSchemaSetup::create($executor);
+        $this->seedCorpus($executor);
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $_ENV['DB_ADAPTER'],
+            $_SERVER['DB_ADAPTER'],
+            $_ENV['DB_NAME'],
+            $_SERVER['DB_NAME'],
+            $_ENV['ANTHROPIC_API_KEY'],
+            $_SERVER['ANTHROPIC_API_KEY'],
+        );
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+    }
+
+    public function test_create_session_and_send_message_returns_citations(): void
+    {
+        $factory = new Psr17Factory();
+        $application = $this->application();
+
+        $sessionResponse = $application->handle(
+            $factory->createServerRequest('POST', 'https://example.test/chat/sessions'),
+        );
+
+        $sessionPayload = $this->decodeJson($sessionResponse);
+        self::assertSame(201, $sessionResponse->getStatusCode());
+        self::assertNotEmpty($sessionPayload['session_token']);
+
+        $messageResponse = $application->handle(
+            $factory->createServerRequest('POST', 'https://example.test/chat/messages')
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('X-Session-Token', $sessionPayload['session_token'])
+                ->withBody($factory->createStream(json_encode([
+                    'content' => 'What pairs well with seafood?',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        $messagePayload = $this->decodeJson($messageResponse);
+
+        self::assertSame(200, $messageResponse->getStatusCode());
+        self::assertSame('assistant', $messagePayload['role']);
+        self::assertNotEmpty($messagePayload['content']);
+        self::assertNotEmpty($messagePayload['citations']);
+        self::assertSame(2, $messagePayload['citations'][0]['page_number']);
+    }
+
+    public function test_send_message_returns_404_for_unknown_session_token(): void
+    {
+        $factory = new Psr17Factory();
+
+        $response = $this->application()->handle(
+            $factory->createServerRequest('POST', 'https://example.test/chat/messages')
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('X-Session-Token', 'missing-token')
+                ->withBody($factory->createStream(json_encode([
+                    'content' => 'Hello',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    private function seedCorpus(PdoDatabaseQueryExecutor $executor): void
+    {
+        $sourceId = (new PdoSourceRepository($executor))->save(new Source(
+            name: 'Catalog',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/catalog.pdf',
+        ));
+
+        $documentId = (new PdoDocumentRepository($executor))->save(new Document(
+            sourceId: $sourceId,
+            title: 'Pairings',
+            position: 0,
+        ));
+
+        (new PdoChunkRepository($executor))->save(new Chunk(
+            documentId: $documentId,
+            sourceId: $sourceId,
+            content: 'Dry ginjo pairs well with white fish and light seafood dishes.',
+            chunkIndex: 0,
+            pageNumber: 2,
+            sectionLabel: 'Pairings',
+        ));
+    }
+
+    private function application(): RequestHandlerInterface
+    {
+        $container = (new RuntimeContainerFactory())->create();
+        $application = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        return $application;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Chat/SendChatMessageUseCaseTest.php
+++ b/tests/Chat/SendChatMessageUseCaseTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Chat;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chat\SendChatMessageInput;
+use NeneCorpus\Chat\SendChatMessageUseCase;
+use NeneCorpus\Llm\Citation;
+use NeneCorpus\Llm\GenerateChatReplyOutput;
+use NeneCorpus\Llm\GenerateChatReplyUseCaseInterface;
+use NeneCorpus\Message\MessageRole;
+use NeneCorpus\Message\PdoChatMessageRepository;
+use NeneCorpus\Session\ChatSession;
+use NeneCorpus\Session\PdoChatSessionRepository;
+use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class SendChatMessageUseCaseTest extends TestCase
+{
+    public function test_execute_persists_user_and_assistant_messages(): void
+    {
+        $executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        ChatSchemaSetup::create($executor);
+
+        $sessions = new PdoChatSessionRepository($executor);
+        $sessionId = $sessions->save(new ChatSession(publicToken: 'token-abc'));
+        $session = $sessions->findById($sessionId);
+        self::assertNotNull($session);
+
+        $generateReply = $this->createMock(GenerateChatReplyUseCaseInterface::class);
+        $generateReply->expects(self::once())
+            ->method('execute')
+            ->willReturn(new GenerateChatReplyOutput(
+                content: 'Assistant answer.',
+                citations: [
+                    new Citation(
+                        chunkId: 1,
+                        documentId: 2,
+                        sourceId: 3,
+                        excerpt: 'Excerpt text.',
+                    ),
+                ],
+            ));
+
+        $output = (new SendChatMessageUseCase(
+            $sessions,
+            new PdoChatMessageRepository($executor),
+            $generateReply,
+        ))->execute(new SendChatMessageInput(
+            sessionToken: 'token-abc',
+            content: 'User question?',
+        ));
+
+        self::assertSame('assistant', $output->role);
+        self::assertSame('Assistant answer.', $output->content);
+        self::assertCount(1, $output->citations);
+
+        $messages = (new PdoChatMessageRepository($executor))->findBySessionId($sessionId, 10, 0);
+        self::assertCount(2, $messages);
+        self::assertSame(MessageRole::User, $messages[0]->role);
+        self::assertSame(MessageRole::Assistant, $messages[1]->role);
+        self::assertNotNull($messages[1]->citationsJson);
+    }
+}

--- a/tests/Llm/GenerateChatReplyUseCaseTest.php
+++ b/tests/Llm/GenerateChatReplyUseCaseTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Llm;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Llm\CorpusSearchToolHandler;
+use NeneCorpus\Llm\GenerateChatReplyInput;
+use NeneCorpus\Llm\GenerateChatReplyUseCase;
+use NeneCorpus\Llm\StubClaudeMessagesClient;
+use NeneCorpus\Search\PdoChunkSearchRepository;
+use NeneCorpus\Search\SearchChunksUseCase;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class GenerateChatReplyUseCaseTest extends TestCase
+{
+    public function test_execute_returns_grounded_reply_with_citations(): void
+    {
+        $executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($executor);
+
+        $sourceId = (new PdoSourceRepository($executor))->save(new Source(
+            name: 'Catalog',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/catalog.pdf',
+        ));
+
+        $documentId = (new PdoDocumentRepository($executor))->save(new Document(
+            sourceId: $sourceId,
+            title: 'Pairings',
+            position: 0,
+        ));
+
+        (new PdoChunkRepository($executor))->save(new Chunk(
+            documentId: $documentId,
+            sourceId: $sourceId,
+            content: 'Dry ginjo pairs well with white fish and light seafood dishes.',
+            chunkIndex: 0,
+            pageNumber: 2,
+            sectionLabel: 'Pairings',
+        ));
+
+        $search = new SearchChunksUseCase(new PdoChunkSearchRepository($executor));
+        $useCase = new GenerateChatReplyUseCase(
+            new StubClaudeMessagesClient(),
+            new CorpusSearchToolHandler($search),
+        );
+
+        $output = $useCase->execute(new GenerateChatReplyInput(
+            userMessage: 'What pairs well with seafood?',
+        ));
+
+        self::assertStringContainsString('corpus search results', strtolower($output->content));
+        self::assertCount(1, $output->citations);
+        self::assertSame(2, $output->citations[0]->pageNumber);
+        self::assertSame('Pairings', $output->citations[0]->sectionLabel);
+    }
+}


### PR DESCRIPTION
## Summary

- `Llm/`: Anthropic Messages client, `search_corpus` tool_use loop, `Citation` model, stub client when `ANTHROPIC_API_KEY` is empty
- `Chat/`: `POST /chat/sessions`, `POST /chat/messages` with `X-Session-Token`
- OpenAPI **v0.6** — sync JSON chat + citation schemas
- 47 tests (HTTP + use case)

## Test plan

- [x] `composer check` ローカル green
- [ ] CI green

Closes #25

## Self-review checklist

- [x] Issue-driven branch
- [x] Handler → UseCase → Repository / Llm adapter layering
- [x] Consumer routes use session token, not admin JWT
- [x] No secrets committed

Made with [Cursor](https://cursor.com)