### PR TITLE
feat(admin): sources 一覧 API と Admin UI (#39)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NeNe Corpus API
-  version: 0.6.0
+  version: 0.7.0
   description: >
     NeNe Corpus public API contract — self-hosted knowledge chat on NENE2.
     Phase 2 adds consumer sync JSON chat with citations.
@@ -160,6 +160,43 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
   /admin/sources:
+    get:
+      tags:
+        - Ingestion
+      summary: List sources
+      description: Paginated list of corpus sources with ingestion status and document/chunk counts.
+      operationId: listSources
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Source list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListSourcesResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
     post:
       tags:
         - Ingestion
@@ -625,6 +662,56 @@ components:
         chunk_count:
           type: integer
           format: int64
+    ListSourcesResponse:
+      type: object
+      required:
+        - sources
+      properties:
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceListItem'
+    SourceListItem:
+      type: object
+      required:
+        - source_id
+        - name
+        - source_type
+        - status
+        - document_count
+        - chunk_count
+        - created_at
+        - updated_at
+      properties:
+        source_id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        source_type:
+          type: string
+          enum:
+            - csv
+            - pdf
+        status:
+          type: string
+          enum:
+            - pending
+            - processing
+            - ready
+            - failed
+        document_count:
+          type: integer
+          format: int64
+        chunk_count:
+          type: integer
+          format: int64
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     CreateChatSessionResponse:
       type: object
       required:

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -29,7 +29,7 @@ Last updated: 2026-05-25
 
 - ✅ Frontend scaffold（#33）
 - ✅ embed widget → sync JSON chat 接続（#37）
-- 🔜 Admin screens
+- 🔜 Admin sources UI（#39 進行中）
 
 `composer check` ローカル / GitHub Actions Backend CI ともに green。
 

--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -1,42 +1,66 @@
 import { useEffect, useState } from 'react';
 import { fetchJson, type HealthResponse } from '@nene-corpus/api-client';
 import { cssVars } from '@nene-corpus/tokens';
+import { LoginForm, SourcesPanel } from './SourcesPanel';
+import { useAdminAuth } from './useAdminAuth';
 
 export function App() {
+  const { token, profile, isReady, error, login, logout } = useAdminAuth();
   const [health, setHealth] = useState<HealthResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     fetchJson<HealthResponse>('/health')
       .then(setHealth)
-      .catch((cause: unknown) => {
-        setError(cause instanceof Error ? cause.message : 'Health check failed');
-      });
+      .catch(() => setHealth(null));
   }, []);
+
+  if (!isReady) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-600">
+        Loading…
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900">
       <header className="border-b border-slate-200 bg-white px-6 py-4">
-        <h1 className="text-xl font-semibold">NeNe Corpus Admin</h1>
-        <p className="text-sm text-slate-600">Phase 3 scaffold — sources, ingestion, and logs land here.</p>
-      </header>
-      <main className="mx-auto max-w-3xl px-6 py-8 space-y-4">
-        <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <h2 className="font-medium">API health</h2>
-          {health && (
-            <p className="mt-2 text-sm">
-              {health.service} — <span className="font-mono">{health.status}</span>
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold">NeNe Corpus Admin</h1>
+            <p className="text-sm text-slate-600">
+              {health ? `${health.service} — ${health.status}` : 'API health unavailable'}
             </p>
+          </div>
+          {profile && (
+            <div className="flex items-center gap-3 text-sm">
+              <span className="text-slate-600">{profile.email}</span>
+              <button
+                className="rounded-md border border-slate-300 px-3 py-1.5 hover:bg-slate-50"
+                type="button"
+                onClick={logout}
+              >
+                Sign out
+              </button>
+            </div>
           )}
-          {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
-        </section>
-        <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
-          <h2 className="font-medium">Widget theme preview</h2>
-          <p className="mt-2 text-sm text-slate-600">
-            Admin uses Tailwind. The embed widget uses BEM + CSS variables such as{' '}
-            <code className="rounded bg-slate-100 px-1">{cssVars.colorPrimary}</code>.
-          </p>
-        </section>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl space-y-6 px-6 py-8">
+        {token === null ? (
+          <LoginForm error={error} onLogin={login} />
+        ) : (
+          <>
+            <SourcesPanel token={token} />
+            <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="font-medium">Widget theme preview</h2>
+              <p className="mt-2 text-sm text-slate-600">
+                Admin uses Tailwind. The embed widget uses BEM + CSS variables such as{' '}
+                <code className="rounded bg-slate-100 px-1">{cssVars.colorPrimary}</code>.
+              </p>
+            </section>
+          </>
+        )}
       </main>
     </div>
   );

--- a/frontend/apps/admin/src/SourcesPanel.tsx
+++ b/frontend/apps/admin/src/SourcesPanel.tsx
@@ -1,0 +1,175 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { listSources, type SourceListItem } from '@nene-corpus/api-client';
+
+interface SourcesPanelProps {
+  token: string;
+}
+
+export function SourcesPanel({ token }: SourcesPanelProps) {
+  const [sources, setSources] = useState<SourceListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSources(): Promise<void> {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await listSources(token);
+
+        if (!cancelled) {
+          setSources(response.sources);
+        }
+      } catch (cause: unknown) {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : 'Failed to load sources.');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadSources();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 px-4 py-3">
+        <h2 className="font-medium">Sources</h2>
+        <p className="text-sm text-slate-600">Corpus uploads and ingestion status.</p>
+      </div>
+      {isLoading && <p className="px-4 py-6 text-sm text-slate-600">Loading sources…</p>}
+      {error !== null && <p className="px-4 py-6 text-sm text-red-600">{error}</p>}
+      {!isLoading && error === null && sources.length === 0 && (
+        <p className="px-4 py-6 text-sm text-slate-600">No sources yet. Upload via API for now.</p>
+      )}
+      {!isLoading && sources.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="bg-slate-50 text-left text-slate-600">
+              <tr>
+                <th className="px-4 py-2 font-medium">Name</th>
+                <th className="px-4 py-2 font-medium">Type</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Documents</th>
+                <th className="px-4 py-2 font-medium">Chunks</th>
+                <th className="px-4 py-2 font-medium">Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sources.map((source) => (
+                <tr key={source.source_id} className="border-t border-slate-100">
+                  <td className="px-4 py-2 font-medium">{source.name}</td>
+                  <td className="px-4 py-2 uppercase text-xs tracking-wide text-slate-500">
+                    {source.source_type}
+                  </td>
+                  <td className="px-4 py-2">
+                    <StatusBadge status={source.status} />
+                  </td>
+                  <td className="px-4 py-2 tabular-nums">{source.document_count}</td>
+                  <td className="px-4 py-2 tabular-nums">{source.chunk_count}</td>
+                  <td className="px-4 py-2 text-slate-600">{formatTimestamp(source.updated_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StatusBadge({ status }: { status: SourceListItem['status'] }) {
+  const styles: Record<SourceListItem['status'], string> = {
+    pending: 'bg-slate-100 text-slate-700',
+    processing: 'bg-amber-100 text-amber-800',
+    ready: 'bg-emerald-100 text-emerald-800',
+    failed: 'bg-red-100 text-red-800',
+  };
+
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${styles[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+interface LoginFormProps {
+  error: string | null;
+  onLogin: (email: string, password: string) => Promise<void>;
+}
+
+export function LoginForm({ error, onLogin }: LoginFormProps) {
+  const [email, setEmail] = useState('admin@example.com');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      await onLogin(email, password);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="mx-auto max-w-md rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="text-lg font-medium">Admin login</h2>
+      <p className="mt-1 text-sm text-slate-600">Sign in with your operator credentials.</p>
+      <form className="mt-4 space-y-4" onSubmit={(event) => void handleSubmit(event)}>
+        <label className="block text-sm">
+          <span className="font-medium text-slate-700">Email</span>
+          <input
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+            type="email"
+            autoComplete="username"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-slate-700">Password</span>
+          <input
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </label>
+        {error !== null && <p className="text-sm text-red-600">{error}</p>}
+        <button
+          className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/apps/admin/src/authStorage.ts
+++ b/frontend/apps/admin/src/authStorage.ts
@@ -1,0 +1,17 @@
+const TOKEN_STORAGE_KEY = 'nene-corpus.admin_token';
+
+export function loadStoredAdminToken(): string | null {
+  if (typeof sessionStorage === 'undefined') {
+    return null;
+  }
+
+  return sessionStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
+export function storeAdminToken(token: string): void {
+  sessionStorage.setItem(TOKEN_STORAGE_KEY, token);
+}
+
+export function clearAdminToken(): void {
+  sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+}

--- a/frontend/apps/admin/src/useAdminAuth.ts
+++ b/frontend/apps/admin/src/useAdminAuth.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getAdminMe, loginAdmin, type AdminMeResponse } from '@nene-corpus/api-client';
+import { clearAdminToken, loadStoredAdminToken, storeAdminToken } from './authStorage';
+
+interface UseAdminAuthResult {
+  token: string | null;
+  profile: AdminMeResponse | null;
+  isReady: boolean;
+  error: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+export function useAdminAuth(): UseAdminAuthResult {
+  const [token, setToken] = useState<string | null>(null);
+  const [profile, setProfile] = useState<AdminMeResponse | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const stored = loadStoredAdminToken();
+
+    if (stored === null) {
+      setIsReady(true);
+      return;
+    }
+
+    async function restoreSession(): Promise<void> {
+      try {
+        const me = await getAdminMe(stored!);
+
+        if (cancelled) {
+          return;
+        }
+
+        setToken(stored);
+        setProfile(me);
+      } catch {
+        if (!cancelled) {
+          clearAdminToken();
+        }
+      } finally {
+        if (!cancelled) {
+          setIsReady(true);
+        }
+      }
+    }
+
+    void restoreSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    setError(null);
+
+    try {
+      const response = await loginAdmin(email, password);
+      storeAdminToken(response.access_token);
+      const me = await getAdminMe(response.access_token);
+      setToken(response.access_token);
+      setProfile(me);
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : 'Login failed.');
+      throw cause;
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    clearAdminToken();
+    setToken(null);
+    setProfile(null);
+    setError(null);
+  }, []);
+
+  return { token, profile, isReady, error, login, logout };
+}

--- a/frontend/packages/api-client/src/admin.ts
+++ b/frontend/packages/api-client/src/admin.ts
@@ -1,0 +1,30 @@
+import { fetchJson } from './fetch-json';
+import type {
+  AdminMeResponse,
+  ListSourcesResponse,
+  LoginAdminResponse,
+} from './types';
+
+export async function loginAdmin(
+  email: string,
+  password: string,
+  apiBase = '',
+): Promise<LoginAdminResponse> {
+  return fetchJson<LoginAdminResponse>(`${apiBase}/admin/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+export async function getAdminMe(token: string, apiBase = ''): Promise<AdminMeResponse> {
+  return fetchJson<AdminMeResponse>(`${apiBase}/admin/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export async function listSources(token: string, apiBase = ''): Promise<ListSourcesResponse> {
+  return fetchJson<ListSourcesResponse>(`${apiBase}/admin/sources`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -1,8 +1,13 @@
+export { loginAdmin, getAdminMe, listSources } from './admin';
 export { createChatSession, sendChatMessage } from './chat';
 export { fetchJson } from './fetch-json';
 export type {
+  AdminMeResponse,
   Citation,
   CreateChatSessionResponse,
   HealthResponse,
+  ListSourcesResponse,
+  LoginAdminResponse,
   SendChatMessageResponse,
+  SourceListItem,
 } from './types';

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -26,3 +26,30 @@ export interface SendChatMessageResponse {
   content: string;
   citations: Citation[];
 }
+
+export interface LoginAdminResponse {
+  access_token: string;
+  token_type: string;
+  expires_at: string;
+}
+
+export interface AdminMeResponse {
+  id: number;
+  email: string;
+  role: string;
+}
+
+export interface SourceListItem {
+  source_id: number;
+  name: string;
+  source_type: 'csv' | 'pdf';
+  status: 'pending' | 'processing' | 'ready' | 'failed';
+  document_count: number;
+  chunk_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListSourcesResponse {
+  sources: SourceListItem[];
+}

--- a/src/Source/ListSourcesHandler.php
+++ b/src/Source/ListSourcesHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListSourcesHandler
+{
+    public function __construct(
+        private ListSourcesUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $query = $request->getQueryParams();
+        $limit = isset($query['limit']) ? (int) $query['limit'] : 50;
+        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+
+        $summaries = $this->useCase->execute(new ListSourcesInput(limit: $limit, offset: $offset));
+
+        return $this->response->create([
+            'sources' => array_map(
+                static fn (SourceSummary $summary): array => [
+                    'source_id' => $summary->source->id,
+                    'name' => $summary->source->name,
+                    'source_type' => $summary->source->sourceType->value,
+                    'status' => $summary->source->status->value,
+                    'document_count' => $summary->documentCount,
+                    'chunk_count' => $summary->chunkCount,
+                    'created_at' => $summary->source->createdAt,
+                    'updated_at' => $summary->source->updatedAt,
+                ],
+                $summaries,
+            ),
+        ]);
+    }
+}

--- a/src/Source/ListSourcesInput.php
+++ b/src/Source/ListSourcesInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+final readonly class ListSourcesInput
+{
+    public function __construct(
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Source/ListSourcesUseCase.php
+++ b/src/Source/ListSourcesUseCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+final readonly class ListSourcesUseCase implements ListSourcesUseCaseInterface
+{
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private SourceRepositoryInterface $sources,
+    ) {
+    }
+
+    public function execute(ListSourcesInput $input): array
+    {
+        $limit = max(1, min(self::MAX_LIMIT, $input->limit));
+        $offset = max(0, $input->offset);
+
+        return $this->sources->findAllSummaries($limit, $offset);
+    }
+}

--- a/src/Source/ListSourcesUseCaseInterface.php
+++ b/src/Source/ListSourcesUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+interface ListSourcesUseCaseInterface
+{
+    /** @return list<SourceSummary> */
+    public function execute(ListSourcesInput $input): array;
+}

--- a/src/Source/PdoSourceRepository.php
+++ b/src/Source/PdoSourceRepository.php
@@ -40,6 +40,42 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
         return array_map(fn (array $row): Source => $this->mapRow($row), $rows);
     }
 
+    public function findAllSummaries(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT
+                    s.id, s.name, s.source_type, s.status, s.storage_path, s.original_filename,
+                    s.mime_type, s.byte_size, s.error_message, s.ingestion_config_json,
+                    s.created_at, s.updated_at, s.is_deleted, s.deleted_at,
+                    (
+                        SELECT COUNT(*)
+                        FROM documents d
+                        WHERE d.source_id = s.id AND d.is_deleted = 0
+                    ) AS document_count,
+                    (
+                        SELECT COUNT(*)
+                        FROM chunks c
+                        WHERE c.source_id = s.id
+                    ) AS chunk_count
+                FROM sources s
+                WHERE s.is_deleted = 0
+                ORDER BY s.id DESC
+                LIMIT ? OFFSET ?
+                SQL,
+            [$limit, $offset],
+        );
+
+        return array_map(
+            fn (array $row): SourceSummary => new SourceSummary(
+                source: $this->mapRow($row),
+                documentCount: (int) $row['document_count'],
+                chunkCount: (int) $row['chunk_count'],
+            ),
+            $rows,
+        );
+    }
+
     public function save(Source $source): int
     {
         $now = $this->now();

--- a/src/Source/SourceRepositoryInterface.php
+++ b/src/Source/SourceRepositoryInterface.php
@@ -11,6 +11,9 @@ interface SourceRepositoryInterface
     /** @return list<Source> */
     public function findAll(int $limit, int $offset): array;
 
+    /** @return list<SourceSummary> */
+    public function findAllSummaries(int $limit, int $offset): array;
+
     public function save(Source $source): int;
 
     public function update(Source $source): void;

--- a/src/Source/SourceRouteRegistrar.php
+++ b/src/Source/SourceRouteRegistrar.php
@@ -11,12 +11,19 @@ final readonly class SourceRouteRegistrar
 {
     public function __construct(
         private DeleteSourceHandler $deleteHandler,
+        private ListSourcesHandler $listHandler,
     ) {
     }
 
     public function __invoke(Router $router): void
     {
         $delete = $this->deleteHandler;
+        $list = $this->listHandler;
+
+        $router->get(
+            '/admin/sources',
+            static fn (ServerRequestInterface $request) => $list->handle($request),
+        );
 
         $router->delete(
             '/admin/sources/{id}',

--- a/src/Source/SourceServiceProvider.php
+++ b/src/Source/SourceServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Chunk\ChunkRepositoryInterface;
 use NeneCorpus\Document\DocumentRepositoryInterface;
 use Psr\Container\ContainerInterface;
@@ -31,6 +32,35 @@ final readonly class SourceServiceProvider implements ServiceProviderInterface
                     }
 
                     return new PdoSourceRepository($query);
+                },
+            )
+            ->set(
+                ListSourcesUseCaseInterface::class,
+                static function (ContainerInterface $container): ListSourcesUseCaseInterface {
+                    $sources = $container->get(SourceRepositoryInterface::class);
+
+                    if (!$sources instanceof SourceRepositoryInterface) {
+                        throw new LogicException('Source repository service is invalid.');
+                    }
+
+                    return new ListSourcesUseCase($sources);
+                },
+            )
+            ->set(
+                ListSourcesHandler::class,
+                static function (ContainerInterface $container): ListSourcesHandler {
+                    $useCase = $container->get(ListSourcesUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListSourcesUseCaseInterface) {
+                        throw new LogicException('List sources use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListSourcesHandler($useCase, $response);
                 },
             )
             ->set(
@@ -88,12 +118,17 @@ final readonly class SourceServiceProvider implements ServiceProviderInterface
                 self::ROUTE_REGISTRAR,
                 static function (ContainerInterface $container): SourceRouteRegistrar {
                     $delete = $container->get(DeleteSourceHandler::class);
+                    $list = $container->get(ListSourcesHandler::class);
 
                     if (!$delete instanceof DeleteSourceHandler) {
                         throw new LogicException('Delete source handler service is invalid.');
                     }
 
-                    return new SourceRouteRegistrar($delete);
+                    if (!$list instanceof ListSourcesHandler) {
+                        throw new LogicException('List sources handler service is invalid.');
+                    }
+
+                    return new SourceRouteRegistrar($delete, $list);
                 },
             );
     }

--- a/src/Source/SourceSummary.php
+++ b/src/Source/SourceSummary.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Source;
+
+final readonly class SourceSummary
+{
+    public function __construct(
+        public Source $source,
+        public int $documentCount,
+        public int $chunkCount,
+    ) {
+    }
+}

--- a/tests/Source/SourceAdminHttpTest.php
+++ b/tests/Source/SourceAdminHttpTest.php
@@ -108,6 +108,35 @@ final class SourceAdminHttpTest extends TestCase
         self::assertSame(404, $response->getStatusCode());
     }
 
+    public function test_list_sources_returns_summaries(): void
+    {
+        $sourceId = $this->createPdfSource();
+
+        $response = $this->authorizedRequest('GET', '/admin/sources');
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertArrayHasKey('sources', $payload);
+        self::assertIsArray($payload['sources']);
+        self::assertNotSame([], $payload['sources']);
+
+        $first = $payload['sources'][0];
+        self::assertSame($sourceId, $first['source_id']);
+        self::assertSame('ready', $first['status']);
+        self::assertSame('pdf', $first['source_type']);
+        self::assertSame(1, $first['document_count']);
+        self::assertSame(1, $first['chunk_count']);
+    }
+
+    public function test_list_sources_requires_auth(): void
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('GET', 'https://example.test/admin/sources'),
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
     private function createPdfSource(): int
     {
         $response = $this->authorizedRequest('POST', '/admin/sources', json_encode([


### PR DESCRIPTION
## Summary

- `GET /admin/sources` — JWT 必須、status / document_count / chunk_count 付き一覧
- OpenAPI **v0.7** — `ListSourcesResponse` / `SourceListItem`
- `@nene-corpus/api-client` — `loginAdmin`, `getAdminMe`, `listSources`
- Admin SPA — ログイン + sources テーブル（status バッジ、counts、updated_at）

Self-review: openapi-contract

## Test plan

- [x] `composer check`（52 tests）
- [x] `npm run check --prefix frontend`
- [ ] http://localhost:5173 — ログイン → sources 一覧
- [ ] CI green → merge

### ローカル admin ユーザー（初回のみ）

Docker MySQL に admin ユーザーが無い場合:

```bash
docker compose exec app php -r "
\$h = password_hash('secret-password', PASSWORD_ARGON2ID);
\$n = gmdate('Y-m-d H:i:s');
new PDO('mysql:host=mysql;dbname=nene_corpus', 'nene_corpus', 'nene_corpus')
  ->exec(\"INSERT INTO admin_users (email, password_hash, created_at, updated_at) VALUES ('admin@example.com', '\$h', '\$n', '\$n')\");
"
```

Closes #39

Made with [Cursor](https://cursor.com)