### PR TITLE
fix(ingestion): Shift-JIS CSV preview 500 (#61)

### DIFF
--- a/src/Ingestion/CsvParser.php
+++ b/src/Ingestion/CsvParser.php
@@ -8,6 +8,11 @@ final readonly class CsvParser
 {
     private const SAMPLE_ROW_LIMIT = 5;
 
+    public function __construct(
+        private CsvTextNormalizer $textNormalizer = new CsvTextNormalizer(),
+    ) {
+    }
+
     /**
      * @return array{
      *     headers: list<string>,
@@ -150,6 +155,7 @@ final readonly class CsvParser
      */
     private function readRows(string $bytes): array
     {
+        $bytes = $this->textNormalizer->normalize($bytes);
         $delimiter = $this->detectDelimiter($bytes);
         $lines = preg_split('/\R/', $bytes) ?: [];
         $rows = [];

--- a/src/Ingestion/CsvTextNormalizer.php
+++ b/src/Ingestion/CsvTextNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Ingestion;
+
+final readonly class CsvTextNormalizer
+{
+    private const UTF8 = 'UTF-8';
+
+    /** @var list<string> */
+    private const CANDIDATE_ENCODINGS = [
+        'UTF-8',
+        'SJIS-win',
+        'SJIS',
+        'EUC-JP',
+        'ISO-2022-JP',
+        'Windows-1252',
+        'ASCII',
+    ];
+
+    public function normalize(string $bytes): string
+    {
+        if ($bytes === '') {
+            return $bytes;
+        }
+
+        $bytes = $this->stripUtf8Bom($bytes);
+
+        if ($this->isValidUtf8($bytes)) {
+            return $bytes;
+        }
+
+        $encoding = mb_detect_encoding($bytes, implode(', ', self::CANDIDATE_ENCODINGS), true);
+
+        if ($encoding === false || $encoding === self::UTF8) {
+            $encoding = 'SJIS-win';
+        }
+
+        $converted = mb_convert_encoding($bytes, self::UTF8, $encoding);
+
+        if (!is_string($converted) || !$this->isValidUtf8($converted)) {
+            throw new CsvIngestionException(
+                'CSV file uses an unsupported or invalid character encoding.',
+                'content',
+            );
+        }
+
+        return $converted;
+    }
+
+    private function stripUtf8Bom(string $bytes): string
+    {
+        return str_starts_with($bytes, "\xEF\xBB\xBF") ? substr($bytes, 3) : $bytes;
+    }
+
+    private function isValidUtf8(string $bytes): bool
+    {
+        return mb_check_encoding($bytes, self::UTF8);
+    }
+}

--- a/tests/Ingestion/CsvIngestionHttpTest.php
+++ b/tests/Ingestion/CsvIngestionHttpTest.php
@@ -86,6 +86,26 @@ CSV;
         self::assertSame(',', $payload['detected_delimiter']);
     }
 
+    public function test_preview_accepts_shift_jis_csv(): void
+    {
+        $csv = mb_convert_encoding(
+            "product_name,description\nWidget A,日本語テスト\n",
+            'SJIS-win',
+            'UTF-8',
+        );
+
+        $response = $this->authorizedPost('/admin/ingestion/csv/preview', [
+            'filename' => 'catalog.csv',
+            'content' => base64_encode($csv),
+        ]);
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(['product_name', 'description'], $payload['headers']);
+        self::assertSame('日本語テスト', $payload['sample_rows'][0][1]);
+    }
+
     public function test_create_source_persists_corpus_rows(): void
     {
         $csv = <<<'CSV'

--- a/tests/Ingestion/CsvParserTest.php
+++ b/tests/Ingestion/CsvParserTest.php
@@ -54,4 +54,18 @@ CSV;
         self::assertSame('description: Great widget', $rows[0]['content']);
         self::assertSame(['price' => '100'], $rows[0]['metadata']);
     }
+
+    public function test_preview_normalizes_shift_jis_bytes_to_utf8(): void
+    {
+        $csv = mb_convert_encoding(
+            "product_name,description\nWidget A,日本語テスト\n",
+            'SJIS-win',
+            'UTF-8',
+        );
+
+        $preview = $this->parser->preview($csv);
+
+        self::assertSame(['product_name', 'description'], $preview['headers']);
+        self::assertSame('日本語テスト', $preview['sample_rows'][0][1]);
+    }
 }


### PR DESCRIPTION
## Summary
- `CsvTextNormalizer` — UTF-8 以外（主に Shift-JIS / CP932）を検出・変換
- `CsvParser` が読み取り前に正規化
- 判別不能な場合は 422（`CsvIngestionException`）

Closes #61

## Root cause
日本語 Excel CSV が CP932 のまま JSON レスポンス化され `Malformed UTF-8` → HTTP 500。

## Test plan
- [x] `composer check` — 58 tests green
- [x] ローカル API で Shift-JIS preview が 200


Made with [Cursor](https://cursor.com)