### PR TITLE
feat(admin): 管理画面内 Help / Docs パネルを追加 (#117)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -4,8 +4,10 @@ import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
 import { ConversationLogsPanel } from './ConversationLogsPanel';
 import { AppearancePanel } from './AppearancePanel';
+import { HelpPanel } from './HelpPanel';
 import { LocaleSelector } from './LocaleSelector';
 import { ThemeToggle } from './ThemeToggle';
+import { scrollToHelp } from './scrollToHelp';
 import { useAdminAuth } from './useAdminAuth';
 
 export function App() {
@@ -36,6 +38,9 @@ export function App() {
             {profile && <p className="nc-text-muted">{profile.email}</p>}
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2">
+            <button className="nc-btn nc-header-btn" type="button" onClick={scrollToHelp}>
+              {t(Msg.admin.help.open)}
+            </button>
             <LocaleSelector />
             <ThemeToggle />
             {profile && (
@@ -48,13 +53,17 @@ export function App() {
       </header>
       <main className="mx-auto max-w-5xl space-y-6 px-6 py-8">
         {token === null ? (
-          <LoginForm error={error} onLogin={login} />
+          <>
+            <LoginForm error={error} onLogin={login} />
+            <HelpPanel />
+          </>
         ) : (
           <>
             <IngestionPanel token={token} onUploaded={() => setSourcesReloadKey((key) => key + 1)} />
             <SourcesPanel token={token} reloadKey={sourcesReloadKey} />
             <ConversationLogsPanel token={token} />
             <AppearancePanel token={token} />
+            <HelpPanel />
           </>
         )}
       </main>

--- a/frontend/apps/admin/src/HelpPanel.tsx
+++ b/frontend/apps/admin/src/HelpPanel.tsx
@@ -1,0 +1,38 @@
+import { Msg, useMsg } from '@nene-corpus/i18n';
+import { ADMIN_HELP_SECTIONS } from './helpSections';
+
+export function HelpPanel() {
+  const t = useMsg();
+
+  return (
+    <section id="admin-help" className="nc-panel scroll-mt-24">
+      <div className="nc-panel-head">
+        <h2 className="font-medium">{t(Msg.admin.help.title)}</h2>
+        <p>{t(Msg.admin.help.subtitle)}</p>
+      </div>
+      <div className="space-y-3 px-4 py-4">
+        {ADMIN_HELP_SECTIONS.map((section) => (
+          <details
+            key={section.titleKey}
+            className="group rounded-admin border border-accent-border bg-accent text-xs text-fg-muted"
+          >
+            <summary className="cursor-pointer list-none px-3 py-2.5 font-medium text-fg marker:content-none [&::-webkit-details-marker]:hidden">
+              <span className="inline-flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className="inline-block text-focus transition-transform group-open:rotate-90"
+                >
+                  ▶
+                </span>
+                {t(section.titleKey)}
+              </span>
+            </summary>
+            <div className="border-t border-accent-border px-3 py-3 leading-relaxed">
+              <p className="whitespace-pre-line nc-text-subtle">{t(section.bodyKey)}</p>
+            </div>
+          </details>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/admin/src/helpSections.ts
+++ b/frontend/apps/admin/src/helpSections.ts
@@ -1,0 +1,15 @@
+import { Msg, type MsgKey } from '@nene-corpus/i18n';
+
+export interface HelpSectionDef {
+  titleKey: MsgKey;
+  bodyKey: MsgKey;
+}
+
+export const ADMIN_HELP_SECTIONS: HelpSectionDef[] = [
+  { titleKey: Msg.admin.help.quickStart.title, bodyKey: Msg.admin.help.quickStart.body },
+  { titleKey: Msg.admin.help.ingestion.title, bodyKey: Msg.admin.help.ingestion.body },
+  { titleKey: Msg.admin.help.embed.title, bodyKey: Msg.admin.help.embed.body },
+  { titleKey: Msg.admin.help.appearance.title, bodyKey: Msg.admin.help.appearance.body },
+  { titleKey: Msg.admin.help.troubleshooting.title, bodyKey: Msg.admin.help.troubleshooting.body },
+  { titleKey: Msg.admin.help.faq.title, bodyKey: Msg.admin.help.faq.body },
+];

--- a/frontend/apps/admin/src/scrollToHelp.ts
+++ b/frontend/apps/admin/src/scrollToHelp.ts
@@ -1,0 +1,3 @@
+export function scrollToHelp(): void {
+  document.getElementById('admin-help')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -167,6 +167,35 @@ export const Msg = {
       loadFailed: 'admin.appearance.loadFailed',
       saveFailed: 'admin.appearance.saveFailed',
     },
+    help: {
+      title: 'admin.help.title',
+      subtitle: 'admin.help.subtitle',
+      open: 'admin.help.open',
+      quickStart: {
+        title: 'admin.help.quickStart.title',
+        body: 'admin.help.quickStart.body',
+      },
+      ingestion: {
+        title: 'admin.help.ingestion.title',
+        body: 'admin.help.ingestion.body',
+      },
+      embed: {
+        title: 'admin.help.embed.title',
+        body: 'admin.help.embed.body',
+      },
+      appearance: {
+        title: 'admin.help.appearance.title',
+        body: 'admin.help.appearance.body',
+      },
+      troubleshooting: {
+        title: 'admin.help.troubleshooting.title',
+        body: 'admin.help.troubleshooting.body',
+      },
+      faq: {
+        title: 'admin.help.faq.title',
+        body: 'admin.help.faq.body',
+      },
+    },
   },
   widget: {
     chat: {

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -160,6 +160,27 @@ export const de = defineMessages({
   'admin.appearance.saveSuccess': 'Einstellungen gespeichert.',
   'admin.appearance.loadFailed': 'Einstellungen konnten nicht geladen werden.',
   'admin.appearance.saveFailed': 'Einstellungen konnten nicht gespeichert werden.',
+  'admin.help.title': 'Hilfe & Betreiberhandbuch',
+  'admin.help.subtitle': 'Schnellstart, Embed-Setup und Fehlerbehebung in diesem Bildschirm.',
+  'admin.help.open': 'Hilfe',
+  'admin.help.quickStart.title': 'Schnellstart',
+  'admin.help.quickStart.body':
+    '1. Mit Betreiber-E-Mail und Passwort anmelden.\n2. Ingestion — CSV/PDF hochladen oder Text einfügen.\n3. Quellen — Status Ready prüfen.\n4. Erscheinungsbild — Farben anpassen und Embed-Snippet kopieren.\n5. Snippet auf der Homepage (gleiche Origin) einfügen und Chat testen.',
+  'admin.help.ingestion.title': 'Ingestion (CSV, PDF, Text)',
+  'admin.help.ingestion.body':
+    'Datei — CSV braucht Vorschau und Spalten-Mapping. PDF extrahiert Text pro Seite. Max. 5 MB.\n\nText — Tab Text einfügen für FAQ oder Kurznotizen. Jeder Eintrag wird ein durchsuchbares Dokument.\n\nWenn Quellen Ready zeigt, ist das Korpus für den Chat bereit.',
+  'admin.help.embed.title': 'Auf der Homepage einbetten',
+  'admin.help.embed.body':
+    'Kein WordPress-Plugin. Auf gleicher Origin installieren, dann HTML-Snippet aus Erscheinungsbild einfügen.\n\nSnippet lädt widget.css + widget.js und startet den Chat. data-endpoint muss zum Installationspfad passen.\n\nVor Produktion auf Staging testen. HTTPS empfohlen.',
+  'admin.help.appearance.title': 'Erscheinungsbild & Vorschau',
+  'admin.help.appearance.body':
+    'Widget-Farben, Radius, max. Breite und optionaler HERO-Willkommenstext.\n\nWidget-Sprache: Browser des Besuchers oder fest.\n\nVorschau-iframe zeigt das live Widget. Speichern zum Übernehmen — Snippet-Pfad wird automatisch gesetzt.',
+  'admin.help.troubleshooting.title': 'Fehlerbehebung',
+  'admin.help.troubleshooting.body':
+    'Login schlägt fehl — Zugangsdaten und /health an der Basis-URL prüfen.\n\nQuellen Failed — CSV-Mapping oder PDF prüfen.\n\nWidget leer — widget.js und widget.css müssen von gleicher Origin laden.\n\nNach Update — Datenbank-Migrationen ausführen.\n\nDev-Vorschau weiß — Admin- (:5173) und Widget-Dev-Server (:5174) nach Pull neu starten.',
+  'admin.help.faq.title': 'FAQ',
+  'admin.help.faq.body':
+    'Verlassen Daten meinen Server? — Korpus bleibt in Ihrer DB. Nur relevante Textausschnitte gehen an die Claude-API.\n\nSubdomain? — Ja, Document Root auf public_html zeigen.\n\nStreaming? — Nur synchroner JSON-Chat, kein SSE-Streaming.\n\nMehr — Shared-Hosting-Docs im Release-ZIP.',
   'widget.chat.panelLabel': 'NeNe Corpus Chat',
   'widget.chat.emptyPrompt': 'Stellen Sie eine Frage zu unseren Produkten.',
   'widget.chat.loading': 'Korpus wird durchsucht…',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -161,6 +161,27 @@ export const en = defineMessages({
   'admin.appearance.saveSuccess': 'Appearance settings saved.',
   'admin.appearance.loadFailed': 'Failed to load appearance settings.',
   'admin.appearance.saveFailed': 'Failed to save appearance settings.',
+  'admin.help.title': 'Help & operator guide',
+  'admin.help.subtitle': 'Quick start, embed setup, and troubleshooting from this screen.',
+  'admin.help.open': 'Help',
+  'admin.help.quickStart.title': 'Quick start',
+  'admin.help.quickStart.body':
+    '1. Sign in with your operator email and password.\n2. Ingestion — upload CSV/PDF or paste text to build the corpus.\n3. Sources — confirm status is Ready.\n4. Appearance — tune colors and copy the embed snippet.\n5. Paste the snippet into your homepage (same domain) and test the chat widget.',
+  'admin.help.ingestion.title': 'Ingestion (CSV, PDF, text)',
+  'admin.help.ingestion.body':
+    'File upload — CSV needs a preview and column mapping (title + content columns). PDF text is extracted per page. Max file size is 5 MB.\n\nPaste text — use the Text tab for FAQ answers or short notes. Each paste becomes one searchable document.\n\nWhen status shows Ready in Sources, the corpus is available to chat.',
+  'admin.help.embed.title': 'Embed on your homepage',
+  'admin.help.embed.body':
+    'NeNe Corpus is not a WordPress plugin. Install it on the same origin as your site, then add one HTML block from Appearance → embed snippet.\n\nThe snippet loads widget.css + widget.js and auto-starts the chat UI. data-endpoint must point at your install base path (e.g. /nene-corpus).\n\nTest on a staging URL before production. HTTPS is recommended.',
+  'admin.help.appearance.title': 'Appearance & preview',
+  'admin.help.appearance.body':
+    'Set widget colors, corner radius, max width, and optional HERO welcome copy.\n\nWidget locale can follow the visitor browser or stay fixed.\n\nThe preview iframe shows the live widget. Click Save to persist — the embed snippet reflects your install path automatically.',
+  'admin.help.troubleshooting.title': 'Troubleshooting',
+  'admin.help.troubleshooting.body':
+    'Admin login fails — check operator credentials and that the API responds at /health on your base URL.\n\nSources stay Failed — re-upload or fix CSV mapping; for PDF, confirm text is extractable.\n\nWidget is blank — open browser devtools; ensure widget.js and widget.css load from the same origin.\n\nAfter a product update — run database migrations (installer docs or docker compose exec app composer migrations:migrate).\n\nLocal dev preview white — restart admin (:5173) and widget (:5174) dev servers after pulling i18n changes.',
+  'admin.help.faq.title': 'FAQ',
+  'admin.help.faq.body':
+    'Does data leave my server? — Your corpus stays in your database. Only retrieved text chunks are sent to the Claude API when visitors ask questions.\n\nCan I use a subdomain? — Yes. Point the subdomain document root at public_html and set the embed base path accordingly.\n\nStreaming responses? — NeNe Corpus uses sync JSON chat (loading indicator in the widget), not SSE token streaming.\n\nMore detail — see shared-hosting operator docs shipped with the release ZIP.',
   'widget.chat.panelLabel': 'NeNe Corpus chat',
   'widget.chat.emptyPrompt': 'Ask a question about our products.',
   'widget.chat.loading': 'Searching the corpus…',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -160,6 +160,27 @@ export const fr = defineMessages({
   'admin.appearance.saveSuccess': 'Paramètres enregistrés.',
   'admin.appearance.loadFailed': 'Impossible de charger les paramètres.',
   'admin.appearance.saveFailed': 'Impossible d’enregistrer les paramètres.',
+  'admin.help.title': 'Aide et guide opérateur',
+  'admin.help.subtitle': 'Démarrage, intégration et dépannage depuis cet écran.',
+  'admin.help.open': 'Aide',
+  'admin.help.quickStart.title': 'Démarrage rapide',
+  'admin.help.quickStart.body':
+    '1. Connectez-vous avec l’e-mail et le mot de passe opérateur.\n2. Ingestion — téléversez CSV/PDF ou collez du texte.\n3. Sources — vérifiez le statut Ready.\n4. Apparence — ajustez les couleurs et copiez le snippet d’intégration.\n5. Collez le snippet sur votre page d’accueil (même origine) et testez le chat.',
+  'admin.help.ingestion.title': 'Ingestion (CSV, PDF, texte)',
+  'admin.help.ingestion.body':
+    'Fichier — le CSV exige un aperçu et un mapping de colonnes. Le PDF extrait le texte par page. Taille max. 5 Mo.\n\nTexte — onglet Coller du texte pour FAQ ou notes courtes. Chaque collage devient un document consultable.\n\nQuand Sources affiche Ready, le corpus est prêt pour le chat.',
+  'admin.help.embed.title': 'Intégrer sur votre site',
+  'admin.help.embed.body':
+    'Ce n’est pas un plugin WordPress. Installez sur la même origine, puis ajoutez le snippet HTML depuis Apparence.\n\nLe snippet charge widget.css + widget.js et démarre le chat. data-endpoint doit correspondre à votre chemin d’installation.\n\nTestez en staging avant la production. HTTPS recommandé.',
+  'admin.help.appearance.title': 'Apparence et aperçu',
+  'admin.help.appearance.body':
+    'Couleurs, rayon, largeur max. et texte HERO du widget.\n\nLocale du widget : navigateur du visiteur ou fixe.\n\nL’iframe d’aperçu montre le widget en direct. Enregistrez pour persister — le snippet suit votre chemin d’installation.',
+  'admin.help.troubleshooting.title': 'Dépannage',
+  'admin.help.troubleshooting.body':
+    'Connexion impossible — vérifiez les identifiants et /health sur votre URL de base.\n\nSources en Failed — revoyez le mapping CSV ou le PDF.\n\nWidget vide — vérifiez que widget.js et widget.css se chargent depuis la même origine.\n\nAprès mise à jour — exécutez les migrations de base de données.\n\nAperçu dev blanc — redémarrez les serveurs dev admin (:5173) et widget (:5174) après un pull.',
+  'admin.help.faq.title': 'FAQ',
+  'admin.help.faq.body':
+    'Les données quittent-elles mon serveur ? — Le corpus reste dans votre base. Seuls les extraits pertinents partent vers l’API Claude.\n\nSous-domaine ? — Oui, pointez la racine documentaire vers public_html.\n\nStreaming ? — Chat JSON synchrone uniquement, pas de streaming SSE.\n\nPlus de détails — docs hébergement mutualisé fournis avec le ZIP de release.',
   'widget.chat.panelLabel': 'Chat NeNe Corpus',
   'widget.chat.emptyPrompt': 'Posez une question sur nos produits.',
   'widget.chat.loading': 'Recherche dans le corpus…',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -160,6 +160,27 @@ export const ja = defineMessages({
   'admin.appearance.saveSuccess': '設定を保存しました。',
   'admin.appearance.loadFailed': '設定の読み込みに失敗しました。',
   'admin.appearance.saveFailed': '設定の保存に失敗しました。',
+  'admin.help.title': 'ヘルプ・運用ガイド',
+  'admin.help.subtitle': 'この画面から、使い方・埋め込み・トラブルシュートを確認できます。',
+  'admin.help.open': 'ヘルプ',
+  'admin.help.quickStart.title': 'クイックスタート',
+  'admin.help.quickStart.body':
+    '1. オペレーターのメールとパスワードでログイン\n2. 取り込み — CSV/PDF をアップロード、またはテキストを貼り付け\n3. ソース — ステータスが Ready になることを確認\n4. 外観 — 色を調整し、embed スニペットをコピー\n5. 自サイト（同一ドメイン）の HTML に貼り付けてチャットを試す',
+  'admin.help.ingestion.title': '取り込み（CSV / PDF / テキスト）',
+  'admin.help.ingestion.body':
+    'ファイル — CSV はプレビュー後に列マッピング（タイトル列・本文列）が必要です。PDF はページ単位でテキスト抽出。最大 5 MB。\n\nテキスト — 「テキスト入力」タブで FAQ や短文を貼り付け。1 回の入力が 1 件の検索用ドキュメントになります。\n\nソース一覧が Ready になればチャットで検索できます。',
+  'admin.help.embed.title': 'ホームページへの埋め込み',
+  'admin.help.embed.body':
+    'WordPress プラグインではありません。同一オリジンに NeNe Corpus を置き、外観設定の embed スニペットを HTML に 1 ブロック追加します。\n\nwidget.css と widget.js がチャット UI を自動起動します。data-endpoint はインストールパス（例: /nene-corpus）に合わせてください。\n\n本番前にステージング URL で確認することをおすすめします。HTTPS 推奨。',
+  'admin.help.appearance.title': '外観とプレビュー',
+  'admin.help.appearance.body':
+    'ウィジェットの色・角丸・最大幅・HERO ウェルカム文を設定できます。\n\nウィジェット言語は訪問者のブラウザに合わせるか固定できます。\n\nプレビュー iframe で確認後、保存で反映。スニペットのパスはインストール先に合わせて自動生成されます。',
+  'admin.help.troubleshooting.title': 'トラブルシュート',
+  'admin.help.troubleshooting.body':
+    'ログインできない — 認証情報と、ベース URL の /health が応答するか確認。\n\nソースが Failed — CSV の列設定や PDF のテキスト抽出を見直し。\n\nウィジェットが真っ白 — 開発者ツールで widget.js / widget.css が同一オリジンから読めているか確認。\n\nアップデート後に Admin が 500 — DB マイグレーションを実行（docker compose exec app composer migrations:migrate など）。\n\nローカル dev でプレビュー真っ白 — git pull 後は admin (:5173) と widget (:5174) の dev サーバーを再起動。',
+  'admin.help.faq.title': 'よくある質問',
+  'admin.help.faq.body':
+    'データは外部に出る？ — コーパスは自社 DB に保存。質問時に検索でヒットしたテキスト断片のみ Claude API に送られます。\n\nサブドメインは使える？ — 可能です。サブドメインの document root を public_html に向け、embed のベースパスを合わせてください。\n\nストリーミング応答は？ — sync JSON チャット（ローディング表示）のみ。SSE の逐次表示は非対応です。\n\n詳細 — リリース ZIP 同梱の shared-hosting 運用ドキュメントを参照。',
   'widget.chat.panelLabel': 'NeNe Corpus チャット',
   'widget.chat.emptyPrompt': '商品やサービスについて質問してみてください。',
   'widget.chat.loading': '資料を検索しています…',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -160,6 +160,27 @@ export const ptBr = defineMessages({
   'admin.appearance.saveSuccess': 'Configurações salvas.',
   'admin.appearance.loadFailed': 'Falha ao carregar configurações.',
   'admin.appearance.saveFailed': 'Falha ao salvar configurações.',
+  'admin.help.title': 'Ajuda e guia do operador',
+  'admin.help.subtitle': 'Início rápido, embed e solução de problemas nesta tela.',
+  'admin.help.open': 'Ajuda',
+  'admin.help.quickStart.title': 'Início rápido',
+  'admin.help.quickStart.body':
+    '1. Entre com e-mail e senha do operador.\n2. Ingestão — envie CSV/PDF ou cole texto.\n3. Fontes — confirme status Ready.\n4. Aparência — ajuste cores e copie o snippet de embed.\n5. Cole o snippet na homepage (mesma origem) e teste o chat.',
+  'admin.help.ingestion.title': 'Ingestão (CSV, PDF, texto)',
+  'admin.help.ingestion.body':
+    'Arquivo — CSV exige prévia e mapeamento de colunas. PDF extrai texto por página. Máx. 5 MB.\n\nTexto — aba Colar texto para FAQ ou notas curtas. Cada colagem vira um documento pesquisável.\n\nQuando Fontes mostrar Ready, o corpus está pronto para o chat.',
+  'admin.help.embed.title': 'Embutir na homepage',
+  'admin.help.embed.body':
+    'Não é plugin WordPress. Instale na mesma origem e adicione o snippet HTML em Aparência.\n\nO snippet carrega widget.css + widget.js e inicia o chat. data-endpoint deve apontar ao caminho da instalação.\n\nTeste em staging antes da produção. HTTPS recomendado.',
+  'admin.help.appearance.title': 'Aparência e prévia',
+  'admin.help.appearance.body':
+    'Cores, raio, largura máx. e texto HERO do widget.\n\nIdioma do widget: navegador do visitante ou fixo.\n\nA prévia em iframe mostra o widget ao vivo. Salve para persistir — o snippet segue o caminho da instalação.',
+  'admin.help.troubleshooting.title': 'Solução de problemas',
+  'admin.help.troubleshooting.body':
+    'Falha no login — verifique credenciais e /health na URL base.\n\nFontes Failed — revise mapeamento CSV ou PDF.\n\nWidget em branco — confirme widget.js e widget.css na mesma origem.\n\nApós atualização — execute migrações do banco.\n\nPrévia dev em branco — reinicie servidores dev admin (:5173) e widget (:5174) após pull.',
+  'admin.help.faq.title': 'FAQ',
+  'admin.help.faq.body':
+    'Os dados saem do meu servidor? — O corpus fica no seu banco. Apenas trechos relevantes vão à API Claude.\n\nSubdomínio? — Sim, aponte o document root para public_html.\n\nStreaming? — Apenas chat JSON síncrono, sem SSE.\n\nMais detalhes — docs de shared hosting no ZIP de release.',
   'widget.chat.panelLabel': 'Chat NeNe Corpus',
   'widget.chat.emptyPrompt': 'Faça uma pergunta sobre nossos produtos.',
   'widget.chat.loading': 'Pesquisando no corpus…',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -155,6 +155,27 @@ export const zhHans = defineMessages({
   'admin.appearance.saveSuccess': '外观设置已保存。',
   'admin.appearance.loadFailed': '加载外观设置失败。',
   'admin.appearance.saveFailed': '保存外观设置失败。',
+  'admin.help.title': '帮助与运营指南',
+  'admin.help.subtitle': '在此屏幕查看快速入门、嵌入设置与故障排除。',
+  'admin.help.open': '帮助',
+  'admin.help.quickStart.title': '快速入门',
+  'admin.help.quickStart.body':
+    '1. 使用运营账号登录。\n2. 导入 — 上传 CSV/PDF 或粘贴文本。\n3. 数据源 — 确认状态为 Ready。\n4. 外观 — 调整颜色并复制嵌入代码片段。\n5. 将片段粘贴到同域首页并测试聊天。',
+  'admin.help.ingestion.title': '导入（CSV、PDF、文本）',
+  'admin.help.ingestion.body':
+    '文件 — CSV 需预览并映射列；PDF 按页提取文本。最大 5 MB。\n\n文本 — 使用「粘贴文本」标签页导入 FAQ 或短文，每次粘贴为一个可搜索文档。\n\n数据源列表显示 Ready 后即可用于聊天检索。',
+  'admin.help.embed.title': '嵌入到首页',
+  'admin.help.embed.body':
+    '不是 WordPress 插件。请安装在同一源站，然后从外观设置复制 HTML 片段。\n\n片段加载 widget.css 与 widget.js 并自动启动聊天。data-endpoint 需与安装路径一致。\n\n建议先在预发环境测试。推荐使用 HTTPS。',
+  'admin.help.appearance.title': '外观与预览',
+  'admin.help.appearance.body':
+    '设置组件颜色、圆角、最大宽度及可选 HERO 欢迎语。\n\n组件语言可跟随访客浏览器或固定。\n\n预览 iframe 显示实时效果，保存后生效；嵌入片段路径自动匹配安装位置。',
+  'admin.help.troubleshooting.title': '故障排除',
+  'admin.help.troubleshooting.body':
+    '无法登录 — 检查账号与基础 URL 的 /health。\n\n数据源 Failed — 检查 CSV 列映射或 PDF 文本。\n\n组件空白 — 确认 widget.js / widget.css 从同域加载。\n\n更新后 Admin 500 — 执行数据库迁移。\n\n本地预览空白 — git pull 后重启 admin (:5173) 与 widget (:5174) 开发服务器。',
+  'admin.help.faq.title': '常见问题',
+  'admin.help.faq.body':
+    '数据会离开服务器吗？ — 语料库保存在您的数据库；仅将检索到的文本片段发送至 Claude API。\n\n可用子域名吗？ — 可以，将 document root 指向 public_html。\n\n流式响应？ — 仅同步 JSON 聊天，不支持 SSE 逐字流。\n\n更多说明 — 见发布 ZIP 中的共享主机运营文档。',
   'widget.chat.panelLabel': 'NeNe Corpus 聊天',
   'widget.chat.emptyPrompt': '请提问有关我们产品的问题。',
   'widget.chat.loading': '正在搜索语料库…',


### PR DESCRIPTION
## Summary

- ヘッダー「ヘルプ」ボタン → `#admin-help` パネルへスムーズスクロール
- アコーディオン形式の運用ガイド 6 セクション（クイックスタート、取り込み、embed、外観、トラブルシュート、FAQ）
- ログイン前・ログイン後どちらでも表示
- 6 ロケール i18n（`admin.help.*`）

Self-review: docs-policy

## Test plan

- [x] `npm run check --prefix frontend`
- [x] `composer check`
- [ ] http://localhost:5173 — ヘルプボタンで最下部パネルへスクロール、各セクション展開
- [ ] ログイン画面でも Help パネル表示
- [ ] CI green → merge

Closes #117

Made with [Cursor](https://cursor.com)