### PR TITLE
docs: SSE 非ゴールを ADR・product docs に統一 (#97)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ NeNe Corpus is a self-hosted knowledge chat OSS on NENE2:
 
 - **Primary operators:** Japan SMB on PHP shared hosting (Tier A); **also** Docker/VPS (Tier B). Same codebase — ADR 0003.
 - Ingest PDF, CSV, and structured sources into a searchable corpus.
-- Answer end-user questions with **cited** responses (**sync JSON chat** default; **SSE streaming** optional on Tier B).
+- Answer end-user questions with **cited** responses via **sync JSON chat** (widget CSS for loading/motion; **SSE streaming** is a non-goal).
 - Embed **embed widget** on existing homepages with one same-origin `<script>` (Phase 3).
 - Admin UI for ingestion, corpus management, conversation logs, and settings.
 - OpenAPI as the contract; MCP for ops/read-only agent tooling only.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Ops / AI (MCP)         ───────────────────
 - **Backend**: PHP 8.4, NENE2, Handler → UseCase → Repository
 - **API contract**: OpenAPI 3.1 ([`docs/openapi/openapi.yaml`](./docs/openapi/openapi.yaml))
 - **Ingestion**: PDF text extraction, CSV row mapping (planned)
-- **Chat**: **sync JSON chat** + citations, rate limits (**SSE streaming** optional on Tier B — planned)
+- **Chat**: **sync JSON chat** + citations, rate limits; widget CSS for loading/motion UX
 - **Deploy**: dual path — [`docs/deployment/README.md`](./docs/deployment/README.md)
 
 ## Current Status

--- a/docs/adr/0003-dual-deployment-and-embed-widget.md
+++ b/docs/adr/0003-dual-deployment-and-embed-widget.md
@@ -8,7 +8,7 @@ accepted
 
 NeNe Corpus targets self-hosted knowledge chat for small and medium businesses. In Japan, many operators already run company websites on **PHP-capable shared hosting** (FTP upload, MySQL, same domain as their public site). Developers and VPS operators prefer **Docker Compose** for reproducible setup.
 
-These audiences share the same product (corpus, cited chat, admin UI) but need different **installation paths**. The consumer chat use case is typically **low frequency** (rate limits per session/IP, not high-throughput streaming), so token-by-token SSE is a UX enhancement, not a core requirement.
+These audiences share the same product (corpus, cited chat, admin UI) but need different **installation paths**. The consumer chat use case is typically **low frequency** (rate limits per session/IP, not high-throughput streaming). **sync JSON chat** is the only transport; progressive UX is handled in the **embed widget** via CSS (loading indicator, bubble motion, scroll) — not token-by-token streaming.
 
 Alternatives considered:
 
@@ -22,8 +22,8 @@ NeNe Corpus supports **two deployment tiers** with one runtime codebase:
 
 | Tier | Audience | Install path | Chat transport |
 | --- | --- | --- | --- |
-| **A — Shared hosting** | Japan SMB primary | ZIP + web installer + FTP/SSH; MySQL | **sync JSON chat** (default) |
-| **B — Docker / VPS** | Developers, VPS, private cloud | `docker compose up` | **sync JSON chat** (default); **SSE streaming** optional later |
+| **A — Shared hosting** | Japan SMB primary | ZIP + web installer + FTP/SSH; MySQL | **sync JSON chat** |
+| **B — Docker / VPS** | Developers, VPS, private cloud | `docker compose up` | **sync JSON chat** |
 
 **Product delivery:**
 
@@ -33,8 +33,8 @@ NeNe Corpus supports **two deployment tiers** with one runtime codebase:
 
 **Chat API (Phase 2):**
 
-- Default (**sync JSON chat**): `POST` message → wait → JSON response with full text and `citations[]`.
-- Optional later (Tier B — **SSE streaming**): progressive display endpoint.
+- **sync JSON chat** only: `POST` message → wait → JSON response with full text and `citations[]`.
+- **Non-goal:** **SSE streaming** / token-by-token Server-Sent Events — not planned on Tier A or Tier B.
 
 **Markets:**
 
@@ -60,8 +60,8 @@ NeNe Corpus supports **two deployment tiers** with one runtime codebase:
 
 - `docs/deployment/shared-hosting.md` — Tier A operator guide (stub until installer lands).
 - `docs/development/docker.md` — Tier B (existing).
-- Phase 2 OpenAPI: document **sync JSON chat** first; **SSE streaming** as optional extension.
-- Phase 3: **web installer**, **release ZIP**, **embed widget** bundle.
+- Phase 2 OpenAPI: **sync JSON chat** only.
+- Phase 3: **web installer**, **release ZIP**, **embed widget** bundle (CSS motion UX on **sync JSON chat**).
 - Terminology: `docs/explanation/glossary.md`, `docs/development/naming-conventions.md`.
 
 ## Related

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -37,7 +37,6 @@ Exact paths and attributes will be documented when the **embed widget** ships (P
 
 ## Chat transport
 
-- **Default (both tiers):** **sync JSON chat** — POST a message, receive full reply + **citations**.
-- **Optional (Tier B, later):** **SSE streaming** for progressive display.
-
-Low-frequency FAQ-style traffic (**rate limit** per session/IP) does not require **SSE streaming**.
+- **Both tiers:** **sync JSON chat** only — POST a message, receive full reply + **citations**.
+- **Embed widget** adds loading indicators and CSS motion (bubble fade-in, scroll); no token streaming.
+- **Non-goal:** **SSE streaming** — not planned.

--- a/docs/deployment/shared-hosting.md
+++ b/docs/deployment/shared-hosting.md
@@ -44,7 +44,7 @@ NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on 
 ></script>
 ```
 
-Works alongside WordPress, static HTML, or other CMS pages on the **same origin**. The **embed widget** calls **sync JSON chat** (loading indicator while waiting; **SSE streaming** not required on Tier A).
+Works alongside WordPress, static HTML, or other CMS pages on the **same origin**. The **embed widget** calls **sync JSON chat** (loading indicator and CSS motion while waiting).
 
 ## Manual deploy (until web installer exists)
 
@@ -61,7 +61,6 @@ See [Docker development](../development/docker.md) for the canonical runtime lay
 ## Limitations on shared hosting
 
 - **PDF ingestion** may hit execution time and upload size limits — split large files or use Tier B for heavy **ingestion**.
-- **SSE streaming** is not planned as Tier A default; use **sync JSON chat**.
 - **Claude API** usage is pay-as-you-go — configure keys in admin UI (Phase 2+).
 
 ## Troubleshooting

--- a/docs/development/backend-standards.md
+++ b/docs/development/backend-standards.md
@@ -38,7 +38,7 @@ src/
   Source/             # source file metadata
   Document/           # logical documents
   Chunk/              # searchable text segments
-  Chat/               # send message (sync JSON chat; optional SSE streaming on Tier B)
+  Chat/               # send message (sync JSON chat only)
   Session/            # consumer sessions
   Message/            # chat messages
   Search/             # full-text over chunks
@@ -60,7 +60,7 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 
 | Layer | May | Must not |
 | --- | --- | --- |
-| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response (or **SSE streaming** when enabled) | SQL, business rules, direct LLM calls |
+| **Handler** | Parse HTTP, build DTO, call UseCase, map JSON response | SQL, business rules, direct LLM calls |
 | **UseCase** | Business rules, orchestration | `$_SERVER`, PDO, raw HTTP to Claude |
 | **Repository** | SQL / persistence | HTTP, session logic |
 | **Llm adapter** | Call Claude API from infrastructure | Domain invariants |
@@ -73,8 +73,7 @@ Use `final readonly` classes and `declare(strict_types=1);` in every PHP file.
 
 - Every public route appears in `docs/openapi/openapi.yaml` with `operationId`.
 - Success and Problem Details error shapes documented.
-- Chat: document **sync JSON chat** contract first (ADR 0003 — default for Tier A and Tier B). See [`glossary.md`](../explanation/glossary.md).
-- Optional **SSE streaming**: document in OpenAPI when implemented (Tier B only).
+- Chat: **sync JSON chat** only (ADR 0003). See [`glossary.md`](../explanation/glossary.md). **SSE streaming** is a non-goal.
 - RFC 9457 Problem Details for errors; base URL `https://nene-corpus.dev/problems/`.
 
 ---

--- a/docs/development/naming-conventions.md
+++ b/docs/development/naming-conventions.md
@@ -223,7 +223,7 @@ When adding a new public term, update [`glossary.md`](../explanation/glossary.md
 - SQL outside `Pdo*Repository`
 - camelCase in public JSON property names
 - Renaming shipped `operationId` values
-- New synonyms for glossary terms in English docs (e.g. do not write "streaming chat" when the doc means **SSE streaming**; do not write "synchronous JSON" when the doc means **sync JSON chat**)
+- New synonyms for glossary terms in English docs (e.g. do not write "streaming chat" for **sync JSON chat** or widget CSS motion; do not write "synchronous JSON" when the doc means **sync JSON chat**)
 - MCP tools exposed to **embed widget** or consumer chat clients
 
 ---

--- a/docs/explanation/glossary.md
+++ b/docs/explanation/glossary.md
@@ -33,8 +33,8 @@ Canonical English terms for NeNe Corpus documentation, OpenAPI, code comments, a
 
 | Canonical term | Definition | Japanese note | Do not use |
 | --- | --- | --- | --- |
-| **sync JSON chat** | Default consumer chat transport: HTTP POST → wait → single JSON body with message text and **citations**. Tier A and Tier B default. | 同期 JSON チャット | "synchronous JSON", "async chat", "REST polling" (unless describing a future job poll API) |
-| **SSE streaming** | Optional Tier B enhancement: token-by-token Server-Sent Events stream. Not required for FAQ traffic. | SSE ストリーミング | "streaming chat" (ambiguous), "websocket chat" |
+| **sync JSON chat** | Default and **only** consumer chat transport: HTTP POST → wait → single JSON body with message text and **citations**. Tier A and Tier B. Widget UX (loading, bubble motion) is CSS-only. | 同期 JSON チャット | "synchronous JSON", "async chat", "REST polling" (unless describing a future job poll API), "streaming chat" |
+| ~~**SSE streaming**~~ | **Non-goal** — not planned. Do not add SSE endpoints or token-by-token display. | （非ゴール） | "streaming chat", "websocket chat", "SSE" in new specs |
 | **embed widget** | The `widget.js` bundle plus one same-origin `<script>` embed on an existing site. Phase 3. | 埋め込みウィジェット | "chat widget" alone, "plugin", "snippet" |
 | **consumer chat** | End-user Q&A feature (sessions, messages, citations). Distinct from admin UI and MCP. | コンシューマーチャット | "user chatbot", "public bot" |
 | **same origin** | Widget and API share scheme + host + port; avoids CORS on shared hosting. | 同一オリジン | "same domain" (acceptable in casual Japanese; English docs use **same origin**) |

--- a/docs/explanation/product-vision.md
+++ b/docs/explanation/product-vision.md
@@ -30,7 +30,7 @@ Operators who already have a company website on **shared hosting** and want a FA
 
 **Secondary — Tier B developers and VPS / private cloud**
 
-Docker Compose for local dev and production on VPS. Same API and **embed widget** as Tier A; optional **SSE streaming** later.
+Docker Compose for local dev and production on VPS. Same API and **embed widget** as Tier A.
 
 **Later — international**
 
@@ -60,8 +60,8 @@ Same codebase, two installation paths (ADR 0003):
 
 | Tier | Path | Chat transport |
 | --- | --- | --- |
-| **Tier A — shared hosting** | **release ZIP** + **web installer** + MySQL | **sync JSON chat** (default) |
-| **Tier B — Docker / VPS** | `docker compose up` | **sync JSON chat** (default); **SSE streaming** optional |
+| **Tier A — shared hosting** | **release ZIP** + **web installer** + MySQL | **sync JSON chat** |
+| **Tier B — Docker / VPS** | `docker compose up` | **sync JSON chat** |
 
 See [`docs/deployment/README.md`](../deployment/README.md) and [`glossary.md`](./glossary.md).
 
@@ -75,7 +75,7 @@ See [`docs/deployment/README.md`](../deployment/README.md) and [`glossary.md`](.
 
 No site rebuild required. Works with WordPress themes, static HTML, or any CMS that allows a custom script include.
 
-FAQ-style traffic is **low frequency** (**rate limit** per session/IP). **sync JSON chat** with a loading state is sufficient; **SSE streaming** is optional polish for Tier B.
+FAQ-style traffic is **low frequency** (**rate limit** per session/IP). **sync JSON chat** with a loading state and widget CSS motion (bubble fade-in, smooth scroll) is sufficient. **SSE streaming** is a **non-goal**.
 
 ## Philosophy
 
@@ -104,7 +104,7 @@ NENE2 (framework)
 | **NENE2 runtime** | HTTP, DI, middleware, Problem Details |
 | **NeNe Corpus API** | Ingestion, corpus storage, chat, rate limits, audit |
 | **Admin UI** | Upload, reindex, logs, prompt settings, **embed widget** snippet |
-| **Embed widget** | **Consumer chat** UX over **sync JSON chat** (**SSE streaming** optional on Tier B) |
+| **Embed widget** | **Consumer chat** UX over **sync JSON chat** (CSS loading/motion; no token streaming) |
 | **Claude API** | Reasoning + tool_use (server-side only) |
 | **Upstream APIs** | NeNe Records public/search APIs (read-only client) |
 | **MCP tools** | Ops read-only — never consumer-facing |

--- a/docs/inheritance-from-nene2.md
+++ b/docs/inheritance-from-nene2.md
@@ -53,7 +53,7 @@ Install NENE2 as a Composer dependency and treat `vendor/hideyukimori/nene2/docs
 | Backend standards | `docs/development/backend-standards.md` |
 | Language policy | English for public docs, OpenAPI, API errors; Japanese allowed in Issues, PRs, commits, `.cursor/rules/` |
 | Review checklists | `docs/review/` — task-specific lists for this product |
-| Transport | **sync JSON chat** (Phase 2+ default); **SSE streaming** optional (Tier B) — ADR 0003, [`glossary.md`](./explanation/glossary.md) |
+| Transport | **sync JSON chat** only — ADR 0003, [`glossary.md`](./explanation/glossary.md) |
 | Deployment | Tier A shared hosting + Tier B Docker/VPS — `docs/deployment/` |
 | External services | Claude API (server-side), optional NeNe Records HTTP client |
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -7,7 +7,8 @@ Last updated: 2026-05-25
 - Phase 1 完了 — corpus ingestion milestone (#7–#15)
 - Phase 2 完了 — chat sessions, chunk search, sync JSON, rate limiting
 - Phase 3 進行 — frontend monorepo, widget, admin UI, appearance, i18n, admin デザイン (#33–#92)
-- Phase 3+ バックログ追記 — オペレーター docs、テキスト取り込み、Widget UX 拡張（本ファイル）
+- Phase 3+ バックログ追記 — オペレーター docs、テキスト取り込み、Widget UX 拡張
+- SSE 非ゴールを ADR・product docs に統一 (#97)
 
 ## 状態サマリー
 


### PR DESCRIPTION
## Summary

- ADR 0003, product-vision, glossary, deployment, backend-standards, README, AGENTS
- **sync JSON chat** のみ。モダン UX は widget CSS（loading / bubble motion / scroll）
- **SSE streaming** は non-goal として明記

Closes #97

## Test plan

- [ ] docs 内に optional SSE 実装予定の記述が残っていない（non-goal 除く）

Made with [Cursor](https://cursor.com)