### PR TITLE
style(admin): ヘッダー順序・高さ統一と Corpus Blue アクセント (#85)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -32,17 +32,17 @@ export function App() {
       <header className="sticky top-0 z-40 border-b border-border bg-header/80 px-6 py-4 backdrop-blur-md">
         <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
           <div>
-            <h1 className="text-xl font-semibold tracking-tight">{t(Msg.admin.app.title)}</h1>
+            <h1 className="text-xl font-semibold tracking-tight text-brand">{t(Msg.admin.app.title)}</h1>
             {profile && <p className="nc-text-muted">{profile.email}</p>}
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2">
             <LocaleSelector />
+            <ThemeToggle />
             {profile && (
-              <button className="nc-btn text-sm" type="button" onClick={logout}>
+              <button className="nc-btn nc-header-btn" type="button" onClick={logout}>
                 {t(Msg.common.signOut)}
               </button>
             )}
-            <ThemeToggle />
           </div>
         </div>
       </header>

--- a/frontend/apps/admin/src/ThemeToggle.tsx
+++ b/frontend/apps/admin/src/ThemeToggle.tsx
@@ -9,7 +9,7 @@ export function ThemeToggle() {
   return (
     <button
       type="button"
-      className="nc-btn inline-flex items-center justify-center p-2"
+      className="nc-btn nc-header-icon-btn text-brand hover:border-brand/40 hover:bg-brand-muted"
       aria-label={isDark ? t(Msg.admin.app.themeLight) : t(Msg.admin.app.themeDark)}
       title={isDark ? t(Msg.admin.app.themeLight) : t(Msg.admin.app.themeDark)}
       onClick={toggleTheme}

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -19,57 +19,64 @@
   --color-accent: var(--nc-admin-accent);
   --color-accent-border: var(--nc-admin-accent-border);
   --color-focus: var(--nc-admin-focus);
+  --color-brand: var(--nc-admin-brand);
+  --color-brand-muted: var(--nc-admin-brand-muted);
 }
 
 :root {
   color-scheme: light;
   --nc-admin-font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  --nc-admin-page: #c5ced9;
+  /* Widget default (--nc-color-primary) と揃えた Corpus Blue */
+  --nc-admin-brand: #2563eb;
+  --nc-admin-brand-muted: #dbeafe;
+  --nc-admin-page: #b8c5d9;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
-    #d0d8e2 0%,
-    #c5ced9 42%,
-    #b8c2cf 100%
+    #d2dcef 0%,
+    #bfcce2 42%,
+    #aebdd6 100%
   );
   --nc-admin-surface: #ffffff;
-  --nc-admin-surface-muted: #e4e9ef;
+  --nc-admin-surface-muted: #eef2fa;
   --nc-admin-header: rgb(255 255 255 / 0.88);
-  --nc-admin-border: rgb(15 23 42 / 0.12);
+  --nc-admin-border: rgb(37 99 235 / 0.14);
   --nc-admin-border-subtle: rgb(15 23 42 / 0.07);
-  --nc-admin-border-strong: rgb(15 23 42 / 0.18);
+  --nc-admin-border-strong: rgb(37 99 235 / 0.22);
   --nc-admin-fg: #171717;
   --nc-admin-fg-muted: #475569;
   --nc-admin-fg-subtle: #64748b;
-  --nc-admin-primary: #171717;
+  --nc-admin-primary: var(--nc-admin-brand);
   --nc-admin-primary-fg: #ffffff;
-  --nc-admin-accent: rgb(59 130 246 / 0.12);
-  --nc-admin-accent-border: rgb(59 130 246 / 0.32);
-  --nc-admin-focus: #3b82f6;
+  --nc-admin-accent: rgb(37 99 235 / 0.1);
+  --nc-admin-accent-border: rgb(37 99 235 / 0.28);
+  --nc-admin-focus: var(--nc-admin-brand);
 }
 
 .dark {
   color-scheme: dark;
+  --nc-admin-brand: #3b82f6;
+  --nc-admin-brand-muted: rgb(59 130 246 / 0.18);
   --nc-admin-page: #0a0a0a;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
-    #1a1a1a 0%,
-    #121212 42%,
+    #141820 0%,
+    #101218 42%,
     #0a0a0a 100%
   );
   --nc-admin-surface: #1f1f1f;
-  --nc-admin-surface-muted: #2a2a2a;
+  --nc-admin-surface-muted: #262b36;
   --nc-admin-header: rgb(23 23 23 / 0.9);
-  --nc-admin-border: rgb(255 255 255 / 0.12);
+  --nc-admin-border: rgb(96 165 250 / 0.18);
   --nc-admin-border-subtle: rgb(255 255 255 / 0.07);
-  --nc-admin-border-strong: rgb(255 255 255 / 0.2);
+  --nc-admin-border-strong: rgb(96 165 250 / 0.28);
   --nc-admin-fg: #ececec;
   --nc-admin-fg-muted: #a3a3a3;
   --nc-admin-fg-subtle: #737373;
-  --nc-admin-primary: #f5f5f5;
-  --nc-admin-primary-fg: #171717;
-  --nc-admin-accent: rgb(96 165 250 / 0.16);
+  --nc-admin-primary: var(--nc-admin-brand);
+  --nc-admin-primary-fg: #ffffff;
+  --nc-admin-accent: rgb(59 130 246 / 0.16);
   --nc-admin-accent-border: rgb(96 165 250 / 0.38);
-  --nc-admin-focus: #60a5fa;
+  --nc-admin-focus: var(--nc-admin-brand);
 }
 
 @layer base {
@@ -120,7 +127,15 @@
   }
 
   .nc-select-compact {
-    @apply py-1 text-xs;
+    @apply h-8 py-0 text-xs leading-none;
+  }
+
+  .nc-header-btn {
+    @apply h-8 px-3 text-sm leading-none;
+  }
+
+  .nc-header-icon-btn {
+    @apply inline-flex h-8 w-8 shrink-0 items-center justify-center p-0;
   }
 
   .nc-btn {
@@ -128,7 +143,7 @@
   }
 
   .nc-btn-primary {
-    @apply rounded-admin bg-primary px-4 py-2 text-sm font-medium text-primary-fg transition-opacity hover:opacity-90 disabled:opacity-60;
+    @apply rounded-admin bg-primary px-4 py-2 text-sm font-medium text-primary-fg shadow-sm shadow-brand/20 transition-opacity hover:opacity-90 disabled:opacity-60;
   }
 
   .nc-btn-success {


### PR DESCRIPTION
## Summary

- ヘッダー右: **言語 → テーマ → サインアウト**（サインアウトが右端）
- 3 コントロールを **h-8（32px）** で統一
- **Corpus Blue `#2563eb`**（Widget 既定 primary と同系）を Admin ブランド色に
  - タイトル、Primary ボタン、フォーカス、選択ハイライト、背景グラデの青み
- ダークモードは `#3b82f6` + 微青グラデ

Closes #85

## Test plan

- [ ] ヘッダー順序と高さが揃っている
- [ ] ログイン・保存など Primary ボタンが青
- [ ] ライト/ダーク両方で白黒だけに見えない

Made with [Cursor](https://cursor.com)