### PR TITLE
fix(ingestion): WooCommerce UTF-8 CSV の文字化けを修正 (#65)

### DIFF
--- a/src/Ingestion/CsvParser.php
+++ b/src/Ingestion/CsvParser.php
@@ -157,7 +157,8 @@ final readonly class CsvParser
     {
         $bytes = $this->textNormalizer->normalize($bytes);
         $delimiter = $this->detectDelimiter($bytes);
-        $lines = preg_split('/\R/', $bytes) ?: [];
+        // Do not use \R: it matches U+0085 (NEL), which appears inside UTF-8 CJK bytes (e.g. 項, 配).
+        $lines = preg_split('/\r\n|\n|\r/', $bytes) ?: [];
         $rows = [];
 
         foreach ($lines as $line) {

--- a/src/Ingestion/CsvTextNormalizer.php
+++ b/src/Ingestion/CsvTextNormalizer.php
@@ -11,10 +11,9 @@ final readonly class CsvTextNormalizer
     private const UTF8 = 'UTF-8';
 
     /** @var list<string> */
-    private const FALLBACK_ENCODINGS = [
+    private const LEGACY_ENCODINGS = [
         'SJIS-win',
         'SJIS',
-        'Windows-1252',
         'EUC-JP',
         'ISO-2022-JP',
     ];
@@ -26,7 +25,6 @@ final readonly class CsvTextNormalizer
         'SJIS',
         'EUC-JP',
         'ISO-2022-JP',
-        'Windows-1252',
         'ASCII',
     ];
 
@@ -36,21 +34,32 @@ final readonly class CsvTextNormalizer
             return $bytes;
         }
 
-        $bytes = $this->stripUtf8Bom($bytes);
+        $bytes = $this->stripBom($bytes);
 
         if ($this->isJsonSafeUtf8($bytes)) {
             return $bytes;
         }
 
-        foreach ($this->encodingCandidates($bytes) as $encoding) {
-            if ($encoding === self::UTF8) {
-                continue;
+        if (mb_check_encoding($bytes, self::UTF8)) {
+            $scrubbed = $this->scrubUtf8($bytes);
+
+            if ($this->isJsonSafeUtf8($scrubbed)) {
+                return $scrubbed;
             }
+        } elseif ($this->headerLooksLikeUtf8($bytes)) {
+            // UTF-8 export with isolated bad bytes (e.g. WooCommerce); do not misread as Shift-JIS.
+            $scrubbed = $this->scrubUtf8($bytes);
 
-            $converted = mb_convert_encoding($bytes, self::UTF8, $encoding);
+            if ($this->isJsonSafeUtf8($scrubbed)) {
+                return $scrubbed;
+            }
+        } else {
+            foreach ($this->legacyEncodingCandidates($bytes) as $encoding) {
+                $converted = mb_convert_encoding($bytes, self::UTF8, $encoding);
 
-            if (is_string($converted) && $this->isJsonSafeUtf8($converted)) {
-                return $converted;
+                if (is_string($converted) && $this->isJsonSafeUtf8($converted)) {
+                    return $converted;
+                }
             }
         }
 
@@ -68,24 +77,8 @@ final readonly class CsvTextNormalizer
 
     public function scrubCell(string $value): string
     {
-        if ($value === '') {
+        if ($value === '' || $this->isJsonSafeUtf8($value)) {
             return $value;
-        }
-
-        if ($this->isJsonSafeUtf8($value)) {
-            return $value;
-        }
-
-        foreach ($this->encodingCandidates($value) as $encoding) {
-            if ($encoding === self::UTF8) {
-                continue;
-            }
-
-            $converted = mb_convert_encoding($value, self::UTF8, $encoding);
-
-            if (is_string($converted) && $this->isJsonSafeUtf8($converted)) {
-                return $converted;
-            }
         }
 
         $scrubbed = $this->scrubUtf8($value);
@@ -96,16 +89,16 @@ final readonly class CsvTextNormalizer
     /**
      * @return list<string>
      */
-    private function encodingCandidates(string $bytes): array
+    private function legacyEncodingCandidates(string $bytes): array
     {
         $detected = mb_detect_encoding($bytes, implode(', ', self::DETECT_ENCODINGS), true);
         $candidates = [];
 
-        if (is_string($detected) && $detected !== '') {
+        if (is_string($detected) && $detected !== '' && $detected !== self::UTF8) {
             $candidates[] = $detected;
         }
 
-        foreach (self::FALLBACK_ENCODINGS as $encoding) {
+        foreach (self::LEGACY_ENCODINGS as $encoding) {
             if (!in_array($encoding, $candidates, true)) {
                 $candidates[] = $encoding;
             }
@@ -114,7 +107,25 @@ final readonly class CsvTextNormalizer
         return $candidates;
     }
 
-    private function stripUtf8Bom(string $bytes): string
+    private function headerLooksLikeUtf8(string $bytes): bool
+    {
+        $firstLine = $this->firstLine($bytes);
+
+        if ($firstLine === '' || !mb_check_encoding($firstLine, self::UTF8)) {
+            return false;
+        }
+
+        return preg_match('/[^\x00-\x7F]/', $firstLine) === 1;
+    }
+
+    private function firstLine(string $bytes): string
+    {
+        $length = strcspn($bytes, "\r\n");
+
+        return substr($bytes, 0, $length);
+    }
+
+    private function stripBom(string $bytes): string
     {
         if (str_starts_with($bytes, "\xEF\xBB\xBF")) {
             return substr($bytes, 3);

--- a/tests/Ingestion/CsvIngestionHttpTest.php
+++ b/tests/Ingestion/CsvIngestionHttpTest.php
@@ -123,6 +123,26 @@ CSV;
         self::assertSame('日本語の商品説明', $payload['sample_rows'][0][5]);
     }
 
+    public function test_preview_preserves_utf8_woocommerce_export(): void
+    {
+        $csv = <<<'CSV'
+ID,タイプ,SKU,GTIN、UPC、EAN、ISBN,名前,注意事項,配送クラス
+47,simple,2019-s0030940-01,,オオタニヨシミ A3ポスター「花の玉章」,0,通常
+CSV;
+
+        $response = $this->authorizedPost('/admin/ingestion/csv/preview', [
+            'filename' => 'wc-product-export.csv',
+            'content' => base64_encode($csv),
+        ]);
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('注意事項', $payload['headers'][5]);
+        self::assertSame('配送クラス', $payload['headers'][6]);
+        self::assertSame('オオタニヨシミ A3ポスター「花の玉章」', $payload['sample_rows'][0][4]);
+    }
+
     public function test_create_source_persists_corpus_rows(): void
     {
         $csv = <<<'CSV'

--- a/tests/Ingestion/CsvParserTest.php
+++ b/tests/Ingestion/CsvParserTest.php
@@ -93,4 +93,31 @@ CSV;
         self::assertSame(['product_name', 'description'], $preview['headers']);
         self::assertSame(1, $preview['row_count']);
     }
+
+    public function test_preview_preserves_utf8_woocommerce_headers(): void
+    {
+        $csv = <<<'CSV'
+ID,タイプ,SKU,名前,注意事項,配送クラス
+47,simple,2019-s0030940-01,オオタニヨシミ A3ポスター「花の玉章」,説明文,通常
+CSV;
+
+        $preview = $this->parser->preview($csv);
+
+        self::assertSame(
+            ['ID', 'タイプ', 'SKU', '名前', '注意事項', '配送クラス'],
+            $preview['headers'],
+        );
+        self::assertSame('オオタニヨシミ A3ポスター「花の玉章」', $preview['sample_rows'][0][3]);
+    }
+
+    public function test_preview_does_not_mojibake_utf8_headers_with_invalid_byte_in_row(): void
+    {
+        $csv = "ID,タイプ,注意事項,配送クラス\n1,simple,\xED\xA0\x80,通常\n";
+
+        $preview = $this->parser->preview($csv);
+
+        self::assertSame('注意事項', $preview['headers'][2]);
+        self::assertSame('配送クラス', $preview['headers'][3]);
+        self::assertStringNotContainsString('æ', $preview['headers'][2]);
+    }
 }


### PR DESCRIPTION
## Summary

- UTF-8 として正しい CSV セルに CP1252 / SJIS 再変換をかけないよう `CsvTextNormalizer` を整理
- 行分割で PHP `\R` を使わない（`\x85` が「項」「配」等の UTF-8 3 バイト目と一致し、ヘッダーが途中で切れていた）
- UTF-8 ヘッダー + 本文に孤立した不正バイトがある WooCommerce export は scrub のみで処理

## Test plan

- [x] `composer check`
- [ ] hide の `wc-product-export-*.csv` で Admin preview を再確認
- [ ] 「注意事項」「配送クラス」が正しく表示されること
- [ ] 商品名「オオタニヨシミ A3ポスター「花の玉章」」が正しく表示されること

Closes #65

Made with [Cursor](https://cursor.com)