### PR TITLE
fix(frontend): workspace パッケージの Vite キャッシュ問題を修正 (#43)

### DIFF
--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -4,8 +4,12 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  optimizeDeps: {
+    exclude: ['@nene-corpus/api-client', '@nene-corpus/tokens'],
+  },
   server: {
     port: 5173,
+    strictPort: true,
     proxy: {
       '/health': 'http://localhost:8080',
       '/admin': 'http://localhost:8080',

--- a/frontend/apps/widget/vite.config.ts
+++ b/frontend/apps/widget/vite.config.ts
@@ -4,8 +4,12 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    exclude: ['@nene-corpus/api-client', '@nene-corpus/tokens'],
+  },
   server: {
     port: 5174,
+    strictPort: true,
     proxy: {
       '/chat': 'http://localhost:8080',
     },


### PR DESCRIPTION
## Summary

- `@nene-corpus/api-client` / `@nene-corpus/tokens` を `optimizeDeps.exclude` に追加
- admin (5173) / widget (5174) に `strictPort: true` を設定
- api-client 更新後に Admin が真っ白になる再発を防止

Self-review: docs-policy (N/A — config only)

## Test plan

- [x] `npm run check --prefix frontend`
- [x] `npm run dev:admin` → ログイン画面表示（手動確認済み）
- [ ] CI green → merge

Closes #43

Made with [Cursor](https://cursor.com)