### PR TITLE
fix(frontend): workspace alias で Vite stale export を防ぐ (#49)

### DIFF
--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -1,9 +1,19 @@
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
+const appRoot = fileURLToPath(new URL('.', import.meta.url));
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@nene-corpus/api-client': resolve(appRoot, '../../packages/api-client/src/index.ts'),
+      '@nene-corpus/tokens': resolve(appRoot, '../../packages/tokens/src/index.ts'),
+    },
+  },
   optimizeDeps: {
     exclude: ['@nene-corpus/api-client', '@nene-corpus/tokens'],
   },

--- a/frontend/apps/widget/vite.config.ts
+++ b/frontend/apps/widget/vite.config.ts
@@ -1,9 +1,18 @@
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const appRoot = fileURLToPath(new URL('.', import.meta.url));
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@nene-corpus/api-client': resolve(appRoot, '../../packages/api-client/src/index.ts'),
+      '@nene-corpus/tokens': resolve(appRoot, '../../packages/tokens/src/index.ts'),
+    },
+  },
   optimizeDeps: {
     exclude: ['@nene-corpus/api-client', '@nene-corpus/tokens'],
   },


### PR DESCRIPTION
## Summary

- admin / widget の `vite.config.ts` に `@nene-corpus/api-client` / `@nene-corpus/tokens` の `resolve.alias` を追加
- api-client に export 追加後、dev サーバー再起動なしでも HMR が追従しやすくなる

Closes #49

Made with [Cursor](https://cursor.com)