### PR TITLE
fix(frontend): i18n キー追加後の Vite stale cache でプレビューが真っ白になる (#113)

### DIFF
--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -63,6 +63,7 @@ frontend/
 - **Theme (Admin):** light/dark via CSS variables on `:root` / `.dark`. Toggle in header; persist `nene-corpus.admin.theme` (`light` | `dark`, default from `prefers-color-scheme`). Small radius tokens (`rounded-admin*` ≈ 4–8px), subtle page gradient, glassy header (`backdrop-blur`). Reuse `nc-panel`, `nc-input`, `nc-btn*` component classes.
 - Use `formatTimestamp(value, locale)` for locale-aware dates.
 - Pair labels with optional help via `HelpLabel` (`label` + `help` strings from `Msg.*Help` keys). Tooltip opens on hover and keyboard focus; use `\n` in help strings for line breaks. CSV column mapping also has a collapsible `ColumnMappingGuide` accordion after preview.
+- **`keys.ts` を更新したあと** dev サーバーが古い `Msg` ツリーを返すことがある（プレビュー真っ白・ボタン空文字）。`npm run dev --prefix frontend` を **admin (:5173) と widget (:5174) 両方再起動**する。`resolveMsgKey(Msg.*, 'literal.key')` で HMR 遅延時もフォールバック可能（`packages/i18n/src/resolve-msg-key.ts`）。
 
 ---
 

--- a/frontend/apps/admin/src/AppearancePanel.tsx
+++ b/frontend/apps/admin/src/AppearancePanel.tsx
@@ -7,7 +7,7 @@ import {
   type WidgetHero,
   type WidgetTheme,
 } from '@nene-corpus/api-client';
-import { Msg, useMsg } from '@nene-corpus/i18n';
+import { Msg, resolveMsgKey, useMsg } from '@nene-corpus/i18n';
 import { adminApiBase } from './config';
 import { EmbedSnippetSection } from './EmbedSnippetSection';
 
@@ -245,7 +245,9 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
               />
             </label>
             <label className="block text-sm">
-              <span className="font-medium text-fg">{t(Msg.admin.appearance.maxWidth)}</span>
+              <span className="font-medium text-fg">
+                {t(resolveMsgKey(Msg.admin.appearance.maxWidth, 'admin.appearance.maxWidth'))}
+              </span>
               <input
                 className="nc-input"
                 type="text"

--- a/frontend/apps/admin/src/EmbedSnippetSection.tsx
+++ b/frontend/apps/admin/src/EmbedSnippetSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Msg, useMsg } from '@nene-corpus/i18n';
+import { Msg, resolveMsgKey, useMsg } from '@nene-corpus/i18n';
 import { adminApiBase } from './config';
 import { buildEmbedSnippet } from './embedSnippet';
 
@@ -17,7 +17,7 @@ export function EmbedSnippetSection() {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2000);
     } catch {
-      setCopyError(t(Msg.admin.appearance.embedCopyFailed));
+      setCopyError(t(resolveMsgKey(Msg.admin.appearance.embedCopyFailed, 'admin.appearance.embedCopyFailed')));
     }
   }
 
@@ -32,7 +32,9 @@ export function EmbedSnippetSection() {
       </pre>
       <div className="flex flex-wrap items-center gap-2">
         <button className="nc-btn-primary" type="button" onClick={() => void handleCopy()}>
-          {copied ? t(Msg.admin.appearance.embedCopied) : t(Msg.admin.appearance.embedCopy)}
+          {copied
+            ? t(resolveMsgKey(Msg.admin.appearance.embedCopied, 'admin.appearance.embedCopied'))
+            : t(resolveMsgKey(Msg.admin.appearance.embedCopy, 'admin.appearance.embedCopy'))}
         </button>
         {copyError !== null && <p className="text-sm text-red-600">{copyError}</p>}
       </div>

--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
   server: {
     port: 5173,
     strictPort: true,
+    watch: {
+      ignored: ['**/node_modules/**', '!**/packages/**'],
+    },
     proxy: {
       '/health': 'http://localhost:8080',
       '/admin': 'http://localhost:8080',

--- a/frontend/apps/widget/src/ChatHero.tsx
+++ b/frontend/apps/widget/src/ChatHero.tsx
@@ -1,5 +1,5 @@
 import type { WidgetHero } from '@nene-corpus/api-client';
-import { Msg, useMsg } from '@nene-corpus/i18n';
+import { Msg, resolveMsgKey, useMsg } from '@nene-corpus/i18n';
 import { nc } from '@nene-corpus/tokens';
 
 export interface ChatHeroProps {
@@ -9,9 +9,14 @@ export interface ChatHeroProps {
 
 export function ChatHero({ hero, onCtaClick }: ChatHeroProps) {
   const t = useMsg();
-  const title = hero.title?.trim() || t(Msg.widget.hero.defaultTitle);
-  const description = hero.description?.trim() || t(Msg.widget.hero.defaultDescription);
-  const ctaLabel = hero.cta_label?.trim() || t(Msg.widget.hero.cta);
+  const title =
+    hero.title?.trim() ||
+    t(resolveMsgKey(Msg.widget.hero?.defaultTitle, 'widget.hero.defaultTitle'));
+  const description =
+    hero.description?.trim() ||
+    t(resolveMsgKey(Msg.widget.hero?.defaultDescription, 'widget.hero.defaultDescription'));
+  const ctaLabel =
+    hero.cta_label?.trim() || t(resolveMsgKey(Msg.widget.hero?.cta, 'widget.hero.cta'));
 
   return (
     <header className={nc.chatHero}>

--- a/frontend/apps/widget/vite.config.ts
+++ b/frontend/apps/widget/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
   server: {
     port: 5174,
     strictPort: true,
+    watch: {
+      ignored: ['**/node_modules/**', '!**/packages/**'],
+    },
     proxy: {
       '/chat': 'http://localhost:8080',
       '/widget/appearance': 'http://localhost:8080',

--- a/frontend/packages/i18n/src/index.ts
+++ b/frontend/packages/i18n/src/index.ts
@@ -1,3 +1,4 @@
+export { resolveMsgKey } from './resolve-msg-key';
 export { Msg } from './keys';
 export { LocaleProvider, useLocaleContext, type LocaleContextValue } from './LocaleProvider';
 export { useLocale, useMsg } from './useMsg';

--- a/frontend/packages/i18n/src/resolve-msg-key.ts
+++ b/frontend/packages/i18n/src/resolve-msg-key.ts
@@ -1,0 +1,6 @@
+import type { MsgKey } from './types';
+
+/** Use when Msg tree may lag behind catalog during Vite HMR (returns a valid MsgKey). */
+export function resolveMsgKey(candidate: string | undefined, fallback: MsgKey): MsgKey {
+  return (candidate ?? fallback) as MsgKey;
+}

--- a/public_html/widget-preview.html
+++ b/public_html/widget-preview.html
@@ -9,13 +9,5 @@
   <body>
     <div id="nene-corpus-widget-root"></div>
     <script src="/widget.js" defer></script>
-    <script>
-      window.addEventListener('DOMContentLoaded', function () {
-        var target = document.getElementById('nene-corpus-widget-root');
-        if (target && window.NeneCorpusWidget) {
-          window.NeneCorpusWidget.init(target);
-        }
-      });
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- `resolveMsgKey()` を追加し、`Msg` ツリーが HMR 遅延で undefined でもカタログから翻訳できるようにした（プレビュー真っ白・コピーボタン空文字の防止）
- admin / widget の Vite `watch` で `packages/**` を監視し、`keys.ts` 更新を拾いやすくした
- `widget-preview.html` を auto-init に統一（手動 `NeneCorpusWidget.init` ブロック削除）
- `frontend-standards.md` に dev 再起動の注記を追加

Self-review: docs-policy

## Test plan

- [x] `npm run check --prefix frontend`
- [ ] http://localhost:5173/admin 外観設定 — プレビュー iframe に HERO 表示
- [ ] embed スニペット「コピー」ボタンに文言表示
- [ ] CI green → merge

Closes #113

Made with [Cursor](https://cursor.com)