### PR TITLE
fix(frontend): Help 追加後の stale keys.ts で Admin が真っ白になる (#119)

### DIFF
--- a/docs/development/frontend-standards.md
+++ b/docs/development/frontend-standards.md
@@ -63,7 +63,7 @@ frontend/
 - **Theme (Admin):** light/dark via CSS variables on `:root` / `.dark`. Toggle in header; persist `nene-corpus.admin.theme` (`light` | `dark`, default from `prefers-color-scheme`). Small radius tokens (`rounded-admin*` ≈ 4–8px), subtle page gradient, glassy header (`backdrop-blur`). Reuse `nc-panel`, `nc-input`, `nc-btn*` component classes.
 - Use `formatTimestamp(value, locale)` for locale-aware dates.
 - Pair labels with optional help via `HelpLabel` (`label` + `help` strings from `Msg.*Help` keys). Tooltip opens on hover and keyboard focus; use `\n` in help strings for line breaks. CSV column mapping also has a collapsible `ColumnMappingGuide` accordion after preview.
-- **`keys.ts` を更新したあと** dev サーバーが古い `Msg` ツリーを返すことがある（プレビュー真っ白・ボタン空文字）。`npm run dev --prefix frontend` を **admin (:5173) と widget (:5174) 両方再起動**する。`resolveMsgKey(Msg.*, 'literal.key')` で HMR 遅延時もフォールバック可能（`packages/i18n/src/resolve-msg-key.ts`）。
+- **`keys.ts` を更新したあと** dev サーバーが古い `Msg` ツリーを返すことがある（プレビュー真っ白・ボタン空文字）。`npm run dev --prefix frontend` を **admin (:5173) と widget (:5174) 両方再起動**する。`resolveMsgKey(Msg.*, 'literal.key')` で HMR 遅延時もフォールバック可能（`packages/i18n/src/resolve-msg-key.ts`）。**モジュール初期化時に `Msg.*` を読む配列定義は避け**、文字列リテラルキーを使う（例: `helpSections.ts`）。
 
 ---
 

--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Msg, applyLocaleFontFamily, toBcp47, useLocale, useMsg } from '@nene-corpus/i18n';
+import { Msg, resolveMsgKey, applyLocaleFontFamily, toBcp47, useLocale, useMsg } from '@nene-corpus/i18n';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
 import { ConversationLogsPanel } from './ConversationLogsPanel';
@@ -39,7 +39,7 @@ export function App() {
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2">
             <button className="nc-btn nc-header-btn" type="button" onClick={scrollToHelp}>
-              {t(Msg.admin.help.open)}
+              {t(resolveMsgKey(Msg.admin.help?.open, 'admin.help.open'))}
             </button>
             <LocaleSelector />
             <ThemeToggle />

--- a/frontend/apps/admin/src/HelpPanel.tsx
+++ b/frontend/apps/admin/src/HelpPanel.tsx
@@ -1,4 +1,4 @@
-import { Msg, useMsg } from '@nene-corpus/i18n';
+import { Msg, resolveMsgKey, useMsg } from '@nene-corpus/i18n';
 import { ADMIN_HELP_SECTIONS } from './helpSections';
 
 export function HelpPanel() {
@@ -7,8 +7,8 @@ export function HelpPanel() {
   return (
     <section id="admin-help" className="nc-panel scroll-mt-24">
       <div className="nc-panel-head">
-        <h2 className="font-medium">{t(Msg.admin.help.title)}</h2>
-        <p>{t(Msg.admin.help.subtitle)}</p>
+        <h2 className="font-medium">{t(resolveMsgKey(Msg.admin.help?.title, 'admin.help.title'))}</h2>
+        <p>{t(resolveMsgKey(Msg.admin.help?.subtitle, 'admin.help.subtitle'))}</p>
       </div>
       <div className="space-y-3 px-4 py-4">
         {ADMIN_HELP_SECTIONS.map((section) => (

--- a/frontend/apps/admin/src/helpSections.ts
+++ b/frontend/apps/admin/src/helpSections.ts
@@ -1,15 +1,16 @@
-import { Msg, type MsgKey } from '@nene-corpus/i18n';
+import type { MsgKey } from '@nene-corpus/i18n';
 
 export interface HelpSectionDef {
   titleKey: MsgKey;
   bodyKey: MsgKey;
 }
 
+/** Literal keys — do not read `Msg.admin.help` at module init (Vite HMR may serve stale `keys.ts`). */
 export const ADMIN_HELP_SECTIONS: HelpSectionDef[] = [
-  { titleKey: Msg.admin.help.quickStart.title, bodyKey: Msg.admin.help.quickStart.body },
-  { titleKey: Msg.admin.help.ingestion.title, bodyKey: Msg.admin.help.ingestion.body },
-  { titleKey: Msg.admin.help.embed.title, bodyKey: Msg.admin.help.embed.body },
-  { titleKey: Msg.admin.help.appearance.title, bodyKey: Msg.admin.help.appearance.body },
-  { titleKey: Msg.admin.help.troubleshooting.title, bodyKey: Msg.admin.help.troubleshooting.body },
-  { titleKey: Msg.admin.help.faq.title, bodyKey: Msg.admin.help.faq.body },
+  { titleKey: 'admin.help.quickStart.title', bodyKey: 'admin.help.quickStart.body' },
+  { titleKey: 'admin.help.ingestion.title', bodyKey: 'admin.help.ingestion.body' },
+  { titleKey: 'admin.help.embed.title', bodyKey: 'admin.help.embed.body' },
+  { titleKey: 'admin.help.appearance.title', bodyKey: 'admin.help.appearance.body' },
+  { titleKey: 'admin.help.troubleshooting.title', bodyKey: 'admin.help.troubleshooting.body' },
+  { titleKey: 'admin.help.faq.title', bodyKey: 'admin.help.faq.body' },
 ];


### PR DESCRIPTION
## Summary

- `helpSections.ts` — モジュール初期化時に `Msg.admin.help.*` を参照しない（stale cache 時の即クラッシュ防止）
- `App` / `HelpPanel` — `resolveMsgKey` フォールバック
- `frontend-standards.md` — モジュール init で Msg ツリーを読まない注記

Self-review: docs-policy

## Test plan

- [x] `npm run check --prefix frontend`
- [ ] Admin :5173 表示、Help パネル展開
- [ ] CI green → merge

Closes #119

Made with [Cursor](https://cursor.com)