### PR TITLE
style(admin): 背景彩度調整とダーク surface 暗化 (#87)

### DIFF
--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -26,56 +26,56 @@
 :root {
   color-scheme: light;
   --nc-admin-font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  /* Widget default (--nc-color-primary) と揃えた Corpus Blue */
-  --nc-admin-brand: #2563eb;
-  --nc-admin-brand-muted: #dbeafe;
-  --nc-admin-page: #b8c5d9;
+  /* Widget と同系統だが彩度を抑えたソフトブルー */
+  --nc-admin-brand: #5c7ec7;
+  --nc-admin-brand-muted: #e8edf5;
+  --nc-admin-page: #c4c9d0;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
-    #d2dcef 0%,
-    #bfcce2 42%,
-    #aebdd6 100%
+    #d2d6dc 0%,
+    #c4c9d0 42%,
+    #b8bec6 100%
   );
   --nc-admin-surface: #ffffff;
   --nc-admin-surface-muted: #eef2fa;
   --nc-admin-header: rgb(255 255 255 / 0.88);
-  --nc-admin-border: rgb(37 99 235 / 0.14);
-  --nc-admin-border-subtle: rgb(15 23 42 / 0.07);
-  --nc-admin-border-strong: rgb(37 99 235 / 0.22);
+  --nc-admin-border: rgb(15 23 42 / 0.1);
+  --nc-admin-border-subtle: rgb(15 23 42 / 0.06);
+  --nc-admin-border-strong: rgb(15 23 42 / 0.16);
   --nc-admin-fg: #171717;
   --nc-admin-fg-muted: #475569;
   --nc-admin-fg-subtle: #64748b;
   --nc-admin-primary: var(--nc-admin-brand);
   --nc-admin-primary-fg: #ffffff;
-  --nc-admin-accent: rgb(37 99 235 / 0.1);
-  --nc-admin-accent-border: rgb(37 99 235 / 0.28);
+  --nc-admin-accent: rgb(92 126 199 / 0.1);
+  --nc-admin-accent-border: rgb(92 126 199 / 0.24);
   --nc-admin-focus: var(--nc-admin-brand);
 }
 
 .dark {
   color-scheme: dark;
-  --nc-admin-brand: #3b82f6;
-  --nc-admin-brand-muted: rgb(59 130 246 / 0.18);
-  --nc-admin-page: #0a0a0a;
+  --nc-admin-brand: #7494d4;
+  --nc-admin-brand-muted: rgb(116 148 212 / 0.14);
+  --nc-admin-page: #080808;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
-    #141820 0%,
-    #101218 42%,
-    #0a0a0a 100%
+    #101010 0%,
+    #0c0c0c 42%,
+    #080808 100%
   );
-  --nc-admin-surface: #1f1f1f;
-  --nc-admin-surface-muted: #262b36;
-  --nc-admin-header: rgb(23 23 23 / 0.9);
-  --nc-admin-border: rgb(96 165 250 / 0.18);
-  --nc-admin-border-subtle: rgb(255 255 255 / 0.07);
-  --nc-admin-border-strong: rgb(96 165 250 / 0.28);
-  --nc-admin-fg: #ececec;
-  --nc-admin-fg-muted: #a3a3a3;
-  --nc-admin-fg-subtle: #737373;
+  --nc-admin-surface: #141414;
+  --nc-admin-surface-muted: #1a1a1a;
+  --nc-admin-header: rgb(12 12 12 / 0.92);
+  --nc-admin-border: rgb(255 255 255 / 0.09);
+  --nc-admin-border-subtle: rgb(255 255 255 / 0.05);
+  --nc-admin-border-strong: rgb(255 255 255 / 0.14);
+  --nc-admin-fg: #e8e8e8;
+  --nc-admin-fg-muted: #9ca3af;
+  --nc-admin-fg-subtle: #6b7280;
   --nc-admin-primary: var(--nc-admin-brand);
   --nc-admin-primary-fg: #ffffff;
-  --nc-admin-accent: rgb(59 130 246 / 0.16);
-  --nc-admin-accent-border: rgb(96 165 250 / 0.38);
+  --nc-admin-accent: rgb(116 148 212 / 0.12);
+  --nc-admin-accent-border: rgb(116 148 212 / 0.28);
   --nc-admin-focus: var(--nc-admin-brand);
 }
 


### PR DESCRIPTION
## Summary

- **ライト:** 背景グラデを低彩度の neutral gray に（白パネルは維持）
- **ダーク:** 背景から青みを除去、パネルを `#141414` に暗化（背景 `#080808` との差を明確化）
- ボーダー・アクセントも neutral 寄りに
- ブランド色を `#5c7ec7` / `#7494d4` にソフト化

Closes #87

## Test plan

- [ ] ライト: 背景がグレー寄り、白パネルはそのまま
- [ ] ダーク: 背景とパネルの明暗差がはっきり、青黒っぽさが減る
- [ ] Primary ボタン・タイトルのアクセントが以前より柔らかい

Made with [Cursor](https://cursor.com)