### PR TITLE
style(admin): ヘッダー整理とタイムスタンプ縮小 (#83)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { fetchJson, type HealthResponse } from '@nene-corpus/api-client';
 import { Msg, applyLocaleFontFamily, toBcp47, useLocale, useMsg } from '@nene-corpus/i18n';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
@@ -13,19 +12,12 @@ export function App() {
   const t = useMsg();
   const { locale } = useLocale();
   const { token, profile, isReady, error, login, logout } = useAdminAuth();
-  const [health, setHealth] = useState<HealthResponse | null>(null);
   const [sourcesReloadKey, setSourcesReloadKey] = useState(0);
 
   useEffect(() => {
     document.documentElement.lang = toBcp47(locale);
     applyLocaleFontFamily(locale);
   }, [locale]);
-
-  useEffect(() => {
-    fetchJson<HealthResponse>('/health')
-      .then(setHealth)
-      .catch(() => setHealth(null));
-  }, []);
 
   if (!isReady) {
     return (
@@ -41,26 +33,16 @@ export function App() {
         <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
           <div>
             <h1 className="text-xl font-semibold tracking-tight">{t(Msg.admin.app.title)}</h1>
-            <p className="nc-text-muted">
-              {health
-                ? t(Msg.admin.app.healthStatus, {
-                    service: health.service,
-                    status: health.status,
-                  })
-                : t(Msg.admin.app.healthUnavailable)}
-            </p>
+            {profile && <p className="nc-text-muted">{profile.email}</p>}
           </div>
-          <div className="flex flex-wrap items-center justify-end gap-2 text-sm">
-            <ThemeToggle />
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <LocaleSelector />
             {profile && (
-              <>
-                <span className="nc-text-muted">{profile.email}</span>
-                <button className="nc-btn" type="button" onClick={logout}>
-                  {t(Msg.common.signOut)}
-                </button>
-              </>
+              <button className="nc-btn text-sm" type="button" onClick={logout}>
+                {t(Msg.common.signOut)}
+              </button>
             )}
+            <ThemeToggle />
           </div>
         </div>
       </header>

--- a/frontend/apps/admin/src/ConversationLogsPanel.tsx
+++ b/frontend/apps/admin/src/ConversationLogsPanel.tsx
@@ -149,7 +149,7 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                     >
                       <td className="px-4 py-2 font-medium tabular-nums">#{session.session_id}</td>
                       <td className="px-4 py-2 tabular-nums">{session.message_count}</td>
-                      <td className="px-4 py-2 nc-text-muted">
+                      <td className="px-4 py-2 nc-text-timestamp">
                         {formatTimestamp(session.last_message_at ?? session.updated_at, locale)}
                       </td>
                     </tr>
@@ -180,7 +180,7 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                         : 'border-border bg-surface-muted'
                     }`}
                   >
-                    <div className="mb-1 flex items-center justify-between gap-2 nc-text-subtle uppercase tracking-wide">
+                    <div className="mb-1 flex items-center justify-between gap-2 nc-text-timestamp uppercase tracking-wide">
                       <span>{t(ROLE_MSG[message.role])}</span>
                       <time dateTime={message.created_at}>
                         {formatTimestamp(message.created_at, locale)}

--- a/frontend/apps/admin/src/LocaleSelector.tsx
+++ b/frontend/apps/admin/src/LocaleSelector.tsx
@@ -14,20 +14,17 @@ export function LocaleSelector() {
   const { locale, setLocale, supportedLocales } = useLocale();
 
   return (
-    <label className="flex items-center gap-2 nc-text-muted">
-      <span className="whitespace-nowrap">{t(Msg.admin.app.language)}</span>
-      <select
-        className="nc-select px-2 py-1.5"
-        value={locale}
-        aria-label={t(Msg.admin.app.language)}
-        onChange={(event) => setLocale(event.target.value as SupportedLocale)}
-      >
-        {supportedLocales.map((code) => (
-          <option key={code} value={code}>
-            {t(LOCALE_LABEL_KEYS[code])}
-          </option>
-        ))}
-      </select>
-    </label>
+    <select
+      className="nc-select nc-select-compact"
+      value={locale}
+      aria-label={t(Msg.admin.app.language)}
+      onChange={(event) => setLocale(event.target.value as SupportedLocale)}
+    >
+      {supportedLocales.map((code) => (
+        <option key={code} value={code}>
+          {t(LOCALE_LABEL_KEYS[code])}
+        </option>
+      ))}
+    </select>
   );
 }

--- a/frontend/apps/admin/src/SourcesPanel.tsx
+++ b/frontend/apps/admin/src/SourcesPanel.tsx
@@ -98,7 +98,7 @@ export function SourcesPanel({ token, reloadKey = 0 }: SourcesPanelProps) {
                   </td>
                   <td className="px-4 py-2 tabular-nums">{source.document_count}</td>
                   <td className="px-4 py-2 tabular-nums">{source.chunk_count}</td>
-                  <td className="px-4 py-2 nc-text-muted">
+                  <td className="px-4 py-2 nc-text-timestamp">
                     {formatTimestamp(source.updated_at, locale)}
                   </td>
                 </tr>

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -107,12 +107,20 @@
     @apply text-[11px] leading-normal text-fg-subtle;
   }
 
+  .nc-text-timestamp {
+    @apply text-[10px] leading-normal text-fg-subtle tabular-nums;
+  }
+
   .nc-input {
     @apply mt-1 w-full rounded-admin border border-border-strong bg-surface px-3 py-2 text-fg outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/25;
   }
 
   .nc-select {
     @apply rounded-admin border border-border-strong bg-surface px-2 py-1.5 text-fg outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/25;
+  }
+
+  .nc-select-compact {
+    @apply py-1 text-xs;
   }
 
   .nc-btn {


### PR DESCRIPTION
## Summary

- API ヘルス行（`NENE2 — ok`）を削除
- ログイン時、メールアドレスをタイトル下に表示
- 言語セレクタはラベルなしのコンパクト select（`aria-label` 維持）
- ヘッダー右: 言語 → サインアウト → テーマ（右端）
- `nc-text-timestamp`（10px）を日時列・メッセージメタに適用

Closes #83

## Test plan

- [ ] ログイン後、タイトル下にメール、右端にテーマアイコン
- [ ] ヘルス表示が消えている
- [ ] 言語 select のみでラベルなし
- [ ] タイムスタンプが他より小さく表示される

Made with [Cursor](https://cursor.com)