### PR TITLE
feat(admin): AI系UIトーンとダーク/ライトモード (#77)

### DIFF
--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -60,6 +60,7 @@ frontend/
 - Wrap admin and widget roots with `LocaleProvider`. Admin: `nene-corpus.admin.locale`; widget: `nene-corpus.widget.locale`. Initial locale: `localStorage` → browser language → `en`.
 - Admin header exposes a locale `<select>` (`LocaleSelector`) — preference is **localStorage only** (no server persistence).
 - **Typography (Admin):** locale-aware stacks via `@fontsource` — Inter (Latin locales), Noto Sans JP (`ja`), Noto Sans SC (`zh-Hans`). Bundled in admin only; `--nc-admin-font-family` on `:root` drives Tailwind `font-sans`. Widget unchanged.
+- **Theme (Admin):** light/dark via CSS variables on `:root` / `.dark`. Toggle in header; persist `nene-corpus.admin.theme` (`light` | `dark`, default from `prefers-color-scheme`). Small radius tokens (`rounded-admin*` ≈ 4–8px), subtle page gradient, glassy header (`backdrop-blur`). Reuse `nc-panel`, `nc-input`, `nc-btn*` component classes.
 - Use `formatTimestamp(value, locale)` for locale-aware dates.
 - Pair labels with optional help via `HelpLabel` (`label` + `help` strings from `Msg.*Help` keys). Tooltip opens on hover and keyboard focus; use `\n` in help strings for line breaks. CSV column mapping also has a collapsible `ColumnMappingGuide` accordion after preview.
 

--- a/frontend/apps/admin/index.html
+++ b/frontend/apps/admin/index.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NeNe Corpus Admin</title>
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('nene-corpus.admin.theme');
+          var dark =
+            stored === 'dark' ||
+            (stored !== 'light' &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (dark) {
+            document.documentElement.classList.add('dark');
+            document.documentElement.dataset.theme = 'dark';
+          }
+        } catch (e) {
+          /* ignore */
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -6,6 +6,7 @@ import { IngestionPanel } from './IngestionPanel';
 import { ConversationLogsPanel } from './ConversationLogsPanel';
 import { AppearancePanel } from './AppearancePanel';
 import { LocaleSelector } from './LocaleSelector';
+import { ThemeToggle } from './ThemeToggle';
 import { useAdminAuth } from './useAdminAuth';
 
 export function App() {
@@ -28,19 +29,19 @@ export function App() {
 
   if (!isReady) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-50 text-slate-600">
+      <div className="flex min-h-screen items-center justify-center text-fg-muted">
         {t(Msg.common.loading)}
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 text-slate-900">
-      <header className="border-b border-slate-200 bg-white px-6 py-4">
+    <div className="min-h-screen text-fg">
+      <header className="sticky top-0 z-40 border-b border-border bg-header/80 px-6 py-4 backdrop-blur-md">
         <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
           <div>
-            <h1 className="text-xl font-semibold">{t(Msg.admin.app.title)}</h1>
-            <p className="text-sm text-slate-600">
+            <h1 className="text-xl font-semibold tracking-tight">{t(Msg.admin.app.title)}</h1>
+            <p className="text-sm text-fg-muted">
               {health
                 ? t(Msg.admin.app.healthStatus, {
                     service: health.service,
@@ -49,16 +50,13 @@ export function App() {
                 : t(Msg.admin.app.healthUnavailable)}
             </p>
           </div>
-          <div className="flex flex-wrap items-center justify-end gap-3 text-sm">
+          <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
+            <ThemeToggle />
             <LocaleSelector />
             {profile && (
               <>
-                <span className="text-slate-600">{profile.email}</span>
-                <button
-                  className="rounded-md border border-slate-300 px-3 py-1.5 hover:bg-slate-50"
-                  type="button"
-                  onClick={logout}
-                >
+                <span className="text-fg-muted">{profile.email}</span>
+                <button className="nc-btn" type="button" onClick={logout}>
                   {t(Msg.common.signOut)}
                 </button>
               </>

--- a/frontend/apps/admin/src/AppearancePanel.tsx
+++ b/frontend/apps/admin/src/AppearancePanel.tsx
@@ -125,19 +125,19 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
   }
 
   return (
-    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
-      <div className="border-b border-slate-200 px-4 py-3">
+    <section className="nc-panel">
+      <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.appearance.title)}</h2>
-        <p className="text-sm text-slate-600">{t(Msg.admin.appearance.subtitle)}</p>
+        <p className="text-sm text-fg-muted">{t(Msg.admin.appearance.subtitle)}</p>
       </div>
       {isLoading ? (
-        <p className="px-4 py-6 text-sm text-slate-600">{t(Msg.common.loading)}</p>
+        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.common.loading)}</p>
       ) : (
         <form className="space-y-4 px-4 py-4" onSubmit={(event) => void handleSubmit(event)}>
           <label className="block text-sm">
-            <span className="font-medium text-slate-700">{t(Msg.admin.appearance.widgetLocale)}</span>
+            <span className="font-medium text-fg">{t(Msg.admin.appearance.widgetLocale)}</span>
             <select
-              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+              className="nc-input"
               value={widgetLocale}
               onChange={(event) => setWidgetLocale(event.target.value)}
             >
@@ -165,9 +165,9 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
               onChange={(value) => updateThemeField('color_text', value)}
             />
             <label className="block text-sm">
-              <span className="font-medium text-slate-700">{t(Msg.admin.appearance.radiusMd)}</span>
+              <span className="font-medium text-fg">{t(Msg.admin.appearance.radiusMd)}</span>
               <input
-                className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+                className="nc-input"
                 type="text"
                 value={theme.radius_md}
                 onChange={(event) => updateThemeField('radius_md', event.target.value)}
@@ -175,18 +175,14 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
             </label>
           </div>
           <div>
-            <h3 className="text-sm font-medium text-slate-700">{t(Msg.admin.appearance.previewTitle)}</h3>
+            <h3 className="text-sm font-medium text-fg">{t(Msg.admin.appearance.previewTitle)}</h3>
             <iframe
-              className="mt-2 h-80 w-full rounded-md border border-slate-200 bg-white"
+              className="mt-2 h-80 w-full rounded-admin border border-border bg-white"
               title={t(Msg.admin.appearance.previewTitle)}
               src={previewSrc}
             />
           </div>
-          <button
-            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
-            type="submit"
-            disabled={isSaving}
-          >
+          <button className="nc-btn-primary" type="submit" disabled={isSaving}>
             {isSaving ? t(Msg.admin.appearance.saving) : t(Msg.admin.appearance.save)}
           </button>
           {error !== null && <p className="text-sm text-red-600">{error}</p>}
@@ -206,16 +202,16 @@ interface ColorFieldProps {
 function ColorField({ label, value, onChange }: ColorFieldProps) {
   return (
     <label className="block text-sm">
-      <span className="font-medium text-slate-700">{label}</span>
+      <span className="font-medium text-fg">{label}</span>
       <div className="mt-1 flex items-center gap-2">
         <input
-          className="h-10 w-12 cursor-pointer rounded border border-slate-300"
+          className="h-10 w-12 cursor-pointer rounded-admin border border-border-strong"
           type="color"
           value={value}
           onChange={(event) => onChange(event.target.value)}
         />
         <input
-          className="w-full rounded-md border border-slate-300 px-3 py-2 font-mono text-xs"
+          className="nc-input font-mono text-xs"
           type="text"
           value={value}
           onChange={(event) => onChange(event.target.value)}

--- a/frontend/apps/admin/src/ColumnMappingGuide.tsx
+++ b/frontend/apps/admin/src/ColumnMappingGuide.tsx
@@ -4,19 +4,19 @@ export function ColumnMappingGuide() {
   const t = useMsg();
 
   return (
-    <details className="group rounded-md border border-sky-200 bg-sky-50/60 text-sm text-slate-700">
-      <summary className="cursor-pointer list-none px-3 py-2.5 font-medium text-sky-950 marker:content-none [&::-webkit-details-marker]:hidden">
+    <details className="group rounded-admin border border-accent-border bg-accent text-sm text-fg-muted">
+      <summary className="cursor-pointer list-none px-3 py-2.5 font-medium text-fg marker:content-none [&::-webkit-details-marker]:hidden">
         <span className="inline-flex items-center gap-2">
           <span
             aria-hidden
-            className="inline-block text-sky-600 transition-transform group-open:rotate-90"
+            className="inline-block text-focus transition-transform group-open:rotate-90"
           >
             ▶
           </span>
           {t(Msg.admin.ingestion.columnMappingGuideTitle)}
         </span>
       </summary>
-      <div className="space-y-3 border-t border-sky-200 px-3 py-3 leading-relaxed">
+      <div className="space-y-3 border-t border-accent-border px-3 py-3 leading-relaxed">
         <p className="whitespace-pre-line">{t(Msg.admin.ingestion.columnMappingGuideIntro)}</p>
         <GuideSection title={t(Msg.admin.ingestion.columnMappingGuideTitleHeading)} body={t(Msg.admin.ingestion.columnMappingGuideTitleBody)} />
         <GuideSection title={t(Msg.admin.ingestion.columnMappingGuideContentHeading)} body={t(Msg.admin.ingestion.columnMappingGuideContentBody)} />
@@ -35,8 +35,8 @@ interface GuideSectionProps {
 function GuideSection({ title, body }: GuideSectionProps) {
   return (
     <section>
-      <h4 className="font-medium text-slate-900">{title}</h4>
-      <p className="mt-1 whitespace-pre-line text-slate-600">{body}</p>
+      <h4 className="font-medium text-fg">{title}</h4>
+      <p className="mt-1 whitespace-pre-line text-fg-muted">{body}</p>
     </section>
   );
 }

--- a/frontend/apps/admin/src/ConversationLogsPanel.tsx
+++ b/frontend/apps/admin/src/ConversationLogsPanel.tsx
@@ -94,26 +94,26 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
   }, [token, selectedSessionId, t]);
 
   return (
-    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
-      <div className="border-b border-slate-200 px-4 py-3">
+    <section className="nc-panel">
+      <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.conversationLogs.title)}</h2>
-        <p className="text-sm text-slate-600">{t(Msg.admin.conversationLogs.subtitle)}</p>
+        <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.subtitle)}</p>
       </div>
 
       {isLoadingSessions && (
-        <p className="px-4 py-6 text-sm text-slate-600">{t(Msg.admin.conversationLogs.loadingSessions)}</p>
+        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.conversationLogs.loadingSessions)}</p>
       )}
       {error !== null && <p className="px-4 py-6 text-sm text-red-600">{error}</p>}
 
       {!isLoadingSessions && error === null && sessions.length === 0 && (
-        <p className="px-4 py-6 text-sm text-slate-600">{t(Msg.admin.conversationLogs.empty)}</p>
+        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.conversationLogs.empty)}</p>
       )}
 
       {!isLoadingSessions && sessions.length > 0 && (
         <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
-          <div className="overflow-x-auto border-b border-slate-200 lg:border-b-0 lg:border-r">
+          <div className="overflow-x-auto border-b border-border lg:border-b-0 lg:border-r">
             <table className="min-w-full text-sm">
-              <thead className="bg-slate-50 text-left text-slate-600">
+              <thead className="nc-table-head">
                 <tr>
                   <th className="px-4 py-2 font-medium">
                     <HelpLabel
@@ -142,14 +142,14 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                   return (
                     <tr
                       key={session.session_id}
-                      className={`border-t border-slate-100 cursor-pointer ${
-                        isSelected ? 'bg-sky-50' : 'hover:bg-slate-50'
+                      className={`nc-table-row cursor-pointer ${
+                        isSelected ? 'bg-accent' : 'hover:bg-surface-muted'
                       }`}
                       onClick={() => setSelectedSessionId(session.session_id)}
                     >
                       <td className="px-4 py-2 font-medium tabular-nums">#{session.session_id}</td>
                       <td className="px-4 py-2 tabular-nums">{session.message_count}</td>
-                      <td className="px-4 py-2 text-slate-600">
+                      <td className="px-4 py-2 text-fg-muted">
                         {formatTimestamp(session.last_message_at ?? session.updated_at, locale)}
                       </td>
                     </tr>
@@ -161,26 +161,26 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
 
           <div className="px-4 py-4">
             {selectedSessionId === null && (
-              <p className="text-sm text-slate-600">{t(Msg.admin.conversationLogs.selectSession)}</p>
+              <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.selectSession)}</p>
             )}
             {selectedSessionId !== null && isLoadingMessages && (
-              <p className="text-sm text-slate-600">{t(Msg.admin.conversationLogs.loadingMessages)}</p>
+              <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.loadingMessages)}</p>
             )}
             {selectedSessionId !== null && !isLoadingMessages && messages.length === 0 && (
-              <p className="text-sm text-slate-600">{t(Msg.admin.conversationLogs.emptyMessages)}</p>
+              <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.emptyMessages)}</p>
             )}
             {selectedSessionId !== null && !isLoadingMessages && messages.length > 0 && (
               <ul className="space-y-4">
                 {messages.map((message) => (
                   <li
                     key={message.message_id}
-                    className={`rounded-md border px-3 py-2 ${
+                    className={`rounded-admin border px-3 py-2 ${
                       message.role === 'assistant'
-                        ? 'border-sky-200 bg-sky-50'
-                        : 'border-slate-200 bg-slate-50'
+                        ? 'border-accent-border bg-accent'
+                        : 'border-border bg-surface-muted'
                     }`}
                   >
-                    <div className="mb-1 flex items-center justify-between gap-2 text-xs text-slate-500">
+                    <div className="mb-1 flex items-center justify-between gap-2 text-xs text-fg-subtle">
                       <span className="uppercase tracking-wide">{t(ROLE_MSG[message.role])}</span>
                       <time dateTime={message.created_at}>
                         {formatTimestamp(message.created_at, locale)}
@@ -188,7 +188,7 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                     </div>
                     <p className="whitespace-pre-wrap text-sm">{message.content}</p>
                     {message.citations.length > 0 && (
-                      <ul className="mt-2 space-y-1 border-t border-slate-200 pt-2 text-xs text-slate-600">
+                      <ul className="mt-2 space-y-1 border-t border-border pt-2 text-xs text-fg-muted">
                         {message.citations.map((citation) => (
                           <li key={citation.chunk_id}>
                             <span className="font-medium">
@@ -203,7 +203,7 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                             {citation.section_label !== undefined && (
                               <span> · {citation.section_label}</span>
                             )}
-                            <p className="mt-0.5 text-slate-500">{citation.excerpt}</p>
+                            <p className="mt-0.5 text-fg-subtle">{citation.excerpt}</p>
                           </li>
                         ))}
                       </ul>

--- a/frontend/apps/admin/src/HelpLabel.tsx
+++ b/frontend/apps/admin/src/HelpLabel.tsx
@@ -65,7 +65,7 @@ export function HelpLabel({ label, help, className = '' }: HelpLabelProps) {
           <span
             id={tooltipId}
             role="tooltip"
-            className="pointer-events-none fixed z-50 w-72 max-w-[calc(100vw-1.5rem)] rounded-md border border-slate-200 bg-white px-3 py-2.5 text-left text-xs font-normal normal-case leading-relaxed tracking-normal whitespace-pre-line text-slate-600 shadow-lg"
+            className="pointer-events-none fixed z-50 w-72 max-w-[calc(100vw-1.5rem)] rounded-admin border border-border bg-surface px-3 py-2.5 text-left text-xs font-normal normal-case leading-relaxed tracking-normal whitespace-pre-line text-fg-muted shadow-lg shadow-black/10"
             style={{ top: coords.top, left: coords.left }}
           >
             {help}
@@ -81,7 +81,7 @@ export function HelpLabel({ label, help, className = '' }: HelpLabelProps) {
         <button
           ref={buttonRef}
           type="button"
-          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-slate-300 bg-slate-50 text-[10px] font-semibold leading-none text-slate-600 hover:border-slate-400 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-1"
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-border-strong bg-surface-muted text-[10px] font-semibold leading-none text-fg-muted hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-focus/40 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent"
           aria-describedby={isOpen ? tooltipId : undefined}
           aria-expanded={isOpen}
           aria-label={`${t(Msg.common.showHelp)}: ${label}`}

--- a/frontend/apps/admin/src/IngestionPanel.tsx
+++ b/frontend/apps/admin/src/IngestionPanel.tsx
@@ -147,20 +147,20 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
   }
 
   return (
-    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
-      <div className="border-b border-slate-200 px-4 py-3">
+    <section className="nc-panel">
+      <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.ingestion.title)}</h2>
-        <p className="text-sm text-slate-600">{t(Msg.admin.ingestion.subtitle)}</p>
+        <p className="text-sm text-fg-muted">{t(Msg.admin.ingestion.subtitle)}</p>
       </div>
       <form className="space-y-4 px-4 py-4" onSubmit={(event) => void handlePreview(event)}>
         <label className="block text-sm">
           <HelpLabel
-            className="font-medium text-slate-700"
+            className="font-medium text-fg"
             label={t(Msg.admin.ingestion.sourceName)}
             help={t(Msg.admin.ingestion.sourceNameHelp)}
           />
           <input
-            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+            className="nc-input"
             type="text"
             value={name}
             onChange={(event) => setName(event.target.value)}
@@ -169,12 +169,12 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
         </label>
         <label className="block text-sm">
           <HelpLabel
-            className="font-medium text-slate-700"
+            className="font-medium text-fg"
             label={t(Msg.admin.ingestion.file)}
             help={t(Msg.admin.ingestion.fileHelp)}
           />
           <input
-            className="mt-1 block w-full text-sm text-slate-600"
+            className="mt-1 block w-full text-sm text-fg-muted"
             type="file"
             accept=".csv,.pdf,text/csv,application/pdf"
             onChange={(event) => handleFileChange(event.target.files?.[0] ?? null)}
@@ -184,19 +184,15 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
           <p className="text-sm text-red-600">{t(Msg.admin.ingestion.unsupportedFile)}</p>
         )}
         {file !== null && sourceType !== null && csvPreview === null && pdfPreview === null && (
-          <button
-            className="rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
-            type="submit"
-            disabled={isPreviewing}
-          >
+          <button className="nc-btn-primary" type="submit" disabled={isPreviewing}>
             {isPreviewing ? t(Msg.admin.ingestion.previewing) : t(Msg.admin.ingestion.previewFile)}
           </button>
         )}
       </form>
 
       {csvPreview !== null && (
-        <div className="space-y-4 border-t border-slate-200 px-4 py-4">
-          <p className="text-sm text-slate-600">
+        <div className="space-y-4 border-t border-border px-4 py-4">
+          <p className="text-sm text-fg-muted">
             {t(Msg.admin.ingestion.csvSummary, {
               count: csvPreview.row_count,
               delimiter: csvPreview.detected_delimiter,
@@ -217,11 +213,11 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
       )}
 
       {pdfPreview !== null && (
-        <div className="space-y-3 border-t border-slate-200 px-4 py-4">
-          <p className="text-sm text-slate-600">
+        <div className="space-y-3 border-t border-border px-4 py-4">
+          <p className="text-sm text-fg-muted">
             {t(Msg.admin.ingestion.pdfPageCount, { count: pdfPreview.page_count })}
           </p>
-          <pre className="max-h-40 overflow-auto rounded-md bg-slate-50 p-3 text-xs text-slate-700 whitespace-pre-wrap">
+          <pre className="max-h-40 overflow-auto rounded-admin bg-surface-muted p-3 text-xs text-fg whitespace-pre-wrap">
             {pdfPreview.sample_text.slice(0, 800)}
             {pdfPreview.sample_text.length > 800 ? '…' : ''}
           </pre>
@@ -229,9 +225,9 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
       )}
 
       {(csvPreview !== null || pdfPreview !== null) && (
-        <div className="border-t border-slate-200 px-4 py-4">
+        <div className="border-t border-border px-4 py-4">
           <button
-            className="rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+            className="nc-btn-success"
             type="button"
             disabled={isSubmitting || (sourceType === 'csv' && contentColumns.length === 0)}
             onClick={() => void handleIngest()}
@@ -289,12 +285,12 @@ function ColumnMappingEditor({
     <div className="grid gap-4 md:grid-cols-3">
       <label className="block text-sm">
         <HelpLabel
-          className="font-medium text-slate-700"
+          className="font-medium text-fg"
           label={t(Msg.admin.ingestion.titleColumn)}
           help={t(Msg.admin.ingestion.titleColumnHelp)}
         />
         <select
-          className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+          className="nc-input"
           value={titleColumn}
           onChange={(event) => onTitleColumnChange(event.target.value)}
         >
@@ -306,7 +302,7 @@ function ColumnMappingEditor({
         </select>
       </label>
       <fieldset className="text-sm">
-        <legend className="font-medium text-slate-700">
+        <legend className="font-medium text-fg">
           <HelpLabel
             label={t(Msg.admin.ingestion.contentColumns)}
             help={t(Msg.admin.ingestion.contentColumnsHelp)}
@@ -326,7 +322,7 @@ function ColumnMappingEditor({
         </div>
       </fieldset>
       <fieldset className="text-sm">
-        <legend className="font-medium text-slate-700">
+        <legend className="font-medium text-fg">
           <HelpLabel
             label={t(Msg.admin.ingestion.metadataColumns)}
             help={t(Msg.admin.ingestion.metadataColumnsHelp)}
@@ -356,9 +352,9 @@ interface PreviewTableProps {
 
 function PreviewTable({ headers, rows }: PreviewTableProps) {
   return (
-    <div className="overflow-x-auto rounded-md border border-slate-200">
+    <div className="overflow-x-auto rounded-admin border border-border">
       <table className="min-w-full text-xs">
-        <thead className="bg-slate-50 text-left text-slate-600">
+        <thead className="nc-table-head">
           <tr>
             {headers.map((header) => (
               <th key={header} className="px-3 py-2 font-medium">
@@ -369,7 +365,7 @@ function PreviewTable({ headers, rows }: PreviewTableProps) {
         </thead>
         <tbody>
           {rows.map((row, index) => (
-            <tr key={index} className="border-t border-slate-100">
+            <tr key={index} className="nc-table-row">
               {row.map((cell, cellIndex) => (
                 <td key={cellIndex} className="px-3 py-2">
                   {cell}

--- a/frontend/apps/admin/src/LocaleSelector.tsx
+++ b/frontend/apps/admin/src/LocaleSelector.tsx
@@ -14,10 +14,10 @@ export function LocaleSelector() {
   const { locale, setLocale, supportedLocales } = useLocale();
 
   return (
-    <label className="flex items-center gap-2 text-sm text-slate-600">
+    <label className="flex items-center gap-2 text-sm text-fg-muted">
       <span className="whitespace-nowrap">{t(Msg.admin.app.language)}</span>
       <select
-        className="rounded-md border border-slate-300 bg-white px-2 py-1.5 text-slate-900"
+        className="nc-select px-2 py-1.5"
         value={locale}
         aria-label={t(Msg.admin.app.language)}
         onChange={(event) => setLocale(event.target.value as SupportedLocale)}

--- a/frontend/apps/admin/src/SourcesPanel.tsx
+++ b/frontend/apps/admin/src/SourcesPanel.tsx
@@ -48,20 +48,20 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
   }, [token, reloadKey, t]);
 
   return (
-    <section className="rounded-lg border border-slate-200 bg-white shadow-sm">
-      <div className="border-b border-slate-200 px-4 py-3">
+    <section className="nc-panel">
+      <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.sources.title)}</h2>
-        <p className="text-sm text-slate-600">{t(Msg.admin.sources.subtitle)}</p>
+        <p className="text-sm text-fg-muted">{t(Msg.admin.sources.subtitle)}</p>
       </div>
-      {isLoading && <p className="px-4 py-6 text-sm text-slate-600">{t(Msg.admin.sources.loading)}</p>}
+      {isLoading && <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.sources.loading)}</p>}
       {error !== null && <p className="px-4 py-6 text-sm text-red-600">{error}</p>}
       {!isLoading && error === null && sources.length === 0 && (
-        <p className="px-4 py-6 text-sm text-slate-600">{t(Msg.admin.sources.empty)}</p>
+        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.sources.empty)}</p>
       )}
       {!isLoading && sources.length > 0 && (
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
-            <thead className="bg-slate-50 text-left text-slate-600">
+            <thead className="nc-table-head">
               <tr>
                 <th className="px-4 py-2 font-medium">{t(Msg.admin.sources.columnName)}</th>
                 <th className="px-4 py-2 font-medium">{t(Msg.admin.sources.columnType)}</th>
@@ -88,9 +88,9 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
             </thead>
             <tbody>
               {sources.map((source) => (
-                <tr key={source.source_id} className="border-t border-slate-100">
+                <tr key={source.source_id} className="nc-table-row">
                   <td className="px-4 py-2 font-medium">{source.name}</td>
-                  <td className="px-4 py-2 uppercase text-xs tracking-wide text-slate-500">
+                  <td className="px-4 py-2 uppercase text-xs tracking-wide text-fg-subtle">
                     {t(SOURCE_TYPE_MSG[source.source_type])}
                   </td>
                   <td className="px-4 py-2">
@@ -98,7 +98,7 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
                   </td>
                   <td className="px-4 py-2 tabular-nums">{source.document_count}</td>
                   <td className="px-4 py-2 tabular-nums">{source.chunk_count}</td>
-                  <td className="px-4 py-2 text-slate-600">
+                  <td className="px-4 py-2 text-fg-muted">
                     {formatTimestamp(source.updated_at, locale)}
                   </td>
                 </tr>
@@ -114,10 +114,10 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
 function StatusBadge({ status }: { status: SourceListItem['status'] }) {
   const t = useMsg();
   const styles: Record<SourceListItem['status'], string> = {
-    pending: 'bg-slate-100 text-slate-700',
-    processing: 'bg-amber-100 text-amber-800',
-    ready: 'bg-emerald-100 text-emerald-800',
-    failed: 'bg-red-100 text-red-800',
+    pending: 'bg-surface-muted text-fg-muted',
+    processing: 'bg-amber-500/15 text-amber-700',
+    ready: 'bg-emerald-500/15 text-emerald-700',
+    failed: 'bg-red-500/15 text-red-700',
   };
 
   return (
@@ -150,14 +150,14 @@ export function LoginForm({ error, onLogin }: LoginFormProps) {
   }
 
   return (
-    <section className="mx-auto max-w-md rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+    <section className="nc-panel mx-auto max-w-md p-6">
       <h2 className="text-lg font-medium">{t(Msg.admin.auth.title)}</h2>
-      <p className="mt-1 text-sm text-slate-600">{t(Msg.admin.auth.subtitle)}</p>
+      <p className="mt-1 text-sm text-fg-muted">{t(Msg.admin.auth.subtitle)}</p>
       <form className="mt-4 space-y-4" onSubmit={(event) => void handleSubmit(event)}>
         <label className="block text-sm">
-          <span className="font-medium text-slate-700">{t(Msg.admin.auth.email)}</span>
+          <span className="font-medium text-fg">{t(Msg.admin.auth.email)}</span>
           <input
-            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+            className="nc-input"
             type="email"
             autoComplete="username"
             value={email}
@@ -166,9 +166,9 @@ export function LoginForm({ error, onLogin }: LoginFormProps) {
           />
         </label>
         <label className="block text-sm">
-          <span className="font-medium text-slate-700">{t(Msg.admin.auth.password)}</span>
+          <span className="font-medium text-fg">{t(Msg.admin.auth.password)}</span>
           <input
-            className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2"
+            className="nc-input"
             type="password"
             autoComplete="current-password"
             value={password}
@@ -177,11 +177,7 @@ export function LoginForm({ error, onLogin }: LoginFormProps) {
           />
         </label>
         {error !== null && <p className="text-sm text-red-600">{error}</p>}
-        <button
-          className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
-          type="submit"
-          disabled={isSubmitting}
-        >
+        <button className="nc-btn-primary w-full" type="submit" disabled={isSubmitting}>
           {isSubmitting ? t(Msg.admin.auth.submitting) : t(Msg.admin.auth.submit)}
         </button>
       </form>

--- a/frontend/apps/admin/src/ThemeProvider.tsx
+++ b/frontend/apps/admin/src/ThemeProvider.tsx
@@ -1,0 +1,63 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  applyAdminTheme,
+  resolveInitialAdminTheme,
+  toggleAdminTheme,
+  writeStoredAdminTheme,
+  type AdminTheme,
+} from './theme';
+
+interface ThemeContextValue {
+  theme: AdminTheme;
+  setTheme: (theme: AdminTheme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<AdminTheme>(() => resolveInitialAdminTheme());
+
+  const setTheme = useCallback((nextTheme: AdminTheme) => {
+    setThemeState(nextTheme);
+    applyAdminTheme(nextTheme);
+    writeStoredAdminTheme(nextTheme);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => {
+      const nextTheme = toggleAdminTheme(current);
+      applyAdminTheme(nextTheme);
+      writeStoredAdminTheme(nextTheme);
+      return nextTheme;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useAdminTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+
+  if (context === null) {
+    throw new Error('useAdminTheme must be used within ThemeProvider.');
+  }
+
+  return context;
+}

--- a/frontend/apps/admin/src/ThemeToggle.tsx
+++ b/frontend/apps/admin/src/ThemeToggle.tsx
@@ -1,0 +1,36 @@
+import { Msg, useMsg } from '@nene-corpus/i18n';
+import { useAdminTheme } from './ThemeProvider';
+
+export function ThemeToggle() {
+  const t = useMsg();
+  const { theme, toggleTheme } = useAdminTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      className="nc-btn inline-flex items-center justify-center p-2"
+      aria-label={isDark ? t(Msg.admin.app.themeLight) : t(Msg.admin.app.themeDark)}
+      title={isDark ? t(Msg.admin.app.themeLight) : t(Msg.admin.app.themeDark)}
+      onClick={toggleTheme}
+    >
+      {isDark ? (
+        <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.75">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 3v2.25M12 18.75V21M4.219 4.219l1.591 1.591M18.19 18.19l1.591 1.591M3 12h2.25M18.75 12H21M4.219 19.781l1.591-1.591M18.19 5.81l1.591-1.591M16.5 12a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z"
+          />
+        </svg>
+      ) : (
+        <svg aria-hidden="true" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.75">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21.752 15.002A9.718 9.718 0 0 1 12 21.75c-5.385 0-9.75-4.365-9.75-9.75 0-4.102 2.554-7.606 6.163-9.027.49-.184 1.026.188 1.026.704v1.332a7.522 7.522 0 0 0 3.022 5.916c.317.263.346.734.06 1.028l-1.684 1.755Z"
+          />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -2,14 +2,120 @@
 
 @theme inline {
   --font-sans: var(--nc-admin-font-family);
+  --radius-admin-sm: 0.25rem;
+  --radius-admin: 0.375rem;
+  --radius-admin-lg: 0.5rem;
+  --color-surface: var(--nc-admin-surface);
+  --color-surface-muted: var(--nc-admin-surface-muted);
+  --color-header: var(--nc-admin-header);
+  --color-border: var(--nc-admin-border);
+  --color-border-subtle: var(--nc-admin-border-subtle);
+  --color-border-strong: var(--nc-admin-border-strong);
+  --color-fg: var(--nc-admin-fg);
+  --color-fg-muted: var(--nc-admin-fg-muted);
+  --color-fg-subtle: var(--nc-admin-fg-subtle);
+  --color-primary: var(--nc-admin-primary);
+  --color-primary-fg: var(--nc-admin-primary-fg);
+  --color-accent: var(--nc-admin-accent);
+  --color-accent-border: var(--nc-admin-accent-border);
+  --color-focus: var(--nc-admin-focus);
 }
 
 :root {
+  color-scheme: light;
   --nc-admin-font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --nc-admin-bg-gradient: linear-gradient(
+    165deg,
+    #fafafa 0%,
+    #f4f4f5 45%,
+    #eceef2 100%
+  );
+  --nc-admin-surface: rgb(255 255 255 / 0.94);
+  --nc-admin-surface-muted: rgb(0 0 0 / 0.035);
+  --nc-admin-header: rgb(255 255 255 / 0.72);
+  --nc-admin-border: rgb(0 0 0 / 0.08);
+  --nc-admin-border-subtle: rgb(0 0 0 / 0.05);
+  --nc-admin-border-strong: rgb(0 0 0 / 0.13);
+  --nc-admin-fg: #171717;
+  --nc-admin-fg-muted: #525252;
+  --nc-admin-fg-subtle: #737373;
+  --nc-admin-primary: #171717;
+  --nc-admin-primary-fg: #ffffff;
+  --nc-admin-accent: rgb(59 130 246 / 0.1);
+  --nc-admin-accent-border: rgb(59 130 246 / 0.28);
+  --nc-admin-focus: #3b82f6;
+}
+
+.dark {
+  color-scheme: dark;
+  --nc-admin-bg-gradient: linear-gradient(
+    165deg,
+    #1c1c1c 0%,
+    #141414 45%,
+    #0a0a0a 100%
+  );
+  --nc-admin-surface: rgb(33 33 33 / 0.96);
+  --nc-admin-surface-muted: rgb(255 255 255 / 0.045);
+  --nc-admin-header: rgb(23 23 23 / 0.78);
+  --nc-admin-border: rgb(255 255 255 / 0.1);
+  --nc-admin-border-subtle: rgb(255 255 255 / 0.06);
+  --nc-admin-border-strong: rgb(255 255 255 / 0.16);
+  --nc-admin-fg: #ececec;
+  --nc-admin-fg-muted: #a3a3a3;
+  --nc-admin-fg-subtle: #737373;
+  --nc-admin-primary: #f5f5f5;
+  --nc-admin-primary-fg: #171717;
+  --nc-admin-accent: rgb(96 165 250 / 0.14);
+  --nc-admin-accent-border: rgb(96 165 250 / 0.35);
+  --nc-admin-focus: #60a5fa;
 }
 
 @layer base {
   body {
-    @apply font-sans antialiased;
+    @apply min-h-screen font-sans antialiased text-fg;
+    background: var(--nc-admin-bg-gradient);
+    background-attachment: fixed;
   }
+}
+
+@layer components {
+  .nc-panel {
+    @apply rounded-admin-lg border border-border bg-surface shadow-sm shadow-black/5;
+  }
+
+  .nc-panel-head {
+    @apply border-b border-border px-4 py-3;
+  }
+
+  .nc-input {
+    @apply mt-1 w-full rounded-admin border border-border-strong bg-surface px-3 py-2 text-fg outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/25;
+  }
+
+  .nc-select {
+    @apply rounded-admin border border-border-strong bg-surface px-2 py-1.5 text-fg outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/25;
+  }
+
+  .nc-btn {
+    @apply rounded-admin border border-border-strong px-3 py-1.5 text-fg transition-colors hover:bg-surface-muted;
+  }
+
+  .nc-btn-primary {
+    @apply rounded-admin bg-primary px-4 py-2 text-sm font-medium text-primary-fg transition-opacity hover:opacity-90 disabled:opacity-60;
+  }
+
+  .nc-btn-success {
+    @apply rounded-admin bg-emerald-700 px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-60;
+  }
+
+  .nc-table-head {
+    @apply bg-surface-muted text-left text-fg-muted;
+  }
+
+  .nc-table-row {
+    @apply border-t border-border-subtle;
+  }
+}
+
+.dark .nc-panel {
+  @apply shadow-black/20;
 }

--- a/frontend/apps/admin/src/main.tsx
+++ b/frontend/apps/admin/src/main.tsx
@@ -7,15 +7,20 @@ import {
   resolveInitialLocale,
 } from '@nene-corpus/i18n';
 import { App } from './App';
+import { ThemeProvider } from './ThemeProvider';
+import { applyAdminTheme, resolveInitialAdminTheme } from './theme';
 import './fonts';
 import './index.css';
 
 applyLocaleFontFamily(resolveInitialLocale(LOCALE_STORAGE_KEY));
+applyAdminTheme(resolveInitialAdminTheme());
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <LocaleProvider>
-      <App />
-    </LocaleProvider>
+    <ThemeProvider>
+      <LocaleProvider>
+        <App />
+      </LocaleProvider>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/frontend/apps/admin/src/theme.ts
+++ b/frontend/apps/admin/src/theme.ts
@@ -1,0 +1,34 @@
+export type AdminTheme = 'light' | 'dark';
+
+export const ADMIN_THEME_STORAGE_KEY = 'nene-corpus.admin.theme';
+
+export function resolveInitialAdminTheme(): AdminTheme {
+  try {
+    const stored = localStorage.getItem(ADMIN_THEME_STORAGE_KEY);
+
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+  } catch {
+    // localStorage unavailable — fall through to system preference.
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function applyAdminTheme(theme: AdminTheme, root: HTMLElement = document.documentElement): void {
+  root.classList.toggle('dark', theme === 'dark');
+  root.dataset.theme = theme;
+}
+
+export function writeStoredAdminTheme(theme: AdminTheme): void {
+  try {
+    localStorage.setItem(ADMIN_THEME_STORAGE_KEY, theme);
+  } catch {
+    // ignore quota / privacy mode
+  }
+}
+
+export function toggleAdminTheme(theme: AdminTheme): AdminTheme {
+  return theme === 'light' ? 'dark' : 'light';
+}

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -34,6 +34,8 @@ export const Msg = {
     app: {
       title: 'admin.app.title',
       language: 'admin.app.language',
+      themeLight: 'admin.app.themeLight',
+      themeDark: 'admin.app.themeDark',
       healthUnavailable: 'admin.app.healthUnavailable',
       healthStatus: 'admin.app.healthStatus',
     },

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -21,6 +21,8 @@ export const de = defineMessages({
   'sourceStatus.failed': 'Fehlgeschlagen',
   'admin.app.title': 'NeNe Corpus Admin',
   'admin.app.language': 'Admin-Sprache',
+  'admin.app.themeLight': 'Zum hellen Modus wechseln',
+  'admin.app.themeDark': 'Zum dunklen Modus wechseln',
   'admin.app.healthUnavailable': 'API-Status nicht verfügbar',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Admin-Anmeldung',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -21,6 +21,8 @@ export const en = defineMessages({
   'sourceStatus.failed': 'Failed',
   'admin.app.title': 'NeNe Corpus Admin',
   'admin.app.language': 'Admin language',
+  'admin.app.themeLight': 'Switch to light mode',
+  'admin.app.themeDark': 'Switch to dark mode',
   'admin.app.healthUnavailable': 'API health unavailable',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Admin login',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -21,6 +21,8 @@ export const fr = defineMessages({
   'sourceStatus.failed': 'Échec',
   'admin.app.title': 'Administration NeNe Corpus',
   'admin.app.language': 'Langue de l’administration',
+  'admin.app.themeLight': 'Passer en mode clair',
+  'admin.app.themeDark': 'Passer en mode sombre',
   'admin.app.healthUnavailable': 'État de l’API indisponible',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Connexion admin',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -21,6 +21,8 @@ export const ja = defineMessages({
   'sourceStatus.failed': '失敗',
   'admin.app.title': 'NeNe Corpus 管理画面',
   'admin.app.language': '管理画面の言語',
+  'admin.app.themeLight': 'ライトモードに切り替え',
+  'admin.app.themeDark': 'ダークモードに切り替え',
   'admin.app.healthUnavailable': 'API の状態を取得できません',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': '管理者ログイン',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -21,6 +21,8 @@ export const ptBr = defineMessages({
   'sourceStatus.failed': 'Falhou',
   'admin.app.title': 'Admin NeNe Corpus',
   'admin.app.language': 'Idioma do admin',
+  'admin.app.themeLight': 'Ativar modo claro',
+  'admin.app.themeDark': 'Ativar modo escuro',
   'admin.app.healthUnavailable': 'Status da API indisponível',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': 'Login admin',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -21,6 +21,8 @@ export const zhHans = defineMessages({
   'sourceStatus.failed': '失败',
   'admin.app.title': 'NeNe Corpus 管理后台',
   'admin.app.language': '管理后台语言',
+  'admin.app.themeLight': '切换到浅色模式',
+  'admin.app.themeDark': '切换到深色模式',
   'admin.app.healthUnavailable': '无法获取 API 状态',
   'admin.app.healthStatus': '{service} — {status}',
   'admin.auth.title': '管理员登录',


### PR DESCRIPTION
## Summary

- Notion / ChatGPT 系の Admin デザイントークン（小さめ角丸 `rounded-admin*`、控えめグラデ背景、ガラス風ヘッダー）
- ライト / ダーク切替（ヘッダーの太陽・月アイコン、`nene-corpus.admin.theme` に永続化）
- 全 Admin コンポーネントをセマンティック CSS 変数 + `nc-panel` / `nc-input` / `nc-btn*` に移行
- `index.html` インライン script でテーマ FOUC を抑制

Closes #77

## Test plan

- [ ] Admin を開き、背景グラデ・小さめ角丸のパネルが表示される
- [ ] ヘッダー右のテーマボタンでライト ↔ ダーク切替
- [ ] リロード後もテーマが維持される
- [ ] ログイン前後、各パネル（取り込み・ソース・会話ログ・外観）が両テーマで読みやすい
- [ ] `npm run check --prefix frontend` 成功

Made with [Cursor](https://cursor.com)