### PR TITLE
docs(deployment): shared-hosting オペレーター手順を更新 (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NeNe Corpus is a self-hosted, open-source knowledge chat platform built on [NENE
 
 - **Self-hosted OSS** — MIT licensed; shared hosting or VPS/private cloud
 - **Cited answers** — every response links back to document chunks
-- **Easy embed** — one `<script>` for the **embed widget** on same-origin pages (Phase 3)
+- **Easy embed** — **embed widget** on same-origin pages ([`docs/deployment/shared-hosting.md`](./docs/deployment/shared-hosting.md))
 - **Secure by design** — audit logs, tenant boundaries, no DB bypass for AI tools
 - **AI-readable** — OpenAPI contract, MCP for ops, explicit Clean Architecture
 - **Sibling to NeNe Records** — optional CMS upstream; never merged into the CMS repo
@@ -38,7 +38,9 @@ curl -fsS http://localhost:8080/health
 
 ### Shared hosting — Japan SMB (Tier A)
 
-Web installer and release ZIP ship in Phase 3. Requirements and planned flow:
+1. Download the **release ZIP** and upload via FTP.
+2. Run the **web installer** at `/install/`.
+3. Manage corpus and chat from **Admin**; embed the widget on your existing site.
 
 > [`docs/deployment/shared-hosting.md`](./docs/deployment/shared-hosting.md)
 
@@ -62,15 +64,15 @@ Ops / AI (MCP)         ───────────────────
 
 ## Current Status
 
-**Phase 0 — Governance & Foundation: complete (2026-05-25)**
+Phases 1–3 core deliverables are complete. See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 
 | Area | State |
 | --- | --- |
-| Governance docs | ADR 0001/0002/0003, inheritance map, Cursor rules |
-| Runtime scaffold | NENE2 consumer, `GET /health`, CI |
-| Ingestion API | Planned (Phase 1) |
-| Chat + citations | Planned (Phase 2) |
-| Admin UI + embed widget + Tier A installer | Planned (Phase 3) |
+| Corpus ingestion + admin API | ✅ |
+| Sync JSON chat + citations | ✅ |
+| Admin UI + embed widget | ✅ |
+| Tier A — installer + release ZIP + operator docs | ✅ |
+| Phase 4 — upstream integrations | Planned |
 
 See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -4,40 +4,55 @@ NeNe Corpus supports **dual deployment** — same product, two installation path
 
 | Tier | Document | Audience |
 | --- | --- | --- |
-| **Tier A — shared hosting** | [`shared-hosting.md`](./shared-hosting.md) | Japan SMB, PHP hosting + MySQL |
-| **Tier B — Docker / VPS** | [`../development/docker.md`](../development/docker.md) | Developers, VPS, private cloud |
-| **Tier B — git clone guide** | [`developer.md`](./developer.md) | Engineers adding Corpus beside an existing stack |
+| **Tier A — shared hosting** | [`shared-hosting.md`](./shared-hosting.md) | Japan SMB — FTP + web installer |
+| **Tier B — Docker / VPS** | [`../development/docker.md`](../development/docker.md) | Developers, reproducible stacks |
+| **Tier B — git clone** | [`developer.md`](./developer.md) | Engineers beside an existing system |
 
 ## Quick reference
 
-**Tier B (available now — development and VPS):**
+### Tier A — shared hosting (operators)
+
+1. Download **release ZIP** (or obtain from your integrator).
+2. Upload `nene-corpus/` via FTP; map URL to `public_html/`.
+3. Open **`/install/`** in a browser — database, admin account, optional API keys.
+4. Sign in at **`/admin/`**, ingest CSV/PDF, embed **widget** on your homepage.
+
+Full guide: [`shared-hosting.md`](./shared-hosting.md)
+
+### Tier B — Docker / VPS (developers)
 
 ```bash
+git clone https://github.com/hideyukiMORI/nene-corpus.git
+cd nene-corpus
 cp .env.example .env
 docker compose up --build -d
 curl -fsS http://localhost:8080/health
 ```
 
-**Tier A (operator guide — web installer in Phase 3):**
-
-See [`shared-hosting.md`](./shared-hosting.md).
+Details: [`../development/docker.md`](../development/docker.md)
 
 ## Embed on an existing site
 
-After install, add the **embed widget** with one script tag on any page on the **same origin**:
+After install, add the **embed widget** on any **same-origin** page. Replace `/nene-corpus` with your base path:
 
 ```html
-<script
-  src="/nene-corpus/widget.js"
-  data-endpoint="/nene-corpus"
-  defer
-></script>
+<link rel="stylesheet" href="/nene-corpus/widget.css" />
+<div id="nene-corpus-widget-root"></div>
+<script src="/nene-corpus/widget.js" data-endpoint="/nene-corpus" defer></script>
+<script>
+  window.addEventListener('DOMContentLoaded', function () {
+    var target = document.getElementById('nene-corpus-widget-root');
+    if (target && window.NeneCorpusWidget) {
+      window.NeneCorpusWidget.init(target);
+    }
+  });
+</script>
 ```
 
-Exact paths and attributes will be documented when the **embed widget** ships (Phase 3). **Same origin** avoids CORS complexity on **shared hosting**.
+**Same origin** avoids CORS complexity on shared hosting. See [`shared-hosting.md`](./shared-hosting.md) for subdirectory and WordPress notes.
 
 ## Chat transport
 
 - **Both tiers:** **sync JSON chat** only — POST a message, receive full reply + **citations**.
-- **Embed widget** adds loading indicators and CSS motion (bubble fade-in, scroll); no token streaming.
-- **Non-goal:** **SSE streaming** — not planned.
+- **Embed widget** adds loading indicators and CSS motion; no token streaming.
+- **Non-goal:** **SSE streaming** — not planned (ADR 0003).

--- a/docs/deployment/shared-hosting.md
+++ b/docs/deployment/shared-hosting.md
@@ -2,79 +2,249 @@
 
 Operator guide for **Tier A** **shared hosting** — the primary deployment target for Japan SMB. See ADR 0003 and [`glossary.md`](../explanation/glossary.md).
 
-> **Status:** **Web installer** and **release ZIP** are available in Phase 3. Docker remains the supported development path (Tier B).
+NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on the **same origin** as your existing homepage and adds a cited **embed widget** via a short HTML snippet.
+
+Engineers on VPS or Docker should use [`developer.md`](./developer.md) or [`../development/docker.md`](../development/docker.md) instead.
+
+---
 
 ## Who this is for
 
 - Companies with an existing homepage on rental hosting (さくura, エックスサーバー, ロリポップ, ConoHa WING, etc.)
-- Operators who want **WordPress-like adoption** — upload, run installer, use admin UI — without replacing their current site
+- Operators who want **WordPress-like adoption** — upload, run installer, manage from admin UI
 - Teams that need corpus and chat data on **their MySQL**, not a SaaS vendor
 
-NeNe Corpus is **not a WordPress plugin**. It installs as a separate PHP app on the **same origin** and embeds **embed widget** into existing pages via one script tag.
+---
 
 ## Requirements
 
 | Requirement | Notes |
 | --- | --- |
-| PHP | 8.2+ planned for Tier A (8.4 for development); confirm with host |
-| Database | MySQL 8.x or MariaDB 10.x (SQLite possible for very small installs — not recommended for production chat) |
-| Web server | Apache with `mod_rewrite` or nginx equivalent; document root includes `public_html/` |
-| HTTPS | Recommended for admin JWT and widget sessions |
-| Outbound HTTPS | Required from Phase 2 (Claude API) — confirm host allows external API calls |
-| Writable dirs | `storage/uploads/`, `var/` or configured cache paths |
-| Cron | Optional but recommended for reindex and cleanup (Phase 1+) |
+| PHP | **8.4+** (matches release ZIP; confirm with your host) |
+| Extensions | `pdo`, `pdo_mysql` (or `pdo_sqlite` for tiny test installs), `json`, `mbstring`, `openssl` |
+| Database | **MySQL 8.x** or **MariaDB 10.x** recommended for production |
+| Web server | Apache + `mod_rewrite`, or nginx with equivalent front-controller routing |
+| HTTPS | Strongly recommended for admin JWT and widget sessions |
+| Outbound HTTPS | Required for Claude API — confirm the host allows external HTTPS |
+| Writable dirs | `storage/uploads/`, `var/` (installer creates `var/installed.lock`) |
+| FTP / file manager | Upload release ZIP contents; SSH optional |
+| Composer on server | **Not required** — `vendor/` is bundled in the release ZIP |
 
-## Planned install flow (Phase 3)
+SQLite is supported by the installer for very small or test installs. It is **not recommended** for production chat traffic.
 
-1. Download **release ZIP** from project releases (includes `vendor/` — no Composer required on server).
-   Maintainers build with `composer release:zip` — see [`tools/README.md`](../../tools/README.md).
-2. Upload via FTP or hosting file manager to e.g. `/nene-corpus/` under the domain.
-3. Open **web installer** at `/nene-corpus/install/` — database credentials, admin account, optional API keys.
-4. Run migrations from installer (no SSH required).
-5. Sign in at `/nene-corpus/admin/` and copy the **embed widget** snippet into your homepage template.
+---
 
-## Embed on existing homepage
+## What you upload
 
-**Same origin** — add one line to any page:
+Maintainers build a **release ZIP** with:
 
-```html
-<script
-  src="https://example.com/nene-corpus/widget.js"
-  data-endpoint="/nene-corpus"
-  defer
-></script>
+```bash
+composer release:zip   # see tools/README.md — requires Node.js + NENE2 sibling checkout
 ```
 
-Works alongside WordPress, static HTML, or other CMS pages on the **same origin**. The **embed widget** calls **sync JSON chat** (loading indicator and CSS motion while waiting).
+Operators receive `nene-corpus-<version>.zip` containing:
 
-## Manual deploy (until web installer exists)
+```text
+nene-corpus/
+├── public_html/          ← point the web server here (or map as subdirectory)
+│   ├── index.php         ← API front controller
+│   ├── admin/            ← Admin UI (static SPA)
+│   ├── install/          ← Web installer
+│   ├── widget.js
+│   └── widget.css
+├── vendor/               ← PHP dependencies (bundled)
+├── src/
+├── database/migrations/
+├── storage/uploads/      ← empty; must stay writable
+├── .env.example
+└── …
+```
 
-For early adopters with SSH or FTP + local build:
+Download from [GitHub Releases](https://github.com/hideyukiMORI/nene-corpus/releases) when published, or obtain the ZIP from your integrator.
 
-1. Run `composer install --no-dev` locally and create a ZIP of the project (including `vendor/`).
-2. Upload to hosting; point a subdomain or subdirectory to `public_html/`.
-3. Copy `.env.example` to `.env` and set `DB_*` for MySQL.
-4. Run `composer migrations:migrate` via SSH, or use a one-time migration script (to be provided in Phase 3).
-5. Ensure `storage/` is writable and not web-accessible.
+---
 
-See [Docker development](../development/docker.md) for the canonical runtime layout.
+## Install flow (recommended)
+
+### 1. Upload via FTP
+
+Extract the ZIP locally, then upload the **`nene-corpus/`** folder to your hosting account.
+
+**Typical layouts:**
+
+| Layout | Example URL | Notes |
+| --- | --- | --- |
+| **Subdirectory** | `https://example.com/nene-corpus/` | Most common — existing site stays at `/` |
+| **Subdomain docroot** | `https://corpus.example.com/` | Point subdomain document root at `nene-corpus/public_html/` |
+
+For subdirectory installs, the public URL path (e.g. `/nene-corpus`) is detected automatically and saved as `NENE_CORPUS_BASE_PATH` during install.
+
+### 2. Set permissions
+
+Ensure the web server user can write to:
+
+- `storage/uploads/` — typically `755` or `775`
+- `var/` — installer writes `installed.lock` here
+
+Project root (`.env`) must **not** be web-accessible — only `public_html/` is exposed.
+
+### 3. Run the web installer
+
+Open in a browser:
+
+```text
+https://example.com/nene-corpus/install/
+```
+
+Fill in:
+
+| Field | Notes |
+| --- | --- |
+| **Base path** | Pre-filled from server detection — usually `/nene-corpus` or empty for subdomain docroot |
+| **Database** | MySQL host, name, user, password (create an empty database in hosting panel first) |
+| **Admin email / password** | First operator account for Admin UI |
+| **Anthropic API key** | Optional during install; required before chat works — can add later |
+
+The installer will:
+
+1. Test the database connection
+2. Write `.env` (including `NENE_CORPUS_BASE_PATH` and `NENE2_LOCAL_JWT_SECRET`)
+3. Run database migrations
+4. Create the admin user
+5. Write `var/installed.lock` (blocks re-install)
+
+### 4. Sign in to Admin
+
+```text
+https://example.com/nene-corpus/admin/
+```
+
+Use the email and password from the installer.
+
+### 5. Ingest documents
+
+In Admin → upload CSV or PDF sources, map columns (CSV), and wait for indexing to complete.
+
+Set **Anthropic API key** in environment or hosting panel if not done during install (`ANTHROPIC_API_KEY` in `.env`).
+
+### 6. Embed the widget on your homepage
+
+Add the following to any page on the **same origin** (WordPress custom HTML block, theme footer, static HTML, etc.).
+
+Replace `/nene-corpus` with your **base path** if different (installer shows detected paths at `/install/`):
+
+```html
+<link rel="stylesheet" href="/nene-corpus/widget.css" />
+<div id="nene-corpus-widget-root"></div>
+<script src="/nene-corpus/widget.js" data-endpoint="/nene-corpus" defer></script>
+<script>
+  window.addEventListener('DOMContentLoaded', function () {
+    var target = document.getElementById('nene-corpus-widget-root');
+    if (target && window.NeneCorpusWidget) {
+      window.NeneCorpusWidget.init(target);
+    }
+  });
+</script>
+```
+
+- `data-endpoint` — public API base path (same as base path; **no** `/api` suffix)
+- Widget appearance (colors, default language) — configure in Admin → Appearance
+
+The **embed widget** uses **sync JSON chat** (full reply + citations). A loading indicator and CSS motion appear while waiting — no token streaming.
+
+---
+
+## Apache (subdirectory) example
+
+If you map `/nene-corpus/` to `public_html/` and the host uses Apache, `public_html/.htaccess` is included:
+
+```apache
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]
+```
+
+Admin SPA routing uses `public_html/admin/.htaccess` similarly.
+
+---
+
+## nginx (subdirectory) sketch
+
+Ask your host or set a location block (paths illustrative):
+
+```nginx
+location /nene-corpus/ {
+    alias /path/to/nene-corpus/public_html/;
+    try_files $uri $uri/ /nene-corpus/index.php?$query_string;
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $request_filename;
+        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
+    }
+}
+```
+
+Exact directives vary by host — use their PHP + subdirectory documentation as the source of truth.
+
+---
+
+## Manual install (SSH fallback)
+
+If the web installer is unavailable but you have SSH:
+
+1. Upload the release ZIP contents (or run `composer release:zip` locally and upload).
+2. Copy `.env.example` to `.env` and set `DB_*`, `NENE2_LOCAL_JWT_SECRET`, `NENE_CORPUS_BASE_PATH`, `ANTHROPIC_API_KEY`.
+3. Run `php vendor/bin/phinx migrate -c phinx.php` from the project root.
+4. Insert an admin user into `admin_users` (password: `password_hash()` with Argon2id).
+5. `touch var/installed.lock` to disable the browser installer.
+6. Ensure `storage/uploads/` is writable.
+
+Prefer the **web installer** when FTP-only access is enough.
+
+---
+
+## After install checklist
+
+- [ ] `https://example.com/nene-corpus/health` returns `{"status":"ok",…}`
+- [ ] Admin login works at `/nene-corpus/admin/`
+- [ ] At least one CSV or PDF source ingested
+- [ ] `ANTHROPIC_API_KEY` set — test a question in the embed widget
+- [ ] Embed snippet added to the public homepage
+- [ ] HTTPS enabled on the domain
+
+---
 
 ## Limitations on shared hosting
 
-- **PDF ingestion** may hit execution time and upload size limits — split large files or use Tier B for heavy **ingestion**.
-- **Claude API** usage is pay-as-you-go — configure keys in admin UI (Phase 2+).
+- **PDF ingestion** may hit PHP `max_execution_time` and upload size limits — split large files or use Tier B (Docker/VPS) for heavy ingestion.
+- **Claude API** is pay-as-you-go — monitor usage in your Anthropic account.
+- **SSE / token streaming** is not supported — sync JSON chat only (see ADR 0003).
+- **Consumer MCP** is not exposed to the widget — admin/ops only.
+
+---
 
 ## Troubleshooting
 
-Document host-specific fixes in Issues/PRs as they appear. Common checks:
+| Symptom | Check |
+| --- | --- |
+| 404 on `/admin/` routes | `public_html/admin/.htaccess` present; `mod_rewrite` enabled |
+| 404 on API (`/health`, `/chat/…`) | `public_html/.htaccess` present; requests reach `index.php` |
+| Installer returns “already installed” | `var/installed.lock` exists — delete only if intentionally re-installing |
+| Database connection failed | Host name (often not `localhost` on shared hosts), user grants, empty database created |
+| Chat returns errors | `ANTHROPIC_API_KEY` in `.env`; outbound HTTPS allowed |
+| Widget loads but chat fails | `data-endpoint` matches base path; same origin as API |
+| Wrong asset paths | `NENE_CORPUS_BASE_PATH` in `.env` matches URL prefix; re-run install or fix manually |
 
-- `public_html/index.php` reachable; rewrite rules pass requests to front controller
-- MySQL user has CREATE/ALTER during install only
-- `storage/` permissions (typically `755` or `775` depending on host)
+Host-specific fixes — document in GitHub Issues/PRs as they appear.
+
+---
 
 ## Related
 
-- ADR 0003: `docs/adr/0003-dual-deployment-and-embed-widget.md`
-- Docker / VPS (Tier B): `docs/development/docker.md`
-- Product vision: `docs/explanation/product-vision.md`
-- Glossary: `docs/explanation/glossary.md`
+- Release ZIP build: [`../../tools/README.md`](../../tools/README.md)
+- Engineer / VPS path: [`developer.md`](./developer.md)
+- ADR 0003: [`../adr/0003-dual-deployment-and-embed-widget.md`](../adr/0003-dual-deployment-and-embed-widget.md)
+- Product vision: [`../explanation/product-vision.md`](../explanation/product-vision.md)
+- Glossary: [`../explanation/glossary.md`](../explanation/glossary.md)

--- a/docs/milestones/2026-05-admin-ui-and-widget.md
+++ b/docs/milestones/2026-05-admin-ui-and-widget.md
@@ -2,7 +2,7 @@
 
 Goal: operable product without curl — React admin, **embed widget**, Tier A install path.
 
-**Status: in progress**
+**Status: complete (2026-05-25)**
 
 Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 3.
 
@@ -17,7 +17,7 @@ Tracked by [`docs/roadmap.md`](../roadmap.md) Phase 3.
 - [x] Appearance settings (operator theme overrides)
 - [x] **web installer** (#101)
 - [x] **release ZIP** (#103)
-- [ ] Shared-hosting operator docs update
+- [x] Shared-hosting operator docs (#105)
 
 ## Phase 3+ backlog (agreed, not started)
 
@@ -29,6 +29,7 @@ See [`docs/todo/current.md`](../todo/current.md) — operator docs, text paste i
 npm run check --prefix frontend
 npm run build --prefix frontend
 composer check
+composer release:zip
 ```
 
 ## Related
@@ -37,5 +38,9 @@ composer check
 - Issue #37 — embed widget sync JSON chat
 - Issue #39 — admin sources list API + UI
 - Issue #45 — admin CSV/PDF upload UI
+- Issue #101 — web installer
+- Issue #103 — release ZIP
+- Issue #105 — shared-hosting operator docs
+- [`docs/deployment/shared-hosting.md`](../deployment/shared-hosting.md)
 - [`docs/development/frontend-standards.md`](../development/frontend-standards.md)
 - ADR 0003 — dual deployment and embed widget

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,6 +58,8 @@ Goal: operable product without curl; Tier A install path.
 - Prompt / scope / fallback settings UI
 - **Tier A deliverables:** **web installer**, **release ZIP** (vendor bundled), shared-hosting operator docs
 
+**Status: complete (2026-05-25).** Milestone: [`milestones/2026-05-admin-ui-and-widget.md`](./milestones/2026-05-admin-ui-and-widget.md).
+
 ## Phase 4: Upstream Integrations
 
 Goal: optional NeNe Records and export APIs.
@@ -71,7 +73,7 @@ Goal: optional NeNe Records and export APIs.
 | Tier | Phase | Deliverable |
 | --- | --- | --- |
 | **Tier B — Docker / VPS** | 0 (now) | `docker compose up`, `docs/development/docker.md` |
-| **Tier A — shared hosting** | 3 | **web installer**, **release ZIP**, `docs/deployment/shared-hosting.md` |
+| **Tier A — shared hosting** | 3 ✅ | **web installer**, **release ZIP**, [`docs/deployment/shared-hosting.md`](./deployment/shared-hosting.md) |
 
 Same API and **embed widget** for both tiers. Chat uses **sync JSON chat** by default.
 

--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -8,7 +8,7 @@ Last updated: 2026-05-25
 - Phase 2 完了 — chat sessions, chunk search, sync JSON, rate limiting
 - Phase 3 進行 — frontend monorepo, widget, admin UI, appearance, i18n, admin デザイン (#33–#92)
 - Phase 3+ バックログ追記 — オペレーター docs、テキスト取り込み、Widget UX 拡張
-- SSE 非ゴールを ADR・product docs に統一 (#97)
+- Tier A 完了 — web installer (#101)、release ZIP (#103)、shared-hosting docs (#105)
 
 ## 状態サマリー
 
@@ -16,7 +16,7 @@ Last updated: 2026-05-25
 
 **Phase 2 — Chat & Citations: 完了（2026-05-25）**
 
-**Phase 3 — Admin UI & Widget: 進行中（2026-05-25）**
+**Phase 3 — Admin UI & Widget: 完了（2026-05-25）**
 
 | 項目 | 状態 |
 | --- | --- |
@@ -25,7 +25,7 @@ Last updated: 2026-05-25
 | Widget i18n + Appearance settings | ✅ |
 | Admin i18n + locale fonts + light/dark theme | ✅ |
 | **Tier A web installer + release ZIP** | ✅ installer / ✅ ZIP build |
-| **Shared-hosting operator docs（installer 連動）** | 🔜 |
+| **Shared-hosting operator docs（installer 連動）** | ✅ |
 
 `composer check` / `npm run check --prefix frontend` / GitHub Actions CI green。
 
@@ -33,11 +33,7 @@ Last updated: 2026-05-25
 
 ## Phase 3 残り（Tier A）
 
-| 優先 | 項目 | 説明 |
-| --- | --- | --- |
-| P0 | **Web installer** | DB・管理者・API キー初回設定（ブラウザ完結） |
-| P0 | **Release ZIP** | `composer release:zip` — vendor 同梱、FTP アップロード想定 ✅ |
-| P1 | Shared-hosting docs 更新 | installer 手順と整合 |
+Tier A コア（installer、release ZIP、operator docs）は完了。Phase 3 milestone クローズ後、Phase 3+ バックログを再整理。
 
 Milestone: [`docs/milestones/2026-05-admin-ui-and-widget.md`](../milestones/2026-05-admin-ui-and-widget.md)
 


### PR DESCRIPTION
## Summary

- `docs/deployment/shared-hosting.md` を FTP → installer → admin → embed のオペレーター正本に刷新
- `docs/deployment/README.md` — Tier A クイックリファレンスと正しい embed スニペット
- `README.md` — Tier A 手順と Current Status を現状に更新
- Phase 3 milestone / todo / roadmap を完了反映

Closes #105

## Test plan

- [ ] 手順が installer + release ZIP フローと矛盾しない
- [ ] embed スニペットが `developer.md` / 実装と一致
- [ ] docs-only — CI green

Self-review: docs-policy

Made with [Cursor](https://cursor.com)