### PR TITLE
fix(ingestion): WooCommerce CSV preview 500 (#63)

### DIFF
--- a/src/Ingestion/CsvParser.php
+++ b/src/Ingestion/CsvParser.php
@@ -166,7 +166,10 @@ final readonly class CsvParser
             }
 
             $row = str_getcsv($line, $delimiter, '"', '\\');
-            $normalized = array_map(static fn (mixed $value): string => trim((string) $value), $row);
+            $normalized = array_map(
+                fn (mixed $value): string => $this->textNormalizer->scrubCell(trim((string) $value)),
+                $row,
+            );
 
             if (implode('', $normalized) === '') {
                 continue;

--- a/src/Ingestion/CsvTextNormalizer.php
+++ b/src/Ingestion/CsvTextNormalizer.php
@@ -4,12 +4,23 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Ingestion;
 
+use JsonException;
+
 final readonly class CsvTextNormalizer
 {
     private const UTF8 = 'UTF-8';
 
     /** @var list<string> */
-    private const CANDIDATE_ENCODINGS = [
+    private const FALLBACK_ENCODINGS = [
+        'SJIS-win',
+        'SJIS',
+        'Windows-1252',
+        'EUC-JP',
+        'ISO-2022-JP',
+    ];
+
+    /** @var list<string> */
+    private const DETECT_ENCODINGS = [
         'UTF-8',
         'SJIS-win',
         'SJIS',
@@ -27,35 +38,129 @@ final readonly class CsvTextNormalizer
 
         $bytes = $this->stripUtf8Bom($bytes);
 
-        if ($this->isValidUtf8($bytes)) {
+        if ($this->isJsonSafeUtf8($bytes)) {
             return $bytes;
         }
 
-        $encoding = mb_detect_encoding($bytes, implode(', ', self::CANDIDATE_ENCODINGS), true);
+        foreach ($this->encodingCandidates($bytes) as $encoding) {
+            if ($encoding === self::UTF8) {
+                continue;
+            }
 
-        if ($encoding === false || $encoding === self::UTF8) {
-            $encoding = 'SJIS-win';
+            $converted = mb_convert_encoding($bytes, self::UTF8, $encoding);
+
+            if (is_string($converted) && $this->isJsonSafeUtf8($converted)) {
+                return $converted;
+            }
         }
 
-        $converted = mb_convert_encoding($bytes, self::UTF8, $encoding);
+        $scrubbed = $this->scrubUtf8($bytes);
 
-        if (!is_string($converted) || !$this->isValidUtf8($converted)) {
-            throw new CsvIngestionException(
-                'CSV file uses an unsupported or invalid character encoding.',
-                'content',
-            );
+        if ($this->isJsonSafeUtf8($scrubbed)) {
+            return $scrubbed;
         }
 
-        return $converted;
+        throw new CsvIngestionException(
+            'CSV file uses an unsupported or invalid character encoding.',
+            'content',
+        );
+    }
+
+    public function scrubCell(string $value): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+
+        if ($this->isJsonSafeUtf8($value)) {
+            return $value;
+        }
+
+        foreach ($this->encodingCandidates($value) as $encoding) {
+            if ($encoding === self::UTF8) {
+                continue;
+            }
+
+            $converted = mb_convert_encoding($value, self::UTF8, $encoding);
+
+            if (is_string($converted) && $this->isJsonSafeUtf8($converted)) {
+                return $converted;
+            }
+        }
+
+        $scrubbed = $this->scrubUtf8($value);
+
+        return $this->isJsonSafeUtf8($scrubbed) ? $scrubbed : $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function encodingCandidates(string $bytes): array
+    {
+        $detected = mb_detect_encoding($bytes, implode(', ', self::DETECT_ENCODINGS), true);
+        $candidates = [];
+
+        if (is_string($detected) && $detected !== '') {
+            $candidates[] = $detected;
+        }
+
+        foreach (self::FALLBACK_ENCODINGS as $encoding) {
+            if (!in_array($encoding, $candidates, true)) {
+                $candidates[] = $encoding;
+            }
+        }
+
+        return $candidates;
     }
 
     private function stripUtf8Bom(string $bytes): string
     {
-        return str_starts_with($bytes, "\xEF\xBB\xBF") ? substr($bytes, 3) : $bytes;
+        if (str_starts_with($bytes, "\xEF\xBB\xBF")) {
+            return substr($bytes, 3);
+        }
+
+        if (str_starts_with($bytes, "\xFF\xFE")) {
+            return $this->convertFromEncoding(substr($bytes, 2), 'UTF-16LE') ?? $bytes;
+        }
+
+        if (str_starts_with($bytes, "\xFE\xFF")) {
+            return $this->convertFromEncoding(substr($bytes, 2), 'UTF-16BE') ?? $bytes;
+        }
+
+        return $bytes;
     }
 
-    private function isValidUtf8(string $bytes): bool
+    private function convertFromEncoding(string $bytes, string $encoding): ?string
     {
-        return mb_check_encoding($bytes, self::UTF8);
+        $converted = mb_convert_encoding($bytes, self::UTF8, $encoding);
+
+        return is_string($converted) ? $converted : null;
+    }
+
+    private function scrubUtf8(string $bytes): string
+    {
+        if (function_exists('mb_scrub')) {
+            return mb_scrub($bytes, self::UTF8);
+        }
+
+        $scrubbed = iconv(self::UTF8, self::UTF8 . '//IGNORE', $bytes);
+
+        return is_string($scrubbed) ? $scrubbed : '';
+    }
+
+    private function isJsonSafeUtf8(string $bytes): bool
+    {
+        if (!mb_check_encoding($bytes, self::UTF8)) {
+            return false;
+        }
+
+        try {
+            json_encode($bytes, JSON_THROW_ON_ERROR);
+
+            return true;
+        } catch (JsonException) {
+            return false;
+        }
     }
 }

--- a/tests/Ingestion/CsvIngestionHttpTest.php
+++ b/tests/Ingestion/CsvIngestionHttpTest.php
@@ -106,6 +106,23 @@ CSV;
         self::assertSame('日本語テスト', $payload['sample_rows'][0][1]);
     }
 
+    public function test_preview_accepts_woocommerce_like_shift_jis_export(): void
+    {
+        $header = 'ID,Type,SKU,Name,Published,Description';
+        $row = mb_convert_encoding('1,simple,SKU-1,Widget,1,日本語の商品説明', 'SJIS-win', 'UTF-8');
+        $csv = $header . "\n" . $row . "\n";
+
+        $response = $this->authorizedPost('/admin/ingestion/csv/preview', [
+            'filename' => 'wc-product-export.csv',
+            'content' => base64_encode($csv),
+        ]);
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('日本語の商品説明', $payload['sample_rows'][0][5]);
+    }
+
     public function test_create_source_persists_corpus_rows(): void
     {
         $csv = <<<'CSV'

--- a/tests/Ingestion/CsvParserTest.php
+++ b/tests/Ingestion/CsvParserTest.php
@@ -68,4 +68,29 @@ CSV;
         self::assertSame(['product_name', 'description'], $preview['headers']);
         self::assertSame('日本語テスト', $preview['sample_rows'][0][1]);
     }
+
+    public function test_preview_handles_ascii_header_with_shift_jis_product_rows(): void
+    {
+        $header = 'ID,Type,SKU,Name,Published,Description';
+        $row = mb_convert_encoding('1,simple,SKU-1,Widget,1,日本語の商品説明', 'SJIS-win', 'UTF-8');
+        $csv = $header . "\n" . $row . "\n";
+
+        $preview = $this->parser->preview($csv);
+
+        self::assertSame(
+            ['ID', 'Type', 'SKU', 'Name', 'Published', 'Description'],
+            $preview['headers'],
+        );
+        self::assertSame('日本語の商品説明', $preview['sample_rows'][0][5]);
+    }
+
+    public function test_preview_scrubs_invalid_utf8_sequences(): void
+    {
+        $csv = "product_name,description\nWidget,\xED\xA0\x80broken\n";
+
+        $preview = $this->parser->preview($csv);
+
+        self::assertSame(['product_name', 'description'], $preview['headers']);
+        self::assertSame(1, $preview['row_count']);
+    }
 }


### PR DESCRIPTION
## Summary
- `CsvTextNormalizer` — `json_encode` で JSON 安全な UTF-8 を検証
- UTF-8 判定でも JSON 非安全なら SJIS-win 等を順に試行
- セル単位 `scrubCell` + `mb_scrub` / iconv フォールバック
- UTF-16 BOM 対応

Closes #63

## Test plan
- [x] `composer check` — 61 tests green
- [x] WooCommerce 風 ASCII ヘッダ + Shift_JIS 行の preview 200


Made with [Cursor](https://cursor.com)