### PR TITLE
fix(admin): Help 本文のダークモード文字色をさらに明るく (#123)

### DIFF
--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -119,7 +119,7 @@
   }
 
   .dark .nc-help-body {
-    @apply text-fg-muted;
+    @apply text-fg/85;
   }
 
   .nc-text-timestamp {


### PR DESCRIPTION
## Summary

- `.dark .nc-help-body` を `text-fg/85` に変更（以前は `text-fg-muted`）

## Test plan

- [ ] ダークモードで Help 本文が読みやすいこと

Closes #123

Made with [Cursor](https://cursor.com)