### PR TITLE
fix(docker): storage/uploads 書き込み権限 (#51)

### DIFF
--- a/docker/app/entrypoint.sh
+++ b/docker/app/entrypoint.sh
@@ -33,6 +33,10 @@ wait_for_mysql() {
 composer install --no-interaction --prefer-dist
 wait_for_mysql
 
+mkdir -p storage/uploads var
+chown -R www-data:www-data storage var
+chmod -R 775 storage var
+
 if [ "${NENE_CORPUS_SKIP_MIGRATE:-0}" != "1" ]; then
   composer migrations:migrate || true
 fi

--- a/frontend/packages/api-client/src/fetch-json.ts
+++ b/frontend/packages/api-client/src/fetch-json.ts
@@ -1,9 +1,22 @@
 export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, init);
+  const text = await response.text();
+
+  let payload: unknown;
+
+  try {
+    payload = text === '' ? null : JSON.parse(text);
+  } catch {
+    throw new Error(
+      response.ok
+        ? `Non-JSON response for ${url}: ${text.slice(0, 160)}`
+        : `HTTP ${response.status} for ${url}: ${text.slice(0, 160)}`,
+    );
+  }
 
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for ${url}`);
   }
 
-  return response.json() as Promise<T>;
+  return payload as T;
 }


### PR DESCRIPTION
## Summary

- Docker entrypoint で `storage/uploads` / `var` を作成し `www-data` に chown
- `fetchJson` が HTML 混入応答を `Non-JSON response` として報告

## Test plan

- [x] `composer check`
- [x] `npm run check --prefix frontend`
- [x] POST /admin/sources — CSV ingest 成功
- [ ] CI green → merge

Closes #51

Made with [Cursor](https://cursor.com)