### PR TITLE
feat(admin): 管理画面ヘッダーに言語セレクタを追加 (#73)

### DIFF
--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -58,6 +58,7 @@ frontend/
 - Supported locales match NENE2 docs: `en`, `ja`, `fr`, `zh-Hans`, `pt-BR`, `de`.
 - OpenAPI / API error `code` / Problem Details stay **English** (NENE2 language policy); only client UI is localized.
 - Wrap admin and widget roots with `LocaleProvider`. Admin: `nene-corpus.admin.locale`; widget: `nene-corpus.widget.locale`. Initial locale: `localStorage` → browser language → `en`.
+- Admin header exposes a locale `<select>` (`LocaleSelector`) — preference is **localStorage only** (no server persistence).
 - Use `formatTimestamp(value, locale)` for locale-aware dates.
 - Pair labels with optional help via `HelpLabel` (`label` + `help` strings from `Msg.*Help` keys). Tooltip opens on hover and keyboard focus; use `\n` in help strings for line breaks. CSV column mapping also has a collapsible `ColumnMappingGuide` accordion after preview.
 

--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
 import { ConversationLogsPanel } from './ConversationLogsPanel';
 import { AppearancePanel } from './AppearancePanel';
+import { LocaleSelector } from './LocaleSelector';
 import { useAdminAuth } from './useAdminAuth';
 
 export function App() {
@@ -47,18 +48,21 @@ export function App() {
                 : t(Msg.admin.app.healthUnavailable)}
             </p>
           </div>
-          {profile && (
-            <div className="flex items-center gap-3 text-sm">
-              <span className="text-slate-600">{profile.email}</span>
-              <button
-                className="rounded-md border border-slate-300 px-3 py-1.5 hover:bg-slate-50"
-                type="button"
-                onClick={logout}
-              >
-                {t(Msg.common.signOut)}
-              </button>
-            </div>
-          )}
+          <div className="flex flex-wrap items-center justify-end gap-3 text-sm">
+            <LocaleSelector />
+            {profile && (
+              <>
+                <span className="text-slate-600">{profile.email}</span>
+                <button
+                  className="rounded-md border border-slate-300 px-3 py-1.5 hover:bg-slate-50"
+                  type="button"
+                  onClick={logout}
+                >
+                  {t(Msg.common.signOut)}
+                </button>
+              </>
+            )}
+          </div>
         </div>
       </header>
       <main className="mx-auto max-w-5xl space-y-6 px-6 py-8">

--- a/frontend/apps/admin/src/LocaleSelector.tsx
+++ b/frontend/apps/admin/src/LocaleSelector.tsx
@@ -1,0 +1,33 @@
+import { Msg, useLocale, useMsg, type MsgKey, type SupportedLocale } from '@nene-corpus/i18n';
+
+const LOCALE_LABEL_KEYS: Record<SupportedLocale, MsgKey> = {
+  en: Msg.locale.en,
+  ja: Msg.locale.ja,
+  fr: Msg.locale.fr,
+  'zh-Hans': Msg.locale.zhHans,
+  'pt-BR': Msg.locale.ptBr,
+  de: Msg.locale.de,
+};
+
+export function LocaleSelector() {
+  const t = useMsg();
+  const { locale, setLocale, supportedLocales } = useLocale();
+
+  return (
+    <label className="flex items-center gap-2 text-sm text-slate-600">
+      <span className="whitespace-nowrap">{t(Msg.admin.app.language)}</span>
+      <select
+        className="rounded-md border border-slate-300 bg-white px-2 py-1.5 text-slate-900"
+        value={locale}
+        aria-label={t(Msg.admin.app.language)}
+        onChange={(event) => setLocale(event.target.value as SupportedLocale)}
+      >
+        {supportedLocales.map((code) => (
+          <option key={code} value={code}>
+            {t(LOCALE_LABEL_KEYS[code])}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -33,6 +33,7 @@ export const Msg = {
   admin: {
     app: {
       title: 'admin.app.title',
+      language: 'admin.app.language',
       healthUnavailable: 'admin.app.healthUnavailable',
       healthStatus: 'admin.app.healthStatus',
     },

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -20,6 +20,7 @@ export const de = defineMessages({
   'sourceStatus.ready': 'Bereit',
   'sourceStatus.failed': 'Fehlgeschlagen',
   'admin.app.title': 'NeNe Corpus Admin',
+  'admin.app.language': 'Admin-Sprache',
   'admin.app.healthUnavailable': 'API-Status nicht verfügbar',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Admin-Anmeldung',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -20,6 +20,7 @@ export const en = defineMessages({
   'sourceStatus.ready': 'Ready',
   'sourceStatus.failed': 'Failed',
   'admin.app.title': 'NeNe Corpus Admin',
+  'admin.app.language': 'Admin language',
   'admin.app.healthUnavailable': 'API health unavailable',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Admin login',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -20,6 +20,7 @@ export const fr = defineMessages({
   'sourceStatus.ready': 'Prêt',
   'sourceStatus.failed': 'Échec',
   'admin.app.title': 'Administration NeNe Corpus',
+  'admin.app.language': 'Langue de l’administration',
   'admin.app.healthUnavailable': 'État de l’API indisponible',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Connexion admin',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -20,6 +20,7 @@ export const ja = defineMessages({
   'sourceStatus.ready': '準備完了',
   'sourceStatus.failed': '失敗',
   'admin.app.title': 'NeNe Corpus 管理画面',
+  'admin.app.language': '管理画面の言語',
   'admin.app.healthUnavailable': 'API の状態を取得できません',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': '管理者ログイン',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -20,6 +20,7 @@ export const ptBr = defineMessages({
   'sourceStatus.ready': 'Pronto',
   'sourceStatus.failed': 'Falhou',
   'admin.app.title': 'Admin NeNe Corpus',
+  'admin.app.language': 'Idioma do admin',
   'admin.app.healthUnavailable': 'Status da API indisponível',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Login admin',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -20,6 +20,7 @@ export const zhHans = defineMessages({
   'sourceStatus.ready': '就绪',
   'sourceStatus.failed': '失败',
   'admin.app.title': 'NeNe Corpus 管理后台',
+  'admin.app.language': '管理后台语言',
   'admin.app.healthUnavailable': '无法获取 API 状态',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': '管理员登录',


### PR DESCRIPTION
## Summary

- ヘッダー右側に `LocaleSelector` を追加（6 ロケール対応）
- `useLocale().setLocale` で `nene-corpus.admin.locale` に保存
- ログイン前後どちらでも切り替え可能
- `frontend-standards.md` に localStorage のみ保存と明記

Closes #73

## Test plan

- [ ] Admin (`:5173`) を開き、ヘッダーに言語セレクタが表示される
- [ ] 日本語 / English などに切り替え、UI 文言が即座に変わる
- [ ] リロード後も選択した言語が維持される
- [ ] ログイン前の画面でもセレクタが使える
- [ ] `npm run check --prefix frontend` が通る

Made with [Cursor](https://cursor.com)