### PR TITLE
feat(admin): 会話ログ API + UI (#53)

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: NeNe Corpus API
-  version: 0.7.0
+  version: 0.8.0
   description: >
     NeNe Corpus public API contract — self-hosted knowledge chat on NENE2.
     Phase 2 adds consumer sync JSON chat with citations.
@@ -17,6 +17,8 @@ tags:
     description: CSV and PDF upload, preview, and ingestion.
   - name: Chat
     description: Consumer sync JSON chat with citations.
+  - name: AdminChat
+    description: Admin read-only access to consumer chat logs.
 paths:
   /health:
     get:
@@ -284,6 +286,90 @@ paths:
           $ref: '#/components/responses/SourceNotFound'
         '422':
           $ref: '#/components/responses/ValidationFailed'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/chat/sessions:
+    get:
+      tags:
+        - AdminChat
+      summary: List chat sessions
+      description: Paginated consumer chat sessions with message counts for the admin conversation log.
+      operationId: listChatSessions
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Chat session list.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListChatSessionsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/chat/sessions/{id}/messages:
+    get:
+      tags:
+        - AdminChat
+      summary: List chat messages
+      description: Messages for a consumer chat session, including citations on assistant replies.
+      operationId: listChatSessionMessages
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 200
+            default: 100
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Chat messages for the session.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListChatSessionMessagesResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/ChatSessionNotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /chat/sessions:
@@ -671,6 +757,78 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SourceListItem'
+    ListChatSessionsResponse:
+      type: object
+      required:
+        - sessions
+      properties:
+        sessions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatSessionSummary'
+    ChatSessionSummary:
+      type: object
+      required:
+        - session_id
+        - message_count
+        - created_at
+        - updated_at
+      properties:
+        session_id:
+          type: integer
+          format: int64
+        message_count:
+          type: integer
+          format: int64
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        last_message_at:
+          type: string
+          format: date-time
+          nullable: true
+    ListChatSessionMessagesResponse:
+      type: object
+      required:
+        - session_id
+        - messages
+      properties:
+        session_id:
+          type: integer
+          format: int64
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChatMessageListItem'
+    ChatMessageListItem:
+      type: object
+      required:
+        - message_id
+        - role
+        - content
+        - citations
+        - created_at
+      properties:
+        message_id:
+          type: integer
+          format: int64
+        role:
+          type: string
+          enum:
+            - user
+            - assistant
+        content:
+          type: string
+        citations:
+          type: array
+          items:
+            $ref: '#/components/schemas/Citation'
+        created_at:
+          type: string
+          format: date-time
     SourceListItem:
       type: object
       required:

--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -3,6 +3,7 @@ import { fetchJson, type HealthResponse } from '@nene-corpus/api-client';
 import { cssVars } from '@nene-corpus/tokens';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
+import { ConversationLogsPanel } from './ConversationLogsPanel';
 import { useAdminAuth } from './useAdminAuth';
 
 export function App() {
@@ -55,6 +56,7 @@ export function App() {
           <>
             <IngestionPanel token={token} onUploaded={() => setSourcesReloadKey((key) => key + 1)} />
             <SourcesPanel token={token} reloadKey={sourcesReloadKey} />
+            <ConversationLogsPanel token={token} />
             <section className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
               <h2 className="font-medium">Widget theme preview</h2>
               <p className="mt-2 text-sm text-slate-600">

--- a/frontend/apps/admin/src/ConversationLogsPanel.tsx
+++ b/frontend/apps/admin/src/ConversationLogsPanel.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react';
+import {
+  listChatSessionMessages,
+  listChatSessions,
+  type ChatMessageListItem,
+  type ChatSessionSummary,
+} from '@nene-corpus/api-client';
+
+interface ConversationLogsPanelProps {
+  token: string;
+}
+
+export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
+  const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
+  const [selectedSessionId, setSelectedSessionId] = useState<number | null>(null);
+  const [messages, setMessages] = useState<ChatMessageListItem[]>([]);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(true);
+  const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSessions(): Promise<void> {
+      setIsLoadingSessions(true);
+      setError(null);
+
+      try {
+        const response = await listChatSessions(token);
+
+        if (!cancelled) {
+          setSessions(response.sessions);
+        }
+      } catch (cause: unknown) {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : 'Failed to load conversation logs.');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingSessions(false);
+        }
+      }
+    }
+
+    void loadSessions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    if (selectedSessionId === null) {
+      setMessages([]);
+      return;
+    }
+
+    const sessionId = selectedSessionId;
+    let cancelled = false;
+
+    async function loadMessages(): Promise<void> {
+      setIsLoadingMessages(true);
+      setError(null);
+
+      try {
+        const response = await listChatSessionMessages(token, sessionId);
+
+        if (!cancelled) {
+          setMessages(response.messages);
+        }
+      } catch (cause: unknown) {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : 'Failed to load messages.');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingMessages(false);
+        }
+      }
+    }
+
+    void loadMessages();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, selectedSessionId]);
+
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 px-4 py-3">
+        <h2 className="font-medium">Conversation logs</h2>
+        <p className="text-sm text-slate-600">Consumer chat sessions and cited replies.</p>
+      </div>
+
+      {isLoadingSessions && <p className="px-4 py-6 text-sm text-slate-600">Loading sessions…</p>}
+      {error !== null && <p className="px-4 py-6 text-sm text-red-600">{error}</p>}
+
+      {!isLoadingSessions && error === null && sessions.length === 0 && (
+        <p className="px-4 py-6 text-sm text-slate-600">
+          No chat sessions yet. Start a conversation in the embed widget.
+        </p>
+      )}
+
+      {!isLoadingSessions && sessions.length > 0 && (
+        <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+          <div className="overflow-x-auto border-b border-slate-200 lg:border-b-0 lg:border-r">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 text-left text-slate-600">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Session</th>
+                  <th className="px-4 py-2 font-medium">Messages</th>
+                  <th className="px-4 py-2 font-medium">Last activity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sessions.map((session) => {
+                  const isSelected = selectedSessionId === session.session_id;
+
+                  return (
+                    <tr
+                      key={session.session_id}
+                      className={`border-t border-slate-100 cursor-pointer ${
+                        isSelected ? 'bg-sky-50' : 'hover:bg-slate-50'
+                      }`}
+                      onClick={() => setSelectedSessionId(session.session_id)}
+                    >
+                      <td className="px-4 py-2 font-medium tabular-nums">#{session.session_id}</td>
+                      <td className="px-4 py-2 tabular-nums">{session.message_count}</td>
+                      <td className="px-4 py-2 text-slate-600">
+                        {formatTimestamp(session.last_message_at ?? session.updated_at)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="px-4 py-4">
+            {selectedSessionId === null && (
+              <p className="text-sm text-slate-600">Select a session to view messages.</p>
+            )}
+            {selectedSessionId !== null && isLoadingMessages && (
+              <p className="text-sm text-slate-600">Loading messages…</p>
+            )}
+            {selectedSessionId !== null && !isLoadingMessages && messages.length === 0 && (
+              <p className="text-sm text-slate-600">No messages in this session.</p>
+            )}
+            {selectedSessionId !== null && !isLoadingMessages && messages.length > 0 && (
+              <ul className="space-y-4">
+                {messages.map((message) => (
+                  <li
+                    key={message.message_id}
+                    className={`rounded-md border px-3 py-2 ${
+                      message.role === 'assistant'
+                        ? 'border-sky-200 bg-sky-50'
+                        : 'border-slate-200 bg-slate-50'
+                    }`}
+                  >
+                    <div className="mb-1 flex items-center justify-between gap-2 text-xs text-slate-500">
+                      <span className="uppercase tracking-wide">{message.role}</span>
+                      <time dateTime={message.created_at}>{formatTimestamp(message.created_at)}</time>
+                    </div>
+                    <p className="whitespace-pre-wrap text-sm">{message.content}</p>
+                    {message.citations.length > 0 && (
+                      <ul className="mt-2 space-y-1 border-t border-slate-200 pt-2 text-xs text-slate-600">
+                        {message.citations.map((citation) => (
+                          <li key={citation.chunk_id}>
+                            <span className="font-medium">Chunk {citation.chunk_id}</span>
+                            {citation.page_number !== undefined && (
+                              <span> · p.{citation.page_number}</span>
+                            )}
+                            {citation.section_label !== undefined && (
+                              <span> · {citation.section_label}</span>
+                            )}
+                            <p className="mt-0.5 text-slate-500">{citation.excerpt}</p>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}

--- a/frontend/packages/api-client/src/admin.ts
+++ b/frontend/packages/api-client/src/admin.ts
@@ -1,6 +1,8 @@
 import { fetchJson } from './fetch-json';
 import type {
   AdminMeResponse,
+  ListChatSessionMessagesResponse,
+  ListChatSessionsResponse,
   ListSourcesResponse,
   LoginAdminResponse,
 } from './types';
@@ -25,6 +27,56 @@ export async function getAdminMe(token: string, apiBase = ''): Promise<AdminMeRe
 
 export async function listSources(token: string, apiBase = ''): Promise<ListSourcesResponse> {
   return fetchJson<ListSourcesResponse>(`${apiBase}/admin/sources`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export async function listChatSessions(
+  token: string,
+  apiBase = '',
+  options: { limit?: number; offset?: number } = {},
+): Promise<ListChatSessionsResponse> {
+  const params = new URLSearchParams();
+
+  if (options.limit !== undefined) {
+    params.set('limit', String(options.limit));
+  }
+
+  if (options.offset !== undefined) {
+    params.set('offset', String(options.offset));
+  }
+
+  const query = params.toString();
+  const path = query.length > 0 ? `/admin/chat/sessions?${query}` : '/admin/chat/sessions';
+
+  return fetchJson<ListChatSessionsResponse>(`${apiBase}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export async function listChatSessionMessages(
+  token: string,
+  sessionId: number,
+  apiBase = '',
+  options: { limit?: number; offset?: number } = {},
+): Promise<ListChatSessionMessagesResponse> {
+  const params = new URLSearchParams();
+
+  if (options.limit !== undefined) {
+    params.set('limit', String(options.limit));
+  }
+
+  if (options.offset !== undefined) {
+    params.set('offset', String(options.offset));
+  }
+
+  const query = params.toString();
+  const path =
+    query.length > 0
+      ? `/admin/chat/sessions/${sessionId}/messages?${query}`
+      : `/admin/chat/sessions/${sessionId}/messages`;
+
+  return fetchJson<ListChatSessionMessagesResponse>(`${apiBase}${path}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 }

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -1,4 +1,4 @@
-export { loginAdmin, getAdminMe, listSources } from './admin';
+export { loginAdmin, getAdminMe, listSources, listChatSessions, listChatSessionMessages } from './admin';
 export { createSource, previewCsvIngestion, previewPdfIngestion } from './ingestion';
 export type { CreateSourcePayload } from './ingestion';
 export { createChatSession, sendChatMessage } from './chat';
@@ -11,6 +11,10 @@ export type {
   CsvColumnMapping,
   HealthResponse,
   ListSourcesResponse,
+  ListChatSessionsResponse,
+  ListChatSessionMessagesResponse,
+  ChatSessionSummary,
+  ChatMessageListItem,
   LoginAdminResponse,
   PreviewCsvIngestionResponse,
   PreviewPdfIngestionResponse,

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -79,3 +79,28 @@ export interface CreateSourceResponse {
   document_count: number;
   chunk_count: number;
 }
+
+export interface ChatSessionSummary {
+  session_id: number;
+  message_count: number;
+  created_at: string;
+  updated_at: string;
+  last_message_at: string | null;
+}
+
+export interface ListChatSessionsResponse {
+  sessions: ChatSessionSummary[];
+}
+
+export interface ChatMessageListItem {
+  message_id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  citations: Citation[];
+  created_at: string;
+}
+
+export interface ListChatSessionMessagesResponse {
+  session_id: number;
+  messages: ChatMessageListItem[];
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -23,6 +23,7 @@ use NeneCorpus\Llm\LlmServiceProvider;
 use NeneCorpus\Message\MessageServiceProvider;
 use NeneCorpus\RateLimit\RateLimitServiceProvider;
 use NeneCorpus\Search\SearchServiceProvider;
+use NeneCorpus\Session\AdminChatRouteRegistrar;
 use NeneCorpus\Session\SessionServiceProvider;
 use NeneCorpus\Source\SourceNotFoundExceptionHandler;
 use NeneCorpus\Source\SourceRouteRegistrar;
@@ -56,6 +57,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $chat = $container->get(ChatServiceProvider::ROUTE_REGISTRAR);
                     $ingestion = $container->get(IngestionServiceProvider::ROUTE_REGISTRAR);
                     $source = $container->get(SourceServiceProvider::ROUTE_REGISTRAR);
+                    $adminChat = $container->get(SessionServiceProvider::ROUTE_REGISTRAR);
 
                     if (!$adminAuth instanceof AdminAuthRouteRegistrar) {
                         throw new LogicException('Admin auth route registrar service is invalid.');
@@ -73,7 +75,11 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Source route registrar service is invalid.');
                     }
 
-                    return [$adminAuth, $chat, $ingestion, $source];
+                    if (!$adminChat instanceof AdminChatRouteRegistrar) {
+                        throw new LogicException('Admin chat route registrar service is invalid.');
+                    }
+
+                    return [$adminAuth, $chat, $ingestion, $source, $adminChat];
                 },
             )
             ->set(

--- a/src/Message/ListChatSessionMessagesHandler.php
+++ b/src/Message/ListChatSessionMessagesHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Routing\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListChatSessionMessagesHandler
+{
+    public function __construct(
+        private ListChatSessionMessagesUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
+        $sessionId = (int) ($parameters['id'] ?? 0);
+        $query = $request->getQueryParams();
+        $limit = isset($query['limit']) ? (int) $query['limit'] : 100;
+        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+
+        $messages = $this->useCase->execute(new ListChatSessionMessagesInput(
+            sessionId: $sessionId,
+            limit: $limit,
+            offset: $offset,
+        ));
+
+        return $this->response->create([
+            'session_id' => $sessionId,
+            'messages' => array_map(
+                fn (ChatMessage $message): array => [
+                    'message_id' => $message->id,
+                    'role' => $message->role->value,
+                    'content' => $message->content,
+                    'citations' => $this->decodeCitations($message->citationsJson),
+                    'created_at' => $message->createdAt,
+                ],
+                $messages,
+            ),
+        ]);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function decodeCitations(?string $citationsJson): array
+    {
+        if ($citationsJson === null || $citationsJson === '') {
+            return [];
+        }
+
+        $decoded = json_decode($citationsJson, true);
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $citations = [];
+
+        foreach ($decoded as $item) {
+            if (is_array($item)) {
+                $citations[] = $item;
+            }
+        }
+
+        return $citations;
+    }
+}

--- a/src/Message/ListChatSessionMessagesInput.php
+++ b/src/Message/ListChatSessionMessagesInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+final readonly class ListChatSessionMessagesInput
+{
+    public function __construct(
+        public int $sessionId,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Message/ListChatSessionMessagesUseCase.php
+++ b/src/Message/ListChatSessionMessagesUseCase.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+use NeneCorpus\Chat\ChatSessionNotFoundException;
+use NeneCorpus\Session\ChatSessionRepositoryInterface;
+
+final readonly class ListChatSessionMessagesUseCase implements ListChatSessionMessagesUseCaseInterface
+{
+    private const MAX_LIMIT = 200;
+
+    public function __construct(
+        private ChatSessionRepositoryInterface $sessions,
+        private ChatMessageRepositoryInterface $messages,
+    ) {
+    }
+
+    public function execute(ListChatSessionMessagesInput $input): array
+    {
+        if ($input->sessionId <= 0) {
+            throw new ChatSessionNotFoundException();
+        }
+
+        $session = $this->sessions->findById($input->sessionId);
+
+        if ($session === null) {
+            throw new ChatSessionNotFoundException();
+        }
+
+        $limit = max(1, min(self::MAX_LIMIT, $input->limit));
+        $offset = max(0, $input->offset);
+
+        return $this->messages->findBySessionId($input->sessionId, $limit, $offset);
+    }
+}

--- a/src/Message/ListChatSessionMessagesUseCaseInterface.php
+++ b/src/Message/ListChatSessionMessagesUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Message;
+
+interface ListChatSessionMessagesUseCaseInterface
+{
+    /** @return list<ChatMessage> */
+    public function execute(ListChatSessionMessagesInput $input): array;
+}

--- a/src/Session/AdminChatRouteRegistrar.php
+++ b/src/Session/AdminChatRouteRegistrar.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+use Nene2\Routing\Router;
+use NeneCorpus\Message\ListChatSessionMessagesHandler;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class AdminChatRouteRegistrar
+{
+    public function __construct(
+        private ListChatSessionsHandler $listSessions,
+        private ListChatSessionMessagesHandler $listMessages,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $listSessions = $this->listSessions;
+        $listMessages = $this->listMessages;
+
+        $router->get(
+            '/admin/chat/sessions',
+            static fn (ServerRequestInterface $request) => $listSessions->handle($request),
+        );
+
+        $router->get(
+            '/admin/chat/sessions/{id}/messages',
+            static fn (ServerRequestInterface $request) => $listMessages->handle($request),
+        );
+    }
+}

--- a/src/Session/ChatSessionRepositoryInterface.php
+++ b/src/Session/ChatSessionRepositoryInterface.php
@@ -13,4 +13,7 @@ interface ChatSessionRepositoryInterface
     public function save(ChatSession $session): int;
 
     public function update(ChatSession $session): void;
+
+    /** @return list<ChatSessionSummary> */
+    public function findAllSummaries(int $limit, int $offset): array;
 }

--- a/src/Session/ChatSessionSummary.php
+++ b/src/Session/ChatSessionSummary.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+final readonly class ChatSessionSummary
+{
+    public function __construct(
+        public ChatSession $session,
+        public int $messageCount,
+        public ?string $lastMessageAt,
+    ) {
+    }
+}

--- a/src/Session/ListChatSessionsHandler.php
+++ b/src/Session/ListChatSessionsHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListChatSessionsHandler
+{
+    public function __construct(
+        private ListChatSessionsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $query = $request->getQueryParams();
+        $limit = isset($query['limit']) ? (int) $query['limit'] : 50;
+        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+
+        $summaries = $this->useCase->execute(new ListChatSessionsInput(limit: $limit, offset: $offset));
+
+        return $this->response->create([
+            'sessions' => array_map(
+                static fn (ChatSessionSummary $summary): array => [
+                    'session_id' => $summary->session->id,
+                    'message_count' => $summary->messageCount,
+                    'created_at' => $summary->session->createdAt,
+                    'updated_at' => $summary->session->updatedAt,
+                    'last_message_at' => $summary->lastMessageAt,
+                ],
+                $summaries,
+            ),
+        ]);
+    }
+}

--- a/src/Session/ListChatSessionsInput.php
+++ b/src/Session/ListChatSessionsInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+final readonly class ListChatSessionsInput
+{
+    public function __construct(
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+}

--- a/src/Session/ListChatSessionsUseCase.php
+++ b/src/Session/ListChatSessionsUseCase.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+final readonly class ListChatSessionsUseCase implements ListChatSessionsUseCaseInterface
+{
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        private ChatSessionRepositoryInterface $sessions,
+    ) {
+    }
+
+    public function execute(ListChatSessionsInput $input): array
+    {
+        $limit = max(1, min(self::MAX_LIMIT, $input->limit));
+        $offset = max(0, $input->offset);
+
+        return $this->sessions->findAllSummaries($limit, $offset);
+    }
+}

--- a/src/Session/ListChatSessionsUseCaseInterface.php
+++ b/src/Session/ListChatSessionsUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Session;
+
+interface ListChatSessionsUseCaseInterface
+{
+    /** @return list<ChatSessionSummary> */
+    public function execute(ListChatSessionsInput $input): array;
+}

--- a/src/Session/PdoChatSessionRepository.php
+++ b/src/Session/PdoChatSessionRepository.php
@@ -62,6 +62,39 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
         );
     }
 
+    public function findAllSummaries(int $limit, int $offset): array
+    {
+        $rows = $this->query->fetchAll(
+            <<<'SQL'
+                SELECT
+                    s.id, s.public_token, s.created_at, s.updated_at,
+                    (
+                        SELECT COUNT(*)
+                        FROM chat_messages m
+                        WHERE m.session_id = s.id
+                    ) AS message_count,
+                    (
+                        SELECT MAX(m.created_at)
+                        FROM chat_messages m
+                        WHERE m.session_id = s.id
+                    ) AS last_message_at
+                FROM chat_sessions s
+                ORDER BY s.id DESC
+                LIMIT ? OFFSET ?
+                SQL,
+            [$limit, $offset],
+        );
+
+        return array_map(
+            fn (array $row): ChatSessionSummary => new ChatSessionSummary(
+                session: $this->mapRow($row),
+                messageCount: (int) $row['message_count'],
+                lastMessageAt: isset($row['last_message_at']) ? (string) $row['last_message_at'] : null,
+            ),
+            $rows,
+        );
+    }
+
     /**
      * @param array<string, mixed> $row
      */

--- a/src/Session/SessionServiceProvider.php
+++ b/src/Session/SessionServiceProvider.php
@@ -8,23 +8,111 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use NeneCorpus\Message\ChatMessageRepositoryInterface;
+use NeneCorpus\Message\ListChatSessionMessagesHandler;
+use NeneCorpus\Message\ListChatSessionMessagesUseCase;
+use NeneCorpus\Message\ListChatSessionMessagesUseCaseInterface;
 use Psr\Container\ContainerInterface;
 
 final readonly class SessionServiceProvider implements ServiceProviderInterface
 {
+    public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.admin_chat';
+
     public function register(ContainerBuilder $builder): void
     {
-        $builder->set(
-            ChatSessionRepositoryInterface::class,
-            static function (ContainerInterface $container): ChatSessionRepositoryInterface {
-                $query = $container->get(DatabaseQueryExecutorInterface::class);
+        $builder
+            ->set(
+                ChatSessionRepositoryInterface::class,
+                static function (ContainerInterface $container): ChatSessionRepositoryInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
 
-                if (!$query instanceof DatabaseQueryExecutorInterface) {
-                    throw new LogicException('Database query executor service is invalid.');
-                }
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
 
-                return new PdoChatSessionRepository($query);
-            },
-        );
+                    return new PdoChatSessionRepository($query);
+                },
+            )
+            ->set(
+                ListChatSessionsUseCaseInterface::class,
+                static function (ContainerInterface $container): ListChatSessionsUseCaseInterface {
+                    $sessions = $container->get(ChatSessionRepositoryInterface::class);
+
+                    if (!$sessions instanceof ChatSessionRepositoryInterface) {
+                        throw new LogicException('Chat session repository service is invalid.');
+                    }
+
+                    return new ListChatSessionsUseCase($sessions);
+                },
+            )
+            ->set(
+                ListChatSessionsHandler::class,
+                static function (ContainerInterface $container): ListChatSessionsHandler {
+                    $useCase = $container->get(ListChatSessionsUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListChatSessionsUseCaseInterface) {
+                        throw new LogicException('List chat sessions use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListChatSessionsHandler($useCase, $response);
+                },
+            )
+            ->set(
+                ListChatSessionMessagesUseCaseInterface::class,
+                static function (ContainerInterface $container): ListChatSessionMessagesUseCaseInterface {
+                    $sessions = $container->get(ChatSessionRepositoryInterface::class);
+                    $messages = $container->get(ChatMessageRepositoryInterface::class);
+
+                    if (!$sessions instanceof ChatSessionRepositoryInterface) {
+                        throw new LogicException('Chat session repository service is invalid.');
+                    }
+
+                    if (!$messages instanceof ChatMessageRepositoryInterface) {
+                        throw new LogicException('Chat message repository service is invalid.');
+                    }
+
+                    return new ListChatSessionMessagesUseCase($sessions, $messages);
+                },
+            )
+            ->set(
+                ListChatSessionMessagesHandler::class,
+                static function (ContainerInterface $container): ListChatSessionMessagesHandler {
+                    $useCase = $container->get(ListChatSessionMessagesUseCaseInterface::class);
+                    $response = $container->get(JsonResponseFactory::class);
+
+                    if (!$useCase instanceof ListChatSessionMessagesUseCaseInterface) {
+                        throw new LogicException('List chat session messages use case service is invalid.');
+                    }
+
+                    if (!$response instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListChatSessionMessagesHandler($useCase, $response);
+                },
+            )
+            ->set(
+                self::ROUTE_REGISTRAR,
+                static function (ContainerInterface $container): AdminChatRouteRegistrar {
+                    $listSessions = $container->get(ListChatSessionsHandler::class);
+                    $listMessages = $container->get(ListChatSessionMessagesHandler::class);
+
+                    if (!$listSessions instanceof ListChatSessionsHandler) {
+                        throw new LogicException('List chat sessions handler service is invalid.');
+                    }
+
+                    if (!$listMessages instanceof ListChatSessionMessagesHandler) {
+                        throw new LogicException('List chat session messages handler service is invalid.');
+                    }
+
+                    return new AdminChatRouteRegistrar($listSessions, $listMessages);
+                },
+            );
     }
 }

--- a/tests/Chat/AdminChatHttpTest.php
+++ b/tests/Chat/AdminChatHttpTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Chat;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
+use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class AdminChatHttpTest extends TestCase
+{
+    private const JWT_SECRET = 'test-admin-jwt-secret';
+
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-admin-chat-' . uniqid('', true) . '.sqlite';
+
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_ENV['DB_ADAPTER'] = 'sqlite';
+        $_ENV['DB_NAME'] = $this->databasePath;
+        $_SERVER['DB_ADAPTER'] = 'sqlite';
+        $_SERVER['DB_NAME'] = $this->databasePath;
+        $_ENV['ANTHROPIC_API_KEY'] = '';
+        $_SERVER['ANTHROPIC_API_KEY'] = '';
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        CorpusSchemaSetup::create($executor);
+        ChatSchemaSetup::create($executor);
+        RateLimitSchemaSetup::create($executor);
+        AdminHttpTestSupport::seedAdminUser($executor);
+        $this->seedCorpus($executor);
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        unset(
+            $_ENV['DB_ADAPTER'],
+            $_SERVER['DB_ADAPTER'],
+            $_ENV['DB_NAME'],
+            $_SERVER['DB_NAME'],
+            $_ENV['ANTHROPIC_API_KEY'],
+            $_SERVER['ANTHROPIC_API_KEY'],
+        );
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+    }
+
+    public function test_list_sessions_returns_summaries_after_chat(): void
+    {
+        $sessionId = $this->createChatWithMessage();
+
+        $response = $this->authorizedRequest('GET', '/admin/chat/sessions');
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertArrayHasKey('sessions', $payload);
+        self::assertIsArray($payload['sessions']);
+        self::assertNotSame([], $payload['sessions']);
+
+        $first = $payload['sessions'][0];
+        self::assertSame($sessionId, $first['session_id']);
+        self::assertSame(2, $first['message_count']);
+        self::assertNotEmpty($first['last_message_at']);
+        self::assertNotEmpty($first['created_at']);
+    }
+
+    public function test_list_session_messages_returns_user_and_assistant_messages(): void
+    {
+        $sessionId = $this->createChatWithMessage();
+
+        $response = $this->authorizedRequest('GET', '/admin/chat/sessions/' . $sessionId . '/messages');
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($sessionId, $payload['session_id']);
+        self::assertCount(2, $payload['messages']);
+
+        $userMessage = $payload['messages'][0];
+        self::assertSame('user', $userMessage['role']);
+        self::assertSame('What pairs well with seafood?', $userMessage['content']);
+        self::assertSame([], $userMessage['citations']);
+
+        $assistantMessage = $payload['messages'][1];
+        self::assertSame('assistant', $assistantMessage['role']);
+        self::assertNotEmpty($assistantMessage['content']);
+        self::assertNotEmpty($assistantMessage['citations']);
+        self::assertSame(2, $assistantMessage['citations'][0]['page_number']);
+    }
+
+    public function test_list_sessions_requires_auth(): void
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('GET', 'https://example.test/admin/chat/sessions'),
+        );
+
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_list_messages_for_missing_session_returns_404(): void
+    {
+        $response = $this->authorizedRequest('GET', '/admin/chat/sessions/9999/messages');
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    private function createChatWithMessage(): int
+    {
+        $factory = $this->factory();
+        $application = $this->application();
+
+        $sessionResponse = $application->handle(
+            $factory->createServerRequest('POST', 'https://example.test/chat/sessions'),
+        );
+        $sessionPayload = $this->decodeJson($sessionResponse);
+        self::assertSame(201, $sessionResponse->getStatusCode());
+
+        $messageResponse = $application->handle(
+            $factory->createServerRequest('POST', 'https://example.test/chat/messages')
+                ->withHeader('Content-Type', 'application/json')
+                ->withHeader('X-Session-Token', $sessionPayload['session_token'])
+                ->withBody($factory->createStream(json_encode([
+                    'content' => 'What pairs well with seafood?',
+                ], JSON_THROW_ON_ERROR))),
+        );
+        self::assertSame(200, $messageResponse->getStatusCode());
+
+        return (int) $sessionPayload['session_id'];
+    }
+
+    private function seedCorpus(PdoDatabaseQueryExecutor $executor): void
+    {
+        $sourceId = (new PdoSourceRepository($executor))->save(new Source(
+            name: 'Catalog',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/catalog.pdf',
+        ));
+
+        $documentId = (new PdoDocumentRepository($executor))->save(new Document(
+            sourceId: $sourceId,
+            title: 'Pairings',
+            position: 0,
+        ));
+
+        (new PdoChunkRepository($executor))->save(new Chunk(
+            documentId: $documentId,
+            sourceId: $sourceId,
+            content: 'Dry ginjo pairs well with white fish and light seafood dishes.',
+            chunkIndex: 0,
+            pageNumber: 2,
+            sectionLabel: 'Pairings',
+        ));
+    }
+
+    private function authorizedRequest(string $method, string $path): ResponseInterface
+    {
+        $token = $this->loginToken();
+
+        return $this->application()->handle(
+            $this->factory()->createServerRequest($method, 'https://example.test' . $path)
+                ->withHeader('Authorization', 'Bearer ' . $token),
+        );
+    }
+
+    private function loginToken(): string
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/auth/login')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream(json_encode([
+                    'email' => 'admin@example.com',
+                    'password' => 'secret-password',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        $payload = $this->decodeJson($response);
+
+        return (string) $payload['access_token'];
+    }
+
+    private function application(): RequestHandlerInterface
+    {
+        $container = (new RuntimeContainerFactory())->create();
+        $application = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        return $application;
+    }
+
+    private function factory(): Psr17Factory
+    {
+        return new Psr17Factory();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Support/AdminHttpTestSupport.php
+++ b/tests/Support/AdminHttpTestSupport.php
@@ -11,6 +11,11 @@ final class AdminHttpTestSupport
     public static function seedCorpusSchema(PdoDatabaseQueryExecutor $executor): void
     {
         CorpusSchemaSetup::create($executor);
+        self::seedAdminUser($executor);
+    }
+
+    public static function seedAdminUser(PdoDatabaseQueryExecutor $executor): void
+    {
         CorpusSchemaSetup::createAdminUsers($executor);
 
         $hash = password_hash('secret-password', PASSWORD_ARGON2ID);


### PR DESCRIPTION
## Summary
- 管理者向け `GET /admin/chat/sessions` と `GET /admin/chat/sessions/{id}/messages` を追加（引用付きメッセージ、JWT 必須）
- OpenAPI を v0.8 に更新
- Admin UI に Conversation logs パネルを追加（セッション一覧 + メッセージ詳細）
- `AdminChatHttpTest` で API 動作を検証

Closes #53

## Test plan
- [x] `composer check` — PHPUnit 56 / PHPStan / OpenAPI / MCP green
- [x] `npm run check --prefix frontend` — typecheck green
- [ ] Admin でログイン → Conversation logs に widget で作成したセッションが表示される
- [ ] セッション選択 → user/assistant メッセージと citations が表示される


Made with [Cursor](https://cursor.com)