### PR TITLE
fix(admin): ライトモードの背景コントラストを強化 (#79)

### DIFF
--- a/frontend/apps/admin/src/AppearancePanel.tsx
+++ b/frontend/apps/admin/src/AppearancePanel.tsx
@@ -177,7 +177,7 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
           <div>
             <h3 className="text-sm font-medium text-fg">{t(Msg.admin.appearance.previewTitle)}</h3>
             <iframe
-              className="mt-2 h-80 w-full rounded-admin border border-border bg-white"
+              className="mt-2 h-80 w-full rounded-admin border border-border bg-surface"
               title={t(Msg.admin.appearance.previewTitle)}
               src={previewSrc}
             />

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -24,57 +24,65 @@
 :root {
   color-scheme: light;
   --nc-admin-font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --nc-admin-page: #e4e9f0;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
-    #fafafa 0%,
-    #f4f4f5 45%,
-    #eceef2 100%
+    #eef2f7 0%,
+    #e4e9f0 42%,
+    #d8dfe8 100%
   );
-  --nc-admin-surface: rgb(255 255 255 / 0.94);
-  --nc-admin-surface-muted: rgb(0 0 0 / 0.035);
-  --nc-admin-header: rgb(255 255 255 / 0.72);
-  --nc-admin-border: rgb(0 0 0 / 0.08);
-  --nc-admin-border-subtle: rgb(0 0 0 / 0.05);
-  --nc-admin-border-strong: rgb(0 0 0 / 0.13);
+  --nc-admin-surface: #ffffff;
+  --nc-admin-surface-muted: #f1f4f8;
+  --nc-admin-header: rgb(255 255 255 / 0.88);
+  --nc-admin-border: rgb(15 23 42 / 0.12);
+  --nc-admin-border-subtle: rgb(15 23 42 / 0.07);
+  --nc-admin-border-strong: rgb(15 23 42 / 0.18);
   --nc-admin-fg: #171717;
-  --nc-admin-fg-muted: #525252;
-  --nc-admin-fg-subtle: #737373;
+  --nc-admin-fg-muted: #475569;
+  --nc-admin-fg-subtle: #64748b;
   --nc-admin-primary: #171717;
   --nc-admin-primary-fg: #ffffff;
-  --nc-admin-accent: rgb(59 130 246 / 0.1);
-  --nc-admin-accent-border: rgb(59 130 246 / 0.28);
+  --nc-admin-accent: rgb(59 130 246 / 0.12);
+  --nc-admin-accent-border: rgb(59 130 246 / 0.32);
   --nc-admin-focus: #3b82f6;
 }
 
 .dark {
   color-scheme: dark;
+  --nc-admin-page: #0a0a0a;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
-    #1c1c1c 0%,
-    #141414 45%,
+    #1a1a1a 0%,
+    #121212 42%,
     #0a0a0a 100%
   );
-  --nc-admin-surface: rgb(33 33 33 / 0.96);
-  --nc-admin-surface-muted: rgb(255 255 255 / 0.045);
-  --nc-admin-header: rgb(23 23 23 / 0.78);
-  --nc-admin-border: rgb(255 255 255 / 0.1);
-  --nc-admin-border-subtle: rgb(255 255 255 / 0.06);
-  --nc-admin-border-strong: rgb(255 255 255 / 0.16);
+  --nc-admin-surface: #1f1f1f;
+  --nc-admin-surface-muted: #2a2a2a;
+  --nc-admin-header: rgb(23 23 23 / 0.9);
+  --nc-admin-border: rgb(255 255 255 / 0.12);
+  --nc-admin-border-subtle: rgb(255 255 255 / 0.07);
+  --nc-admin-border-strong: rgb(255 255 255 / 0.2);
   --nc-admin-fg: #ececec;
   --nc-admin-fg-muted: #a3a3a3;
   --nc-admin-fg-subtle: #737373;
   --nc-admin-primary: #f5f5f5;
   --nc-admin-primary-fg: #171717;
-  --nc-admin-accent: rgb(96 165 250 / 0.14);
-  --nc-admin-accent-border: rgb(96 165 250 / 0.35);
+  --nc-admin-accent: rgb(96 165 250 / 0.16);
+  --nc-admin-accent-border: rgb(96 165 250 / 0.38);
   --nc-admin-focus: #60a5fa;
 }
 
 @layer base {
+  html {
+    min-height: 100%;
+    background-color: var(--nc-admin-page);
+    background-image: var(--nc-admin-bg-gradient);
+    background-attachment: fixed;
+  }
+
   body {
     @apply min-h-screen font-sans antialiased text-fg;
-    background: var(--nc-admin-bg-gradient);
-    background-attachment: fixed;
+    background: transparent;
   }
 }
 
@@ -96,7 +104,7 @@
   }
 
   .nc-btn {
-    @apply rounded-admin border border-border-strong px-3 py-1.5 text-fg transition-colors hover:bg-surface-muted;
+    @apply rounded-admin border border-border-strong bg-surface px-3 py-1.5 text-fg transition-colors hover:bg-surface-muted;
   }
 
   .nc-btn-primary {
@@ -117,5 +125,5 @@
 }
 
 .dark .nc-panel {
-  @apply shadow-black/20;
+  @apply shadow-black/30;
 }


### PR DESCRIPTION
## Summary

- ページ背景グラデを `#eef2f7 → #d8dfe8` に変更（以前は `#fafafa` 付近で真っ白に見えた）
- パネル surface を不透明 `#ffffff`、テーブルヘッダーを `#f1f4f8` に
- 境界線の不透明度を上げ、html 要素にも背景を適用

Closes #79

## Test plan

- [ ] ライトモードでグレー系背景 + 白パネルのコントラストが見える
- [ ] ダークモードでもパネルと背景が分離して見える

Made with [Cursor](https://cursor.com)