### PR TITLE
feat(admin): ロケール別 Typography を @fontsource で同梱 (#75)

### DIFF
--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -59,6 +59,7 @@ frontend/
 - OpenAPI / API error `code` / Problem Details stay **English** (NENE2 language policy); only client UI is localized.
 - Wrap admin and widget roots with `LocaleProvider`. Admin: `nene-corpus.admin.locale`; widget: `nene-corpus.widget.locale`. Initial locale: `localStorage` → browser language → `en`.
 - Admin header exposes a locale `<select>` (`LocaleSelector`) — preference is **localStorage only** (no server persistence).
+- **Typography (Admin):** locale-aware stacks via `@fontsource` — Inter (Latin locales), Noto Sans JP (`ja`), Noto Sans SC (`zh-Hans`). Bundled in admin only; `--nc-admin-font-family` on `:root` drives Tailwind `font-sans`. Widget unchanged.
 - Use `formatTimestamp(value, locale)` for locale-aware dates.
 - Pair labels with optional help via `HelpLabel` (`label` + `help` strings from `Msg.*Help` keys). Tooltip opens on hover and keyboard focus; use `\n` in help strings for line breaks. CSV column mapping also has a collapsible `ColumnMappingGuide` accordion after preview.
 

--- a/frontend/apps/admin/package.json
+++ b/frontend/apps/admin/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/noto-sans-jp": "^5.2.9",
+    "@fontsource/noto-sans-sc": "^5.2.9",
     "@nene-corpus/api-client": "*",
     "@nene-corpus/i18n": "*",
     "@nene-corpus/tokens": "*",

--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchJson, type HealthResponse } from '@nene-corpus/api-client';
-import { Msg, toBcp47, useLocale, useMsg } from '@nene-corpus/i18n';
+import { Msg, applyLocaleFontFamily, toBcp47, useLocale, useMsg } from '@nene-corpus/i18n';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
 import { ConversationLogsPanel } from './ConversationLogsPanel';
@@ -17,6 +17,7 @@ export function App() {
 
   useEffect(() => {
     document.documentElement.lang = toBcp47(locale);
+    applyLocaleFontFamily(locale);
   }, [locale]);
 
   useEffect(() => {

--- a/frontend/apps/admin/src/fonts.ts
+++ b/frontend/apps/admin/src/fonts.ts
@@ -1,0 +1,18 @@
+/**
+ * Admin 用 @fontsource 同梱。Widget には含めない。
+ * Latin: Inter（en, fr, de, pt-BR） / CJK: Noto Sans JP, Noto Sans SC
+ */
+import '@fontsource/inter/latin-400.css';
+import '@fontsource/inter/latin-500.css';
+import '@fontsource/inter/latin-600.css';
+import '@fontsource/inter/latin-ext-400.css';
+import '@fontsource/inter/latin-ext-500.css';
+import '@fontsource/inter/latin-ext-600.css';
+
+import '@fontsource/noto-sans-jp/japanese-400.css';
+import '@fontsource/noto-sans-jp/japanese-500.css';
+import '@fontsource/noto-sans-jp/japanese-600.css';
+
+import '@fontsource/noto-sans-sc/chinese-simplified-400.css';
+import '@fontsource/noto-sans-sc/chinese-simplified-500.css';
+import '@fontsource/noto-sans-sc/chinese-simplified-600.css';

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -1,1 +1,15 @@
 @import 'tailwindcss';
+
+@theme inline {
+  --font-sans: var(--nc-admin-font-family);
+}
+
+:root {
+  --nc-admin-font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+}
+
+@layer base {
+  body {
+    @apply font-sans antialiased;
+  }
+}

--- a/frontend/apps/admin/src/main.tsx
+++ b/frontend/apps/admin/src/main.tsx
@@ -1,8 +1,16 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { LocaleProvider } from '@nene-corpus/i18n';
+import {
+  LocaleProvider,
+  LOCALE_STORAGE_KEY,
+  applyLocaleFontFamily,
+  resolveInitialLocale,
+} from '@nene-corpus/i18n';
 import { App } from './App';
+import './fonts';
 import './index.css';
+
+applyLocaleFontFamily(resolveInitialLocale(LOCALE_STORAGE_KEY));
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,9 @@
       "name": "@nene-corpus/admin",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/noto-sans-jp": "^5.2.9",
+        "@fontsource/noto-sans-sc": "^5.2.9",
         "@nene-corpus/api-client": "*",
         "@nene-corpus/i18n": "*",
         "@nene-corpus/tokens": "*",
@@ -773,6 +776,33 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-jp": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-jp/-/noto-sans-jp-5.2.9.tgz",
+      "integrity": "sha512-6yVGiofnrnbiJjU8ch4JGSs2HqyozxMvsVyVmFwOnDH3u//qQKLqmKM4n0lqN0637uaJNzUW9nIJqbbMgHVQzw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/noto-sans-sc": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans-sc/-/noto-sans-sc-5.2.9.tgz",
+      "integrity": "sha512-bTUIWGBgJDpwi5qAr+x0/lcgv80IHTB9vl6s2f6EymZEa7qYV99yNRBZuKFT+SYDKVunZrjCEhWtpxqmbXWl5Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/frontend/packages/i18n/src/index.ts
+++ b/frontend/packages/i18n/src/index.ts
@@ -12,6 +12,12 @@ export {
 } from './locale';
 export { formatTimestamp, toBcp47 } from './format';
 export {
+  ADMIN_FONT_FAMILY_VAR,
+  LOCALE_FONT_STACKS,
+  applyLocaleFontFamily,
+  getLocaleFontStack,
+} from './locale-fonts';
+export {
   DEFAULT_LOCALE,
   LOCALE_STORAGE_KEY,
   WIDGET_LOCALE_STORAGE_KEY,

--- a/frontend/packages/i18n/src/locale-fonts.ts
+++ b/frontend/packages/i18n/src/locale-fonts.ts
@@ -1,0 +1,28 @@
+import type { SupportedLocale } from './types';
+
+/** Admin SPA が `document.documentElement` に設定する CSS 変数名。 */
+export const ADMIN_FONT_FAMILY_VAR = '--nc-admin-font-family';
+
+/**
+ * ロケール別 UI フォント（@fontsource 同梱体名と一致させる）。
+ * Latin 系は Inter、CJK は Noto Sans 系でビジネス向けのトーンを揃える。
+ */
+export const LOCALE_FONT_STACKS: Record<SupportedLocale, string> = {
+  en: '"Inter", ui-sans-serif, system-ui, sans-serif',
+  ja: '"Noto Sans JP", "Hiragino Sans", "Yu Gothic UI", sans-serif',
+  fr: '"Inter", ui-sans-serif, system-ui, sans-serif',
+  'zh-Hans': '"Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif',
+  'pt-BR': '"Inter", ui-sans-serif, system-ui, sans-serif',
+  de: '"Inter", ui-sans-serif, system-ui, sans-serif',
+};
+
+export function getLocaleFontStack(locale: SupportedLocale): string {
+  return LOCALE_FONT_STACKS[locale];
+}
+
+export function applyLocaleFontFamily(
+  locale: SupportedLocale,
+  root: HTMLElement = document.documentElement,
+): void {
+  root.style.setProperty(ADMIN_FONT_FAMILY_VAR, getLocaleFontStack(locale));
+}


### PR DESCRIPTION
## Summary

- `@fontsource/inter`（en, fr, de, pt-BR）、`noto-sans-jp`（ja）、`noto-sans-sc`（zh-Hans）を Admin に同梱
- `packages/i18n/src/locale-fonts.ts` でスタック正本化、`--nc-admin-font-family` → Tailwind `font-sans`
- ロケール切替・初回ロード時にフォントスタックを適用
- Widget は対象外

Closes #75

## Test plan

- [ ] Admin を開き、英語で Inter が適用される（DevTools → Computed → font-family）
- [ ] 日本語に切替 → Noto Sans JP に変わる
- [ ] 简体中文 → Noto Sans SC
- [ ] リロード後も維持
- [ ] `npm run check --prefix frontend` / admin build 成功

Made with [Cursor](https://cursor.com)