### PR TITLE
feat(admin): CSV/PDF アップロード UI (#45)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from 'react';
 import { fetchJson, type HealthResponse } from '@nene-corpus/api-client';
 import { cssVars } from '@nene-corpus/tokens';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
+import { IngestionPanel } from './IngestionPanel';
 import { useAdminAuth } from './useAdminAuth';
 
 export function App() {
   const { token, profile, isReady, error, login, logout } = useAdminAuth();
   const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [sourcesReloadKey, setSourcesReloadKey] = useState(0);
 
   useEffect(() => {
     fetchJson<HealthResponse>('/health')
@@ -51,7 +53,8 @@ export function App() {
           <LoginForm error={error} onLogin={login} />
         ) : (
           <>
-            <SourcesPanel token={token} />
+            <IngestionPanel token={token} onUploaded={() => setSourcesReloadKey((key) => key + 1)} />
+            <SourcesPanel token={token} reloadKey={sourcesReloadKey} />
             <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
               <h2 className="font-medium">Widget theme preview</h2>
               <p className="mt-2 text-sm text-slate-600">

--- a/frontend/apps/admin/src/IngestionPanel.tsx
+++ b/frontend/apps/admin/src/IngestionPanel.tsx
@@ -1,0 +1,346 @@
+import { FormEvent, useState } from 'react';
+import {
+  createSource,
+  previewCsvIngestion,
+  previewPdfIngestion,
+  type CsvColumnMapping,
+  type PreviewCsvIngestionResponse,
+  type PreviewPdfIngestionResponse,
+} from '@nene-corpus/api-client';
+import { detectSourceType, readFileAsBase64 } from './fileBase64';
+
+interface IngestionPanelProps {
+  token: string;
+  onUploaded: () => void;
+}
+
+export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
+  const [name, setName] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [csvPreview, setCsvPreview] = useState<PreviewCsvIngestionResponse | null>(null);
+  const [pdfPreview, setPdfPreview] = useState<PreviewPdfIngestionResponse | null>(null);
+  const [titleColumn, setTitleColumn] = useState('');
+  const [contentColumns, setContentColumns] = useState<string[]>([]);
+  const [metadataColumns, setMetadataColumns] = useState<string[]>([]);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const sourceType = file ? detectSourceType(file.name) : null;
+
+  function resetPreview(): void {
+    setCsvPreview(null);
+    setPdfPreview(null);
+    setTitleColumn('');
+    setContentColumns([]);
+    setMetadataColumns([]);
+    setError(null);
+    setSuccess(null);
+  }
+
+  function handleFileChange(next: File | null): void {
+    setFile(next);
+    resetPreview();
+
+    if (next !== null && name.trim() === '') {
+      setName(next.name.replace(/\.(csv|pdf)$/i, ''));
+    }
+  }
+
+  async function handlePreview(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+
+    if (file === null || sourceType === null) {
+      setError('Choose a CSV or PDF file.');
+      return;
+    }
+
+    setIsPreviewing(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const content = await readFileAsBase64(file);
+
+      if (sourceType === 'csv') {
+        const preview = await previewCsvIngestion(token, file.name, content);
+        setCsvPreview(preview);
+        setPdfPreview(null);
+        setTitleColumn(preview.headers[0] ?? '');
+        setContentColumns(preview.headers.length > 1 ? preview.headers.slice(1) : preview.headers);
+      } else {
+        const preview = await previewPdfIngestion(token, file.name, content);
+        setPdfPreview(preview);
+        setCsvPreview(null);
+      }
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : 'Preview failed.');
+    } finally {
+      setIsPreviewing(false);
+    }
+  }
+
+  async function handleIngest(): Promise<void> {
+    if (file === null || sourceType === null) {
+      return;
+    }
+
+    const trimmedName = name.trim();
+
+    if (trimmedName === '') {
+      setError('Source name is required.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const content = await readFileAsBase64(file);
+      const payload =
+        sourceType === 'csv'
+          ? {
+              source_type: 'csv' as const,
+              name: trimmedName,
+              filename: file.name,
+              content,
+              column_mapping: buildColumnMapping(titleColumn, contentColumns, metadataColumns),
+            }
+          : {
+              source_type: 'pdf' as const,
+              name: trimmedName,
+              filename: file.name,
+              content,
+            };
+
+      const result = await createSource(token, payload);
+      setSuccess(
+        `Ingested "${result.name}" — ${result.document_count} documents, ${result.chunk_count} chunks.`,
+      );
+      handleFileChange(null);
+      setName('');
+      onUploaded();
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : 'Ingestion failed.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function toggleColumn(column: string, selected: string[], setter: (value: string[]) => void): void {
+    if (selected.includes(column)) {
+      setter(selected.filter((item) => item !== column));
+      return;
+    }
+
+    setter([...selected, column]);
+  }
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 px-4 py-3">
+        <h2 className="font-medium">Upload source</h2>
+        <p className="text-sm text-slate-600">Add CSV or PDF files to the corpus.</p>
+      </div>
+      <form className="space-y-4 px-4 py-4" onSubmit={(event) => void handlePreview(event)}>
+        <label className="block text-sm">
+          <span className="font-medium text-slate-700">Source name</span>
+          <input
+            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Product catalog"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="font-medium text-slate-700">File</span>
+          <input
+            className="mt-1 block w-full text-sm text-slate-600"
+            type="file"
+            accept=".csv,.pdf,text/csv,application/pdf"
+            onChange={(event) => handleFileChange(event.target.files?.[0] ?? null)}
+          />
+        </label>
+        {sourceType === null && file !== null && (
+          <p className="text-sm text-red-600">Only .csv and .pdf files are supported.</p>
+        )}
+        {file !== null && sourceType !== null && csvPreview === null && pdfPreview === null && (
+          <button
+            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+            type="submit"
+            disabled={isPreviewing}
+          >
+            {isPreviewing ? 'Previewing…' : 'Preview file'}
+          </button>
+        )}
+      </form>
+
+      {csvPreview !== null && (
+        <div className="space-y-4 border-t border-slate-200 px-4 py-4">
+          <p className="text-sm text-slate-600">
+            {csvPreview.row_count} rows · delimiter &quot;{csvPreview.detected_delimiter}&quot;
+          </p>
+          <ColumnMappingEditor
+            headers={csvPreview.headers}
+            titleColumn={titleColumn}
+            contentColumns={contentColumns}
+            metadataColumns={metadataColumns}
+            onTitleColumnChange={setTitleColumn}
+            onToggleContent={(column) => toggleColumn(column, contentColumns, setContentColumns)}
+            onToggleMetadata={(column) => toggleColumn(column, metadataColumns, setMetadataColumns)}
+          />
+          <PreviewTable headers={csvPreview.headers} rows={csvPreview.sample_rows} />
+        </div>
+      )}
+
+      {pdfPreview !== null && (
+        <div className="space-y-3 border-t border-slate-200 px-4 py-4">
+          <p className="text-sm text-slate-600">{pdfPreview.page_count} pages detected</p>
+          <pre className="max-h-40 overflow-auto rounded-md bg-slate-50 p-3 text-xs text-slate-700 whitespace-pre-wrap">
+            {pdfPreview.sample_text.slice(0, 800)}
+            {pdfPreview.sample_text.length > 800 ? '…' : ''}
+          </pre>
+        </div>
+      )}
+
+      {(csvPreview !== null || pdfPreview !== null) && (
+        <div className="border-t border-slate-200 px-4 py-4">
+          <button
+            className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+            type="button"
+            disabled={isSubmitting || (sourceType === 'csv' && contentColumns.length === 0)}
+            onClick={() => void handleIngest()}
+          >
+            {isSubmitting ? 'Ingesting…' : 'Ingest into corpus'}
+          </button>
+        </div>
+      )}
+
+      {error !== null && <p className="px-4 pb-4 text-sm text-red-600">{error}</p>}
+      {success !== null && <p className="px-4 pb-4 text-sm text-emerald-700">{success}</p>}
+    </section>
+  );
+}
+
+function buildColumnMapping(
+  titleColumn: string,
+  contentColumns: string[],
+  metadataColumns: string[],
+): CsvColumnMapping {
+  const mapping: CsvColumnMapping = {
+    title_column: titleColumn,
+    content_columns: contentColumns,
+  };
+
+  if (metadataColumns.length > 0) {
+    mapping.metadata_columns = metadataColumns;
+  }
+
+  return mapping;
+}
+
+interface ColumnMappingEditorProps {
+  headers: string[];
+  titleColumn: string;
+  contentColumns: string[];
+  metadataColumns: string[];
+  onTitleColumnChange: (value: string) => void;
+  onToggleContent: (column: string) => void;
+  onToggleMetadata: (column: string) => void;
+}
+
+function ColumnMappingEditor({
+  headers,
+  titleColumn,
+  contentColumns,
+  metadataColumns,
+  onTitleColumnChange,
+  onToggleContent,
+  onToggleMetadata,
+}: ColumnMappingEditorProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      <label className="block text-sm">
+        <span className="font-medium text-slate-700">Title column</span>
+        <select
+          className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+          value={titleColumn}
+          onChange={(event) => onTitleColumnChange(event.target.value)}
+        >
+          {headers.map((header) => (
+            <option key={header} value={header}>
+              {header}
+            </option>
+          ))}
+        </select>
+      </label>
+      <fieldset className="text-sm">
+        <legend className="font-medium text-slate-700">Content columns</legend>
+        <div className="mt-2 space-y-1">
+          {headers.map((header) => (
+            <label key={header} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={contentColumns.includes(header)}
+                onChange={() => onToggleContent(header)}
+              />
+              {header}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+      <fieldset className="text-sm">
+        <legend className="font-medium text-slate-700">Metadata columns (optional)</legend>
+        <div className="mt-2 space-y-1">
+          {headers.map((header) => (
+            <label key={header} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={metadataColumns.includes(header)}
+                onChange={() => onToggleMetadata(header)}
+              />
+              {header}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+    </div>
+  );
+}
+
+interface PreviewTableProps {
+  headers: string[];
+  rows: string[][];
+}
+
+function PreviewTable({ headers, rows }: PreviewTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-md border border-slate-200">
+      <table className="min-w-full text-xs">
+        <thead className="bg-slate-50 text-left text-slate-600">
+          <tr>
+            {headers.map((header) => (
+              <th key={header} className="px-3 py-2 font-medium">
+                {header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index} className="border-t border-slate-100">
+              {row.map((cell, cellIndex) => (
+                <td key={cellIndex} className="px-3 py-2">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/SourcesPanel.tsx
+++ b/frontend/apps/admin/src/SourcesPanel.tsx
@@ -3,9 +3,10 @@ import { listSources, type SourceListItem } from '@nene-corpus/api-client';
 
 interface SourcesPanelProps {
   token: string;
+  reloadKey?: number;
 }
 
-export function SourcesPanel({ token }: SourcesPanelProps) {
+export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
   const [sources, setSources] = useState<SourceListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -39,7 +40,7 @@ export function SourcesPanel({ token }: SourcesPanelProps) {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, reloadKey]);
 
   return (
     <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
@@ -50,7 +51,7 @@ export function SourcesPanel({ token }: SourcesPanelProps) {
       {isLoading && <p className="px-4 py-6 text-sm text-slate-600">Loading sources…</p>}
       {error !== null && <p className="px-4 py-6 text-sm text-red-600">{error}</p>}
       {!isLoading && error === null && sources.length === 0 && (
-        <p className="px-4 py-6 text-sm text-slate-600">No sources yet. Upload via API for now.</p>
+        <p className="px-4 py-6 text-sm text-slate-600">No sources yet. Upload a CSV or PDF above.</p>
       )}
       {!isLoading && sources.length > 0 && (
         <div className="overflow-x-auto">

--- a/frontend/apps/admin/src/fileBase64.ts
+++ b/frontend/apps/admin/src/fileBase64.ts
@@ -1,0 +1,38 @@
+export function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      if (typeof reader.result !== 'string') {
+        reject(new Error('Failed to read file.'));
+        return;
+      }
+
+      const base64 = reader.result.split(',')[1];
+
+      if (base64 === undefined) {
+        reject(new Error('Failed to encode file.'));
+        return;
+      }
+
+      resolve(base64);
+    };
+
+    reader.onerror = () => reject(new Error('Failed to read file.'));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function detectSourceType(filename: string): 'csv' | 'pdf' | null {
+  const lower = filename.toLowerCase();
+
+  if (lower.endsWith('.csv')) {
+    return 'csv';
+  }
+
+  if (lower.endsWith('.pdf')) {
+    return 'pdf';
+  }
+
+  return null;
+}

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -1,13 +1,19 @@
 export { loginAdmin, getAdminMe, listSources } from './admin';
+export { createSource, previewCsvIngestion, previewPdfIngestion } from './ingestion';
+export type { CreateSourcePayload } from './ingestion';
 export { createChatSession, sendChatMessage } from './chat';
 export { fetchJson } from './fetch-json';
 export type {
   AdminMeResponse,
   Citation,
   CreateChatSessionResponse,
+  CreateSourceResponse,
+  CsvColumnMapping,
   HealthResponse,
   ListSourcesResponse,
   LoginAdminResponse,
+  PreviewCsvIngestionResponse,
+  PreviewPdfIngestionResponse,
   SendChatMessageResponse,
   SourceListItem,
 } from './types';

--- a/frontend/packages/api-client/src/ingestion.ts
+++ b/frontend/packages/api-client/src/ingestion.ts
@@ -1,0 +1,60 @@
+import { fetchJson } from './fetch-json';
+import type {
+  CreateSourceResponse,
+  CsvColumnMapping,
+  PreviewCsvIngestionResponse,
+  PreviewPdfIngestionResponse,
+} from './types';
+
+function authHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+export async function previewCsvIngestion(
+  token: string,
+  filename: string,
+  content: string,
+  apiBase = '',
+): Promise<PreviewCsvIngestionResponse> {
+  return fetchJson<PreviewCsvIngestionResponse>(`${apiBase}/admin/ingestion/csv/preview`, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify({ filename, content }),
+  });
+}
+
+export async function previewPdfIngestion(
+  token: string,
+  filename: string,
+  content: string,
+  apiBase = '',
+): Promise<PreviewPdfIngestionResponse> {
+  return fetchJson<PreviewPdfIngestionResponse>(`${apiBase}/admin/ingestion/pdf/preview`, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify({ filename, content }),
+  });
+}
+
+export interface CreateSourcePayload {
+  source_type: 'csv' | 'pdf';
+  name: string;
+  filename: string;
+  content: string;
+  column_mapping?: CsvColumnMapping;
+}
+
+export async function createSource(
+  token: string,
+  payload: CreateSourcePayload,
+  apiBase = '',
+): Promise<CreateSourceResponse> {
+  return fetchJson<CreateSourceResponse>(`${apiBase}/admin/sources`, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify(payload),
+  });
+}

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -53,3 +53,29 @@ export interface SourceListItem {
 export interface ListSourcesResponse {
   sources: SourceListItem[];
 }
+
+export interface PreviewCsvIngestionResponse {
+  headers: string[];
+  sample_rows: string[][];
+  detected_delimiter: string;
+  row_count: number;
+}
+
+export interface PreviewPdfIngestionResponse {
+  page_count: number;
+  sample_text: string;
+}
+
+export interface CsvColumnMapping {
+  title_column: string;
+  content_columns: string[];
+  metadata_columns?: string[];
+}
+
+export interface CreateSourceResponse {
+  source_id: number;
+  name: string;
+  status: SourceListItem['status'];
+  document_count: number;
+  chunk_count: number;
+}


### PR DESCRIPTION
## Summary

- `@nene-corpus/api-client` — `previewCsvIngestion`, `previewPdfIngestion`, `createSource`
- Admin **Upload source** パネル — ファイル選択 → preview → CSV column mapping → ingest
- ingest 成功後 sources 一覧を自動更新

Self-review: docs-policy (N/A — frontend only)

## Test plan

- [x] `npm run check --prefix frontend`
- [x] `composer check`
- [ ] http://localhost:5173 — CSV/PDF アップロード → sources 一覧に反映
- [ ] CI green → merge

Closes #45

Made with [Cursor](https://cursor.com)