### PR TITLE
style(admin): ブランド色を Sage Teal に変更 (#89)

### DIFF
--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -26,9 +26,9 @@
 :root {
   color-scheme: light;
   --nc-admin-font-family: 'Inter', ui-sans-serif, system-ui, sans-serif;
-  /* Widget と同系統だが彩度を抑えたソフトブルー */
-  --nc-admin-brand: #5c7ec7;
-  --nc-admin-brand-muted: #e8edf5;
+  /* Sage Teal — 知識・アーカイブ感。Widget 青とは Admin だけ別アクセント */
+  --nc-admin-brand: #4d8f7f;
+  --nc-admin-brand-muted: #e6f2ef;
   --nc-admin-page: #c4c9d0;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
@@ -37,7 +37,7 @@
     #b8bec6 100%
   );
   --nc-admin-surface: #ffffff;
-  --nc-admin-surface-muted: #eef2fa;
+  --nc-admin-surface-muted: #eef1f0;
   --nc-admin-header: rgb(255 255 255 / 0.88);
   --nc-admin-border: rgb(15 23 42 / 0.1);
   --nc-admin-border-subtle: rgb(15 23 42 / 0.06);
@@ -47,15 +47,15 @@
   --nc-admin-fg-subtle: #64748b;
   --nc-admin-primary: var(--nc-admin-brand);
   --nc-admin-primary-fg: #ffffff;
-  --nc-admin-accent: rgb(92 126 199 / 0.1);
-  --nc-admin-accent-border: rgb(92 126 199 / 0.24);
+  --nc-admin-accent: rgb(77 143 127 / 0.1);
+  --nc-admin-accent-border: rgb(77 143 127 / 0.24);
   --nc-admin-focus: var(--nc-admin-brand);
 }
 
 .dark {
   color-scheme: dark;
-  --nc-admin-brand: #7494d4;
-  --nc-admin-brand-muted: rgb(116 148 212 / 0.14);
+  --nc-admin-brand: #6aad9c;
+  --nc-admin-brand-muted: rgb(106 173 156 / 0.14);
   --nc-admin-page: #080808;
   --nc-admin-bg-gradient: linear-gradient(
     165deg,
@@ -73,9 +73,9 @@
   --nc-admin-fg-muted: #9ca3af;
   --nc-admin-fg-subtle: #6b7280;
   --nc-admin-primary: var(--nc-admin-brand);
-  --nc-admin-primary-fg: #ffffff;
-  --nc-admin-accent: rgb(116 148 212 / 0.12);
-  --nc-admin-accent-border: rgb(116 148 212 / 0.28);
+  --nc-admin-primary-fg: #1a1a1a;
+  --nc-admin-accent: rgb(106 173 156 / 0.12);
+  --nc-admin-accent-border: rgb(106 173 156 / 0.28);
   --nc-admin-focus: var(--nc-admin-brand);
 }
 


### PR DESCRIPTION
## Summary

Admin アクセントを **Sage Teal**（`#4d8f7f` / `#6aad9c`）に変更。背景の neutral gray / ダーク surface は前回調整のまま。

Widget 既定の青とは Admin のみ別 hue — コーパス/アーカイブ感のある落ち着いた青緑。

Closes #89

## Test plan

- [ ] ライト/ダークでタイトル・ボタン・選択行が青緑系
- [ ] 背景は neutral のまま

Made with [Cursor](https://cursor.com)