### PR TITLE
feat(release): Tier A 向け release ZIP ビルド (#103)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,48 @@
+name: Release Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  release-zip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pdo, pdo_sqlite, zip
+          coverage: none
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Clone NENE2 (sibling path for Composer)
+        run: |
+          if [ ! -f ../NENE2/composer.json ]; then
+            git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git ../NENE2
+          fi
+          test -f ../NENE2/composer.json
+
+      - name: Build release ZIP
+        run: composer release:zip
+
+      - name: Verify ZIP contents
+        run: |
+          test -f build/release/nene-corpus-*.zip
+          unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/vendor/autoload.php'
+          unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/admin/index.html'
+          unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/widget.js'

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,11 @@
 /.php-cs-fixer.cache
 /var/
 /public_html/assets/
+/public_html/admin/*
+!/public_html/admin/.htaccess
 /public_html/widget.js
 /public_html/widget.css
+/build/
 /frontend/node_modules/
 /frontend/apps/*/dist/
 /storage/uploads/

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,9 @@
         "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=.",
         "migrations:status": "phinx status -c phinx.php",
         "migrations:migrate": "phinx migrate -c phinx.php",
-        "migrations:rollback": "phinx rollback -c phinx.php",
-        "check": [
+    "migrations:rollback": "phinx rollback -c phinx.php",
+    "release:zip": "bash tools/build-release.sh",
+    "check": [
             "@test",
             "@analyse",
             "@cs",

--- a/docs/deployment/shared-hosting.md
+++ b/docs/deployment/shared-hosting.md
@@ -2,7 +2,7 @@
 
 Operator guide for **Tier A** **shared hosting** — the primary deployment target for Japan SMB. See ADR 0003 and [`glossary.md`](../explanation/glossary.md).
 
-> **Status:** This path is the **product target** for operators. The **web installer** and **release ZIP** ship in **Phase 3**. Until then, advanced operators can deploy manually using the requirements below; Docker remains the supported development path (Tier B).
+> **Status:** **Web installer** and **release ZIP** are available in Phase 3. Docker remains the supported development path (Tier B).
 
 ## Who this is for
 
@@ -26,11 +26,12 @@ NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on 
 
 ## Planned install flow (Phase 3)
 
-1. Download **release ZIP** (includes `vendor/` — no Composer required on server).
+1. Download **release ZIP** from project releases (includes `vendor/` — no Composer required on server).
+   Maintainers build with `composer release:zip` — see [`tools/README.md`](../../tools/README.md).
 2. Upload via FTP or hosting file manager to e.g. `/nene-corpus/` under the domain.
-3. Open **web installer** in browser — database credentials, admin account, optional API keys.
+3. Open **web installer** at `/nene-corpus/install/` — database credentials, admin account, optional API keys.
 4. Run migrations from installer (no SSH required).
-5. Copy the **embed widget** snippet from admin UI into existing homepage template.
+5. Sign in at `/nene-corpus/admin/` and copy the **embed widget** snippet into your homepage template.
 
 ## Embed on existing homepage
 

--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -70,8 +70,10 @@ frontend/
 
 | App | Command | Output |
 | --- | --- | --- |
-| Admin | `npm run build -w @nene-corpus/admin` | `frontend/apps/admin/dist/` |
+| Admin (dev) | `npm run build -w @nene-corpus/admin` | `frontend/apps/admin/dist/` |
+| Admin (release) | `npm run build:release:admin` | `public_html/admin/` |
 | Widget | `npm run build -w @nene-corpus/widget` | `public_html/widget.js` (+ `widget.css`) |
+| **Tier A ZIP** | `composer release:zip` | `build/release/nene-corpus-<git-sha>.zip` |
 
 Public embed file name is fixed: **`widget.js`** (glossary: **embed widget**).
 

--- a/docs/milestones/2026-05-admin-ui-and-widget.md
+++ b/docs/milestones/2026-05-admin-ui-and-widget.md
@@ -15,7 +15,8 @@ Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 3.
 - [x] **embed widget** wired to **sync JSON chat** (#37)
 - [x] conversation logs
 - [x] Appearance settings (operator theme overrides)
-- [ ] **web installer** + **release ZIP** (Tier A)
+- [x] **web installer** (#101)
+- [x] **release ZIP** (#103)
 - [ ] Shared-hosting operator docs update
 
 ## Phase 3+ backlog (agreed, not started)

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -24,7 +24,7 @@ Last updated: 2026-05-25
 | Admin sources / ingestion / conversation logs | ✅ |
 | Widget i18n + Appearance settings | ✅ |
 | Admin i18n + locale fonts + light/dark theme | ✅ |
-| **Tier A web installer + release ZIP** | 🔜 |
+| **Tier A web installer + release ZIP** | ✅ installer / ✅ ZIP build |
 | **Shared-hosting operator docs（installer 連動）** | 🔜 |
 
 `composer check` / `npm run check --prefix frontend` / GitHub Actions CI green。
@@ -36,7 +36,7 @@ Last updated: 2026-05-25
 | 優先 | 項目 | 説明 |
 | --- | --- | --- |
 | P0 | **Web installer** | DB・管理者・API キー初回設定（ブラウザ完結） |
-| P0 | **Release ZIP** | vendor 同梱、FTP アップロード想定 |
+| P0 | **Release ZIP** | `composer release:zip` — vendor 同梱、FTP アップロード想定 ✅ |
 | P1 | Shared-hosting docs 更新 | installer 手順と整合 |
 
 Milestone: [`docs/milestones/2026-05-admin-ui-and-widget.md`](../milestones/2026-05-admin-ui-and-widget.md)

--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -5,8 +5,12 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
 const appRoot = fileURLToPath(new URL('.', import.meta.url));
+const adminOutDir = process.env.NENE_CORPUS_ADMIN_OUT
+  ? resolve(appRoot, process.env.NENE_CORPUS_ADMIN_OUT)
+  : resolve(appRoot, 'dist');
 
 export default defineConfig({
+  base: './',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
@@ -28,7 +32,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: 'dist',
+    outDir: adminOutDir,
     emptyOutDir: true,
   },
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "check": "npm run typecheck --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
+    "build:release": "npm run build:release:admin && npm run build -w @nene-corpus/widget",
+    "build:release:admin": "NENE_CORPUS_ADMIN_OUT=../../../public_html/admin npm run build -w @nene-corpus/admin",
     "dev:admin": "npm run dev -w @nene-corpus/admin",
     "dev:widget": "npm run dev -w @nene-corpus/widget"
   },

--- a/public_html/admin/.htaccess
+++ b/public_html/admin/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine On
+
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.html [QSA,L]

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,11 +3,31 @@
 | Script | Purpose |
 | --- | --- |
 | `tools/validate-openapi.php` | Validate `docs/openapi/openapi.yaml` structure and `$ref` integrity |
+| `tools/build-release.sh` | Build Tier A **release ZIP** (`vendor/` + frontend assets) for shared hosting |
 
 Composer scripts:
 
 ```bash
-composer check      # full quality gate
-composer openapi    # OpenAPI validation only
-composer mcp        # MCP catalog validation
+composer check        # full quality gate
+composer openapi      # OpenAPI validation only
+composer mcp          # MCP catalog validation
+composer release:zip  # build build/release/nene-corpus-<sha>.zip
 ```
+
+## Release ZIP (Tier A)
+
+Requires:
+
+- PHP 8.4+ with `zip` extension (CLI `zip` command)
+- Node.js 20+ and npm
+- [NENE2](https://github.com/hideyukiMORI/NENE2) as a sibling directory (`../NENE2`) or `NENE2_DIR`
+
+```bash
+composer release:zip
+```
+
+Output: `build/release/nene-corpus-<git-sha>.zip`
+
+Upload the extracted `nene-corpus/` folder via FTP, point the vhost (or subdirectory) at `public_html/`, then open `/install/`.
+
+See [`docs/deployment/shared-hosting.md`](../docs/deployment/shared-hosting.md).

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Build a Tier A release ZIP — vendor bundled, frontend assets in public_html/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+NENE2_DIR="${NENE2_DIR:-$(dirname "$ROOT")/NENE2}"
+BUILD_DIR="${RELEASE_BUILD_DIR:-$ROOT/build/release}"
+STAGING_DIR="$BUILD_DIR/staging/nene-corpus"
+VERSION="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo dev)"
+ZIP_PATH="${RELEASE_ZIP:-$BUILD_DIR/nene-corpus-${VERSION}.zip}"
+
+echo "==> NeNe Corpus release build (${VERSION})"
+
+if [[ ! -f "$NENE2_DIR/composer.json" ]]; then
+  echo "error: NENE2 not found at ${NENE2_DIR}. Clone it as a sibling or set NENE2_DIR." >&2
+  exit 1
+fi
+
+echo "==> Install PHP dependencies (production)"
+composer install --no-interaction --no-dev --prefer-dist --optimize-autoloader
+
+echo "==> Build frontend (admin → public_html/admin, widget → public_html/)"
+(
+  cd frontend
+  npm ci
+  npm run build:release
+)
+
+required_paths=(
+  public_html/index.php
+  public_html/install/index.html
+  public_html/admin/index.html
+  public_html/widget.js
+  public_html/widget.css
+  vendor/autoload.php
+)
+
+for path in "${required_paths[@]}"; do
+  if [[ ! -e "$ROOT/$path" ]]; then
+    echo "error: missing required release artifact: $path" >&2
+    exit 1
+  fi
+done
+
+echo "==> Stage release tree"
+rm -rf "$BUILD_DIR/staging"
+mkdir -p "$STAGING_DIR" "$STAGING_DIR/var" "$STAGING_DIR/storage/uploads"
+
+rsync -a \
+  --exclude='.git/' \
+  --exclude='.github/' \
+  --exclude='.cursor/' \
+  --exclude='.env' \
+  --exclude='.env.*' \
+  --exclude='.phpunit.cache/' \
+  --exclude='.phpunit.result.cache' \
+  --exclude='.phpstan.cache/' \
+  --exclude='.php-cs-fixer.cache' \
+  --exclude='build/' \
+  --exclude='docker/' \
+  --exclude='frontend/' \
+  --exclude='node_modules/' \
+  --exclude='tests/' \
+  --exclude='var/*' \
+  --exclude='storage/uploads/*' \
+  "$ROOT/" "$STAGING_DIR/"
+
+touch "$STAGING_DIR/storage/uploads/.gitkeep"
+
+echo "==> Create ZIP: ${ZIP_PATH}"
+mkdir -p "$(dirname "$ZIP_PATH")"
+rm -f "$ZIP_PATH"
+
+if command -v zip >/dev/null 2>&1; then
+  (
+    cd "$BUILD_DIR/staging"
+    zip -rq "$ZIP_PATH" nene-corpus
+  )
+else
+  php -r '
+    $zipPath = getenv("ZIP_PATH");
+    $stagingDir = getenv("STAGING_PARENT");
+    $rootName = "nene-corpus";
+    $zip = new ZipArchive();
+    if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+        fwrite(STDERR, "error: unable to create zip archive\n");
+        exit(1);
+    }
+    $base = $stagingDir . "/" . $rootName;
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($base, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::SELF_FIRST,
+    );
+    foreach ($iterator as $file) {
+        $path = $file->getPathname();
+        $local = $rootName . "/" . substr($path, strlen($base) + 1);
+        if ($file->isDir()) {
+            $zip->addEmptyDir(rtrim(str_replace("\\", "/", $local), "/"));
+            continue;
+        }
+        $zip->addFile($path, str_replace("\\", "/", $local));
+    }
+    $zip->close();
+  ' ZIP_PATH="$ZIP_PATH" STAGING_PARENT="$BUILD_DIR/staging"
+fi
+
+echo "==> Done"
+echo "    ${ZIP_PATH}"
+echo "    $(du -h "$ZIP_PATH" | cut -f1) — upload nene-corpus/ to hosting, then open /install/"


### PR DESCRIPTION
## Summary

- `tools/build-release.sh` + `composer release:zip` — production `vendor/`、admin（`public_html/admin/`）、widget を同梱した ZIP を生成
- Admin release ビルドは `base: './'` でサブディレクトリ設置に対応
- `public_html/admin/.htaccess` — SPA ルーティング fallback
- CI: `.github/workflows/release-build.yml` で ZIP 生成を検証
- docs / todo / milestone を更新

Closes #103

## Test plan

- [ ] `composer release:zip` が `build/release/nene-corpus-*.zip` を生成する
- [ ] ZIP に `vendor/autoload.php`、`public_html/admin/index.html`、`public_html/widget.js` が含まれる
- [ ] Release Build CI green
- [ ] `composer check` / `npm run check --prefix frontend` green

Self-review: backend-api

Made with [Cursor](https://cursor.com)