### PR TITLE
style(admin): 背景を暗めに、補助テキストを小さく (#81)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -29,7 +29,7 @@ export function App() {
 
   if (!isReady) {
     return (
-      <div className="flex min-h-screen items-center justify-center text-fg-muted">
+      <div className="flex min-h-screen items-center justify-center nc-text-muted">
         {t(Msg.common.loading)}
       </div>
     );
@@ -41,7 +41,7 @@ export function App() {
         <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
           <div>
             <h1 className="text-xl font-semibold tracking-tight">{t(Msg.admin.app.title)}</h1>
-            <p className="text-sm text-fg-muted">
+            <p className="nc-text-muted">
               {health
                 ? t(Msg.admin.app.healthStatus, {
                     service: health.service,
@@ -55,7 +55,7 @@ export function App() {
             <LocaleSelector />
             {profile && (
               <>
-                <span className="text-fg-muted">{profile.email}</span>
+                <span className="nc-text-muted">{profile.email}</span>
                 <button className="nc-btn" type="button" onClick={logout}>
                   {t(Msg.common.signOut)}
                 </button>

--- a/frontend/apps/admin/src/AppearancePanel.tsx
+++ b/frontend/apps/admin/src/AppearancePanel.tsx
@@ -128,10 +128,10 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
     <section className="nc-panel">
       <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.appearance.title)}</h2>
-        <p className="text-sm text-fg-muted">{t(Msg.admin.appearance.subtitle)}</p>
+        <p>{t(Msg.admin.appearance.subtitle)}</p>
       </div>
       {isLoading ? (
-        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.common.loading)}</p>
+        <p className="px-4 py-6 nc-text-muted">{t(Msg.common.loading)}</p>
       ) : (
         <form className="space-y-4 px-4 py-4" onSubmit={(event) => void handleSubmit(event)}>
           <label className="block text-sm">

--- a/frontend/apps/admin/src/ColumnMappingGuide.tsx
+++ b/frontend/apps/admin/src/ColumnMappingGuide.tsx
@@ -4,7 +4,7 @@ export function ColumnMappingGuide() {
   const t = useMsg();
 
   return (
-    <details className="group rounded-admin border border-accent-border bg-accent text-sm text-fg-muted">
+    <details className="group rounded-admin border border-accent-border bg-accent text-xs text-fg-muted">
       <summary className="cursor-pointer list-none px-3 py-2.5 font-medium text-fg marker:content-none [&::-webkit-details-marker]:hidden">
         <span className="inline-flex items-center gap-2">
           <span
@@ -36,7 +36,7 @@ function GuideSection({ title, body }: GuideSectionProps) {
   return (
     <section>
       <h4 className="font-medium text-fg">{title}</h4>
-      <p className="mt-1 whitespace-pre-line text-fg-muted">{body}</p>
+      <p className="mt-1 whitespace-pre-line nc-text-subtle">{body}</p>
     </section>
   );
 }

--- a/frontend/apps/admin/src/ConversationLogsPanel.tsx
+++ b/frontend/apps/admin/src/ConversationLogsPanel.tsx
@@ -97,16 +97,16 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
     <section className="nc-panel">
       <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.conversationLogs.title)}</h2>
-        <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.subtitle)}</p>
+        <p>{t(Msg.admin.conversationLogs.subtitle)}</p>
       </div>
 
       {isLoadingSessions && (
-        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.conversationLogs.loadingSessions)}</p>
+        <p className="px-4 py-6 nc-text-muted">{t(Msg.admin.conversationLogs.loadingSessions)}</p>
       )}
       {error !== null && <p className="px-4 py-6 text-sm text-red-600">{error}</p>}
 
       {!isLoadingSessions && error === null && sessions.length === 0 && (
-        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.conversationLogs.empty)}</p>
+        <p className="px-4 py-6 nc-text-muted">{t(Msg.admin.conversationLogs.empty)}</p>
       )}
 
       {!isLoadingSessions && sessions.length > 0 && (
@@ -149,7 +149,7 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                     >
                       <td className="px-4 py-2 font-medium tabular-nums">#{session.session_id}</td>
                       <td className="px-4 py-2 tabular-nums">{session.message_count}</td>
-                      <td className="px-4 py-2 text-fg-muted">
+                      <td className="px-4 py-2 nc-text-muted">
                         {formatTimestamp(session.last_message_at ?? session.updated_at, locale)}
                       </td>
                     </tr>
@@ -161,13 +161,13 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
 
           <div className="px-4 py-4">
             {selectedSessionId === null && (
-              <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.selectSession)}</p>
+              <p className="nc-text-muted">{t(Msg.admin.conversationLogs.selectSession)}</p>
             )}
             {selectedSessionId !== null && isLoadingMessages && (
-              <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.loadingMessages)}</p>
+              <p className="nc-text-muted">{t(Msg.admin.conversationLogs.loadingMessages)}</p>
             )}
             {selectedSessionId !== null && !isLoadingMessages && messages.length === 0 && (
-              <p className="text-sm text-fg-muted">{t(Msg.admin.conversationLogs.emptyMessages)}</p>
+              <p className="nc-text-muted">{t(Msg.admin.conversationLogs.emptyMessages)}</p>
             )}
             {selectedSessionId !== null && !isLoadingMessages && messages.length > 0 && (
               <ul className="space-y-4">
@@ -180,15 +180,15 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                         : 'border-border bg-surface-muted'
                     }`}
                   >
-                    <div className="mb-1 flex items-center justify-between gap-2 text-xs text-fg-subtle">
-                      <span className="uppercase tracking-wide">{t(ROLE_MSG[message.role])}</span>
+                    <div className="mb-1 flex items-center justify-between gap-2 nc-text-subtle uppercase tracking-wide">
+                      <span>{t(ROLE_MSG[message.role])}</span>
                       <time dateTime={message.created_at}>
                         {formatTimestamp(message.created_at, locale)}
                       </time>
                     </div>
                     <p className="whitespace-pre-wrap text-sm">{message.content}</p>
                     {message.citations.length > 0 && (
-                      <ul className="mt-2 space-y-1 border-t border-border pt-2 text-xs text-fg-muted">
+                      <ul className="mt-2 space-y-1 border-t border-border pt-2 nc-text-muted">
                         {message.citations.map((citation) => (
                           <li key={citation.chunk_id}>
                             <span className="font-medium">
@@ -203,7 +203,7 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                             {citation.section_label !== undefined && (
                               <span> · {citation.section_label}</span>
                             )}
-                            <p className="mt-0.5 text-fg-subtle">{citation.excerpt}</p>
+                            <p className="mt-0.5 nc-text-subtle">{citation.excerpt}</p>
                           </li>
                         ))}
                       </ul>

--- a/frontend/apps/admin/src/IngestionPanel.tsx
+++ b/frontend/apps/admin/src/IngestionPanel.tsx
@@ -150,7 +150,7 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
     <section className="nc-panel">
       <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.ingestion.title)}</h2>
-        <p className="text-sm text-fg-muted">{t(Msg.admin.ingestion.subtitle)}</p>
+        <p>{t(Msg.admin.ingestion.subtitle)}</p>
       </div>
       <form className="space-y-4 px-4 py-4" onSubmit={(event) => void handlePreview(event)}>
         <label className="block text-sm">
@@ -174,7 +174,7 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
             help={t(Msg.admin.ingestion.fileHelp)}
           />
           <input
-            className="mt-1 block w-full text-sm text-fg-muted"
+            className="mt-1 block w-full nc-text-muted"
             type="file"
             accept=".csv,.pdf,text/csv,application/pdf"
             onChange={(event) => handleFileChange(event.target.files?.[0] ?? null)}
@@ -192,7 +192,7 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
 
       {csvPreview !== null && (
         <div className="space-y-4 border-t border-border px-4 py-4">
-          <p className="text-sm text-fg-muted">
+          <p className="nc-text-muted">
             {t(Msg.admin.ingestion.csvSummary, {
               count: csvPreview.row_count,
               delimiter: csvPreview.detected_delimiter,
@@ -214,10 +214,10 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
 
       {pdfPreview !== null && (
         <div className="space-y-3 border-t border-border px-4 py-4">
-          <p className="text-sm text-fg-muted">
+          <p className="nc-text-muted">
             {t(Msg.admin.ingestion.pdfPageCount, { count: pdfPreview.page_count })}
           </p>
-          <pre className="max-h-40 overflow-auto rounded-admin bg-surface-muted p-3 text-xs text-fg whitespace-pre-wrap">
+          <pre className="max-h-40 overflow-auto rounded-admin bg-surface-muted p-3 nc-text-muted whitespace-pre-wrap">
             {pdfPreview.sample_text.slice(0, 800)}
             {pdfPreview.sample_text.length > 800 ? '…' : ''}
           </pre>

--- a/frontend/apps/admin/src/LocaleSelector.tsx
+++ b/frontend/apps/admin/src/LocaleSelector.tsx
@@ -14,7 +14,7 @@ export function LocaleSelector() {
   const { locale, setLocale, supportedLocales } = useLocale();
 
   return (
-    <label className="flex items-center gap-2 text-sm text-fg-muted">
+    <label className="flex items-center gap-2 nc-text-muted">
       <span className="whitespace-nowrap">{t(Msg.admin.app.language)}</span>
       <select
         className="nc-select px-2 py-1.5"

--- a/frontend/apps/admin/src/SourcesPanel.tsx
+++ b/frontend/apps/admin/src/SourcesPanel.tsx
@@ -51,12 +51,12 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
     <section className="nc-panel">
       <div className="nc-panel-head">
         <h2 className="font-medium">{t(Msg.admin.sources.title)}</h2>
-        <p className="text-sm text-fg-muted">{t(Msg.admin.sources.subtitle)}</p>
+        <p>{t(Msg.admin.sources.subtitle)}</p>
       </div>
-      {isLoading && <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.sources.loading)}</p>}
+      {isLoading && <p className="px-4 py-6 nc-text-muted">{t(Msg.admin.sources.loading)}</p>}
       {error !== null && <p className="px-4 py-6 text-sm text-red-600">{error}</p>}
       {!isLoading && error === null && sources.length === 0 && (
-        <p className="px-4 py-6 text-sm text-fg-muted">{t(Msg.admin.sources.empty)}</p>
+        <p className="px-4 py-6 nc-text-muted">{t(Msg.admin.sources.empty)}</p>
       )}
       {!isLoading && sources.length > 0 && (
         <div className="overflow-x-auto">
@@ -90,7 +90,7 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
               {sources.map((source) => (
                 <tr key={source.source_id} className="nc-table-row">
                   <td className="px-4 py-2 font-medium">{source.name}</td>
-                  <td className="px-4 py-2 uppercase text-xs tracking-wide text-fg-subtle">
+                  <td className="px-4 py-2 uppercase nc-text-subtle tracking-wide">
                     {t(SOURCE_TYPE_MSG[source.source_type])}
                   </td>
                   <td className="px-4 py-2">
@@ -98,7 +98,7 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
                   </td>
                   <td className="px-4 py-2 tabular-nums">{source.document_count}</td>
                   <td className="px-4 py-2 tabular-nums">{source.chunk_count}</td>
-                  <td className="px-4 py-2 text-fg-muted">
+                  <td className="px-4 py-2 nc-text-muted">
                     {formatTimestamp(source.updated_at, locale)}
                   </td>
                 </tr>
@@ -152,7 +152,7 @@ export function LoginForm({ error, onLogin }: LoginFormProps) {
   return (
     <section className="nc-panel mx-auto max-w-md p-6">
       <h2 className="text-lg font-medium">{t(Msg.admin.auth.title)}</h2>
-      <p className="mt-1 text-sm text-fg-muted">{t(Msg.admin.auth.subtitle)}</p>
+      <p className="mt-1 nc-text-muted">{t(Msg.admin.auth.subtitle)}</p>
       <form className="mt-4 space-y-4" onSubmit={(event) => void handleSubmit(event)}>
         <label className="block text-sm">
           <span className="font-medium text-fg">{t(Msg.admin.auth.email)}</span>

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -24,15 +24,15 @@
 :root {
   color-scheme: light;
   --nc-admin-font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  --nc-admin-page: #e4e9f0;
+  --nc-admin-page: #c5ced9;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
-    #eef2f7 0%,
-    #e4e9f0 42%,
-    #d8dfe8 100%
+    #d0d8e2 0%,
+    #c5ced9 42%,
+    #b8c2cf 100%
   );
   --nc-admin-surface: #ffffff;
-  --nc-admin-surface-muted: #f1f4f8;
+  --nc-admin-surface-muted: #e4e9ef;
   --nc-admin-header: rgb(255 255 255 / 0.88);
   --nc-admin-border: rgb(15 23 42 / 0.12);
   --nc-admin-border-subtle: rgb(15 23 42 / 0.07);
@@ -93,6 +93,18 @@
 
   .nc-panel-head {
     @apply border-b border-border px-4 py-3;
+
+    & > p {
+      @apply text-xs leading-normal text-fg-muted;
+    }
+  }
+
+  .nc-text-muted {
+    @apply text-xs leading-normal text-fg-muted;
+  }
+
+  .nc-text-subtle {
+    @apply text-[11px] leading-normal text-fg-subtle;
   }
 
   .nc-input {
@@ -116,7 +128,7 @@
   }
 
   .nc-table-head {
-    @apply bg-surface-muted text-left text-fg-muted;
+    @apply bg-surface-muted text-left text-xs text-fg-muted;
   }
 
   .nc-table-row {


### PR DESCRIPTION
## Summary

- ライトモード背景を `#b8c2cf` 付近まで暗く（白パネルとの差を強調）
- `nc-text-muted`（12px）/`nc-text-subtle`（11px）を追加
- パネル subtitle、ヘルス表示、ローディング、テーブル副次列などに適用

Closes #81

## Test plan

- [ ] ライトモードで背景が以前より暗いグレーに見える
- [ ] 各パネルの subtitle・ステータス行が小さく表示される
- [ ] 主要見出し・本文の可読性は維持

Made with [Cursor](https://cursor.com)