### PR TITLE
fix(admin): ヘルプ本文のダークモード可読性とヘッダー並び順 (#121)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -38,11 +38,11 @@ export function App() {
             {profile && <p className="nc-text-muted">{profile.email}</p>}
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2">
+            <ThemeToggle />
+            <LocaleSelector />
             <button className="nc-btn nc-header-btn" type="button" onClick={scrollToHelp}>
               {t(resolveMsgKey(Msg.admin.help?.open, 'admin.help.open'))}
             </button>
-            <LocaleSelector />
-            <ThemeToggle />
             {profile && (
               <button className="nc-btn nc-header-btn" type="button" onClick={logout}>
                 {t(Msg.common.signOut)}

--- a/frontend/apps/admin/src/HelpPanel.tsx
+++ b/frontend/apps/admin/src/HelpPanel.tsx
@@ -28,7 +28,7 @@ export function HelpPanel() {
               </span>
             </summary>
             <div className="border-t border-accent-border px-3 py-3 leading-relaxed">
-              <p className="whitespace-pre-line nc-text-subtle">{t(section.bodyKey)}</p>
+              <p className="nc-help-body whitespace-pre-line">{t(section.bodyKey)}</p>
             </div>
           </details>
         ))}

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -114,6 +114,14 @@
     @apply text-[11px] leading-normal text-fg-subtle;
   }
 
+  .nc-help-body {
+    @apply text-xs leading-relaxed text-fg-subtle;
+  }
+
+  .dark .nc-help-body {
+    @apply text-fg-muted;
+  }
+
   .nc-text-timestamp {
     @apply text-[10px] leading-normal text-fg-subtle tabular-nums;
   }


### PR DESCRIPTION
## Summary

- Help 本文 — `.nc-help-body`（light: fg-subtle / dark: fg-muted で可読性向上）
- ヘッダー並び — テーマ → 言語 → ヘルプ → サインアウト

## Test plan

- [x] `npm run check --prefix frontend`
- [ ] ダークモードで Help 本文が読みやすいこと
- [ ] ヘッダー順序確認

Closes #121

Made with [Cursor](https://cursor.com)