### PR TITLE
fix(appearance): 保存422とAdmin chatラベル欠落を修正 (#136)

### DIFF
--- a/frontend/apps/admin/src/AppearancePanel.tsx
+++ b/frontend/apps/admin/src/AppearancePanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@nene-corpus/api-client';
 import { Msg, resolveMsgKey, useLocale, useMsg, isUnresolvedTranslation, type MsgKey } from '@nene-corpus/i18n';
 import { adminApiBase } from './config';
+import { APPEARANCE_CHAT_TOGGLE_FALLBACK } from './appearanceChatToggleFallback';
 import { APPEARANCE_HERO_TOGGLE_FALLBACK } from './appearanceHeroToggleFallback';
 import { EmbedSnippetSection } from './EmbedSnippetSection';
 import { HelpLabel } from './HelpLabel';
@@ -27,6 +28,18 @@ const HERO_TOGGLE_MSG = {
   showCtaHelp: 'admin.appearance.heroShowCtaHelp',
   showImage: 'admin.appearance.heroShowImage',
   showImageHelp: 'admin.appearance.heroShowImageHelp',
+} as const satisfies Record<string, MsgKey>;
+
+/** Literal keys — do not read `Msg.admin.appearance` chat toggles at module init (Vite HMR may serve stale `keys.ts`). */
+const CHAT_APPEARANCE_MSG = {
+  chatTitle: 'admin.appearance.chatTitle',
+  chatSubtitle: 'admin.appearance.chatSubtitle',
+  userAvatarMode: 'admin.appearance.userAvatarMode',
+  userAvatarModeHelp: 'admin.appearance.userAvatarModeHelp',
+  userAvatarModeSilhouette: 'admin.appearance.userAvatarModeSilhouette',
+  userAvatarModeNone: 'admin.appearance.userAvatarModeNone',
+  showAssistantAvatar: 'admin.appearance.showAssistantAvatar',
+  showAssistantAvatarHelp: 'admin.appearance.showAssistantAvatarHelp',
 } as const satisfies Record<string, MsgKey>;
 
 const HERO_IMAGE_MAX_BYTES = 2_097_152;
@@ -94,27 +107,78 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
   const t = useMsg();
   const { locale } = useLocale();
   const heroToggleFallback = APPEARANCE_HERO_TOGGLE_FALLBACK[locale];
+  const chatAppearanceFallback = APPEARANCE_CHAT_TOGGLE_FALLBACK[locale];
+
+  const resolveAppearanceCopy = useMemo(
+    () =>
+      (key: MsgKey, emergency: string): string => {
+        const text = t(key);
+        return isUnresolvedTranslation(text, key) ? emergency : text;
+      },
+    [t],
+  );
 
   const heroToggleCopy = useMemo(() => {
-    const resolve = (key: MsgKey, emergency: string): string => {
-      const text = t(key);
-      return isUnresolvedTranslation(text, key) ? emergency : text;
-    };
-
     return {
-      showTitle: resolve(HERO_TOGGLE_MSG.showTitle, heroToggleFallback.showTitle),
-      showTitleHelp: resolve(HERO_TOGGLE_MSG.showTitleHelp, heroToggleFallback.showTitleHelp),
-      showDescription: resolve(HERO_TOGGLE_MSG.showDescription, heroToggleFallback.showDescription),
-      showDescriptionHelp: resolve(
+      showTitle: resolveAppearanceCopy(HERO_TOGGLE_MSG.showTitle, heroToggleFallback.showTitle),
+      showTitleHelp: resolveAppearanceCopy(
+        HERO_TOGGLE_MSG.showTitleHelp,
+        heroToggleFallback.showTitleHelp,
+      ),
+      showDescription: resolveAppearanceCopy(
+        HERO_TOGGLE_MSG.showDescription,
+        heroToggleFallback.showDescription,
+      ),
+      showDescriptionHelp: resolveAppearanceCopy(
         HERO_TOGGLE_MSG.showDescriptionHelp,
         heroToggleFallback.showDescriptionHelp,
       ),
-      showCta: resolve(HERO_TOGGLE_MSG.showCta, heroToggleFallback.showCta),
-      showCtaHelp: resolve(HERO_TOGGLE_MSG.showCtaHelp, heroToggleFallback.showCtaHelp),
-      showImage: resolve(HERO_TOGGLE_MSG.showImage, heroToggleFallback.showImage),
-      showImageHelp: resolve(HERO_TOGGLE_MSG.showImageHelp, heroToggleFallback.showImageHelp),
+      showCta: resolveAppearanceCopy(HERO_TOGGLE_MSG.showCta, heroToggleFallback.showCta),
+      showCtaHelp: resolveAppearanceCopy(HERO_TOGGLE_MSG.showCtaHelp, heroToggleFallback.showCtaHelp),
+      showImage: resolveAppearanceCopy(HERO_TOGGLE_MSG.showImage, heroToggleFallback.showImage),
+      showImageHelp: resolveAppearanceCopy(
+        HERO_TOGGLE_MSG.showImageHelp,
+        heroToggleFallback.showImageHelp,
+      ),
     };
-  }, [t, heroToggleFallback]);
+  }, [resolveAppearanceCopy, heroToggleFallback]);
+
+  const chatAppearanceCopy = useMemo(() => {
+    return {
+      chatTitle: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.chatTitle,
+        chatAppearanceFallback.chatTitle,
+      ),
+      chatSubtitle: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.chatSubtitle,
+        chatAppearanceFallback.chatSubtitle,
+      ),
+      userAvatarMode: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.userAvatarMode,
+        chatAppearanceFallback.userAvatarMode,
+      ),
+      userAvatarModeHelp: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.userAvatarModeHelp,
+        chatAppearanceFallback.userAvatarModeHelp,
+      ),
+      userAvatarModeSilhouette: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.userAvatarModeSilhouette,
+        chatAppearanceFallback.userAvatarModeSilhouette,
+      ),
+      userAvatarModeNone: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.userAvatarModeNone,
+        chatAppearanceFallback.userAvatarModeNone,
+      ),
+      showAssistantAvatar: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.showAssistantAvatar,
+        chatAppearanceFallback.showAssistantAvatar,
+      ),
+      showAssistantAvatarHelp: resolveAppearanceCopy(
+        CHAT_APPEARANCE_MSG.showAssistantAvatarHelp,
+        chatAppearanceFallback.showAssistantAvatarHelp,
+      ),
+    };
+  }, [resolveAppearanceCopy, chatAppearanceFallback]);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const [widgetLocale, setWidgetLocale] = useState('');
   const [theme, setTheme] = useState<WidgetTheme>(DEFAULT_THEME);
@@ -456,12 +520,12 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
           </div>
           <div className="space-y-3 rounded-admin border border-border p-4">
             <div>
-              <h3 className="text-sm font-medium text-fg">{t(Msg.admin.appearance.chatTitle)}</h3>
-              <p className="mt-1 text-sm nc-text-muted">{t(Msg.admin.appearance.chatSubtitle)}</p>
+              <h3 className="text-sm font-medium text-fg">{chatAppearanceCopy.chatTitle}</h3>
+              <p className="mt-1 text-sm nc-text-muted">{chatAppearanceCopy.chatSubtitle}</p>
             </div>
             <fieldset className="block text-sm">
-              <legend className="font-medium text-fg">{t(Msg.admin.appearance.userAvatarMode)}</legend>
-              <p className="mt-1 text-xs nc-text-muted">{t(Msg.admin.appearance.userAvatarModeHelp)}</p>
+              <legend className="font-medium text-fg">{chatAppearanceCopy.userAvatarMode}</legend>
+              <p className="mt-1 text-xs nc-text-muted">{chatAppearanceCopy.userAvatarModeHelp}</p>
               <div className="mt-2 space-y-2">
                 {USER_AVATAR_MODES.map((mode) => (
                   <label key={mode} className="flex items-center gap-2">
@@ -474,8 +538,8 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
                     />
                     <span>
                       {mode === 'silhouette'
-                        ? t(Msg.admin.appearance.userAvatarModeSilhouette)
-                        : t(Msg.admin.appearance.userAvatarModeNone)}
+                        ? chatAppearanceCopy.userAvatarModeSilhouette
+                        : chatAppearanceCopy.userAvatarModeNone}
                     </span>
                   </label>
                 ))}
@@ -492,8 +556,8 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
                 />
                 <HelpLabel
                   className="font-medium text-fg"
-                  label={t(Msg.admin.appearance.showAssistantAvatar)}
-                  help={t(Msg.admin.appearance.showAssistantAvatarHelp)}
+                  label={chatAppearanceCopy.showAssistantAvatar}
+                  help={chatAppearanceCopy.showAssistantAvatarHelp}
                 />
               </div>
             </div>

--- a/frontend/apps/admin/src/appearanceChatToggleFallback.ts
+++ b/frontend/apps/admin/src/appearanceChatToggleFallback.ts
@@ -1,0 +1,79 @@
+import type { SupportedLocale } from '@nene-corpus/i18n';
+
+export interface ChatAppearanceCopy {
+  chatTitle: string;
+  chatSubtitle: string;
+  userAvatarMode: string;
+  userAvatarModeHelp: string;
+  userAvatarModeSilhouette: string;
+  userAvatarModeNone: string;
+  showAssistantAvatar: string;
+  showAssistantAvatarHelp: string;
+}
+
+/**
+ * Emergency copy when Vite HMR serves a stale `@nene-corpus/i18n` catalog (raw keys or blank labels).
+ * Keep in sync with `packages/i18n/src/locales/*.ts` chat appearance entries.
+ */
+export const APPEARANCE_CHAT_TOGGLE_FALLBACK: Record<SupportedLocale, ChatAppearanceCopy> = {
+  ja: {
+    chatTitle: 'チャット吹き出し',
+    chatSubtitle: '会話エリアのアイコンと吹き出しの見え方を設定します。',
+    userAvatarMode: '訪問者のアイコン',
+    userAvatarModeHelp: '訪問者メッセージ横に汎用シルエットを出すか、吹き出しのみにするか選びます。',
+    userAvatarModeSilhouette: 'シルエット',
+    userAvatarModeNone: 'なし（吹き出しのみ）',
+    showAssistantAvatar: 'アシスタントのアイコン',
+    showAssistantAvatarHelp: '回答横のアシスタントアイコンの表示／非表示を切り替えます。',
+  },
+  en: {
+    chatTitle: 'Chat bubbles',
+    chatSubtitle: 'Control avatars and bubble layout in the conversation area.',
+    userAvatarMode: 'Visitor icon',
+    userAvatarModeHelp: 'Choose whether visitor messages show a generic silhouette or text only.',
+    userAvatarModeSilhouette: 'Silhouette',
+    userAvatarModeNone: 'No icon (bubble only)',
+    showAssistantAvatar: 'Assistant icon',
+    showAssistantAvatarHelp: 'Turn the assistant avatar beside replies on or off.',
+  },
+  'zh-Hans': {
+    chatTitle: '聊天气泡',
+    chatSubtitle: '设置对话区头像与气泡布局。',
+    userAvatarMode: '访客图标',
+    userAvatarModeHelp: '访客消息旁显示通用剪影，或仅显示气泡。',
+    userAvatarModeSilhouette: '剪影',
+    userAvatarModeNone: '无图标（仅气泡）',
+    showAssistantAvatar: '助手图标',
+    showAssistantAvatarHelp: '切换助手回复旁图标的显示或隐藏。',
+  },
+  fr: {
+    chatTitle: 'Bulles de chat',
+    chatSubtitle: 'Icônes et mise en page des messages dans la zone de conversation.',
+    userAvatarMode: 'Icône visiteur',
+    userAvatarModeHelp: 'Silhouette générique à côté des messages visiteur, ou bulle seule.',
+    userAvatarModeSilhouette: 'Silhouette',
+    userAvatarModeNone: 'Aucune (bulle seule)',
+    showAssistantAvatar: 'Icône assistant',
+    showAssistantAvatarHelp: "Afficher ou masquer l'icône à côté des réponses.",
+  },
+  'pt-BR': {
+    chatTitle: 'Balões de chat',
+    chatSubtitle: 'Ícones e layout das mensagens na área de conversa.',
+    userAvatarMode: 'Ícone do visitante',
+    userAvatarModeHelp: 'Silhueta genérica ao lado das mensagens do visitante, ou só o balão.',
+    userAvatarModeSilhouette: 'Silhoueta',
+    userAvatarModeNone: 'Nenhum (só balão)',
+    showAssistantAvatar: 'Ícone do assistente',
+    showAssistantAvatarHelp: 'Ativar ou desativar o ícone ao lado das respostas.',
+  },
+  de: {
+    chatTitle: 'Chat-Sprechblasen',
+    chatSubtitle: 'Avatare und Layout im Gesprächsbereich festlegen.',
+    userAvatarMode: 'Besucher-Symbol',
+    userAvatarModeHelp: 'Generische Silhouette neben Besuchernachrichten oder nur Sprechblase.',
+    userAvatarModeSilhouette: 'Silhouette',
+    userAvatarModeNone: 'Keins (nur Sprechblase)',
+    showAssistantAvatar: 'Assistenten-Symbol',
+    showAssistantAvatarHelp: 'Symbol neben Antworten ein- oder ausblenden.',
+  },
+};

--- a/frontend/packages/api-client/src/fetch-json.ts
+++ b/frontend/packages/api-client/src/fetch-json.ts
@@ -1,3 +1,42 @@
+interface ProblemDetailsError {
+  field?: string;
+  message?: string;
+}
+
+interface ProblemDetailsPayload {
+  detail?: string;
+  errors?: ProblemDetailsError[];
+}
+
+function formatHttpError(status: number, url: string, payload: unknown): string {
+  if (payload !== null && typeof payload === 'object') {
+    const problem = payload as ProblemDetailsPayload;
+
+    if (Array.isArray(problem.errors) && problem.errors.length > 0) {
+      const details = problem.errors
+        .map((error) => {
+          if (error.field && error.message) {
+            return `${error.field}: ${error.message}`;
+          }
+
+          return error.message ?? error.field ?? null;
+        })
+        .filter((detail): detail is string => detail !== null && detail !== '')
+        .join('; ');
+
+      if (details !== '') {
+        return `HTTP ${status} for ${url}: ${details}`;
+      }
+    }
+
+    if (typeof problem.detail === 'string' && problem.detail !== '') {
+      return `HTTP ${status} for ${url}: ${problem.detail}`;
+    }
+  }
+
+  return `HTTP ${status} for ${url}`;
+}
+
 export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, init);
   const text = await response.text();
@@ -15,7 +54,7 @@ export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> 
   }
 
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status} for ${url}`);
+    throw new Error(formatHttpError(response.status, url, payload));
   }
 
   return payload as T;

--- a/src/Appearance/AppearanceBoolean.php
+++ b/src/Appearance/AppearanceBoolean.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Appearance;
+
+final readonly class AppearanceBoolean
+{
+    public static function isValid(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return true;
+        }
+
+        if ($value === 1 || $value === '1' || $value === 'true') {
+            return true;
+        }
+
+        if ($value === 0 || $value === '0' || $value === 'false') {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function toBool(mixed $value, bool $fallback = false): bool
+    {
+        if (!self::isValid($value)) {
+            return $fallback;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if ($value === 1 || $value === '1' || $value === 'true') {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Appearance/AppearanceSettingsValidator.php
+++ b/src/Appearance/AppearanceSettingsValidator.php
@@ -95,16 +95,12 @@ final readonly class AppearanceSettingsValidator
             }
         }
 
-        if (array_key_exists('show_assistant_avatar', $chat)) {
-            $value = $chat['show_assistant_avatar'];
-
-            if (!is_bool($value)) {
-                $errors[] = new ValidationError(
-                    'chat.show_assistant_avatar',
-                    'Show assistant avatar must be a boolean.',
-                    'invalid',
-                );
-            }
+        if (array_key_exists('show_assistant_avatar', $chat) && !AppearanceBoolean::isValid($chat['show_assistant_avatar'])) {
+            $errors[] = new ValidationError(
+                'chat.show_assistant_avatar',
+                'Show assistant avatar must be a boolean.',
+                'invalid',
+            );
         }
 
         return $errors;
@@ -143,9 +139,7 @@ final readonly class AppearanceSettingsValidator
             return [];
         }
 
-        $value = $hero[$key];
-
-        if (is_bool($value)) {
+        if (AppearanceBoolean::isValid($hero[$key])) {
             return [];
         }
 

--- a/src/Appearance/UpdateAppearanceSettingsUseCase.php
+++ b/src/Appearance/UpdateAppearanceSettingsUseCase.php
@@ -16,20 +16,22 @@ final readonly class UpdateAppearanceSettingsUseCase implements UpdateAppearance
 
     public function execute(UpdateAppearanceSettingsInput $input): AppearanceSettings
     {
-        $errors = $this->validator->validate($input->body);
+        /** @var array<string, mixed> $body */
+        $body = $this->normalizeBody($input->body);
+        $errors = $this->validator->validate($body);
 
         if ($errors !== []) {
             throw new ValidationException($errors);
         }
 
-        $widgetLocale = $input->body['widget_locale'] ?? null;
+        $widgetLocale = $body['widget_locale'] ?? null;
         $normalizedLocale = is_string($widgetLocale) && $widgetLocale !== '' ? $widgetLocale : null;
         /** @var array<string, mixed> $themeData */
-        $themeData = $input->body['theme'];
+        $themeData = $body['theme'];
         /** @var array<string, mixed> $heroData */
-        $heroData = is_array($input->body['hero'] ?? null) ? $input->body['hero'] : [];
+        $heroData = is_array($body['hero'] ?? null) ? $body['hero'] : [];
         /** @var array<string, mixed> $chatData */
-        $chatData = is_array($input->body['chat'] ?? null) ? $input->body['chat'] : [];
+        $chatData = is_array($body['chat'] ?? null) ? $body['chat'] : [];
 
         $settings = new AppearanceSettings(
             widgetLocale: $normalizedLocale,
@@ -41,5 +43,18 @@ final readonly class UpdateAppearanceSettingsUseCase implements UpdateAppearance
         $this->repository->save($settings);
 
         return $settings;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     * @return array<string, mixed>
+     */
+    private function normalizeBody(array $body): array
+    {
+        if (!is_array($body['chat'] ?? null)) {
+            $body['chat'] = WidgetChat::defaults()->toArray();
+        }
+
+        return $body;
     }
 }

--- a/src/Appearance/WidgetChat.php
+++ b/src/Appearance/WidgetChat.php
@@ -78,20 +78,6 @@ final readonly class WidgetChat
             return $fallback;
         }
 
-        $value = $data[$key];
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if ($value === 1 || $value === '1') {
-            return true;
-        }
-
-        if ($value === 0 || $value === '0') {
-            return false;
-        }
-
-        return $fallback;
+        return AppearanceBoolean::toBool($data[$key], $fallback);
     }
 }

--- a/src/Appearance/WidgetHero.php
+++ b/src/Appearance/WidgetHero.php
@@ -131,20 +131,6 @@ final readonly class WidgetHero
             return $fallback;
         }
 
-        $value = $data[$key];
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if ($value === 1 || $value === '1') {
-            return true;
-        }
-
-        if ($value === 0 || $value === '0') {
-            return false;
-        }
-
-        return $fallback;
+        return AppearanceBoolean::toBool($data[$key], $fallback);
     }
 }

--- a/tests/Appearance/AppearanceBooleanTest.php
+++ b/tests/Appearance/AppearanceBooleanTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Appearance;
+
+use NeneCorpus\Appearance\AppearanceBoolean;
+use PHPUnit\Framework\TestCase;
+
+final class AppearanceBooleanTest extends TestCase
+{
+    public function test_is_valid_accepts_common_representations(): void
+    {
+        self::assertTrue(AppearanceBoolean::isValid(true));
+        self::assertTrue(AppearanceBoolean::isValid(false));
+        self::assertTrue(AppearanceBoolean::isValid(1));
+        self::assertTrue(AppearanceBoolean::isValid(0));
+        self::assertTrue(AppearanceBoolean::isValid('1'));
+        self::assertTrue(AppearanceBoolean::isValid('0'));
+        self::assertTrue(AppearanceBoolean::isValid('true'));
+        self::assertTrue(AppearanceBoolean::isValid('false'));
+    }
+
+    public function test_is_valid_rejects_unknown_values(): void
+    {
+        self::assertFalse(AppearanceBoolean::isValid('yes'));
+        self::assertFalse(AppearanceBoolean::isValid(2));
+    }
+
+    public function test_to_bool_normalizes_values(): void
+    {
+        self::assertTrue(AppearanceBoolean::toBool('true'));
+        self::assertFalse(AppearanceBoolean::toBool('false'));
+        self::assertTrue(AppearanceBoolean::toBool('1'));
+        self::assertFalse(AppearanceBoolean::toBool(0));
+        self::assertTrue(AppearanceBoolean::toBool('unexpected', true));
+    }
+}

--- a/tests/Appearance/AppearanceHttpTest.php
+++ b/tests/Appearance/AppearanceHttpTest.php
@@ -289,6 +289,53 @@ final class AppearanceHttpTest extends TestCase
         self::assertSame(422, $response->getStatusCode());
     }
 
+    public function test_update_accepts_string_boolean_flags(): void
+    {
+        $token = $this->loginToken();
+
+        $response = $this->authorizedPut($token, [
+            'widget_locale' => null,
+            'theme' => self::defaultThemePayload(),
+            'hero' => [
+                ...self::defaultHeroPayload(),
+                'show_title' => 'true',
+                'show_description' => 'false',
+                'show_cta' => '1',
+                'show_image' => '0',
+            ],
+            'chat' => [
+                'user_avatar_mode' => 'silhouette',
+                'show_assistant_avatar' => 'false',
+            ],
+        ]);
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($payload['hero']['show_title']);
+        self::assertFalse($payload['hero']['show_description']);
+        self::assertTrue($payload['hero']['show_cta']);
+        self::assertFalse($payload['hero']['show_image']);
+        self::assertFalse($payload['chat']['show_assistant_avatar']);
+    }
+
+    public function test_update_defaults_chat_when_missing(): void
+    {
+        $token = $this->loginToken();
+
+        $response = $this->authorizedPut($token, [
+            'widget_locale' => null,
+            'theme' => self::defaultThemePayload(),
+            'hero' => self::defaultHeroPayload(),
+        ]);
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('silhouette', $payload['chat']['user_avatar_mode']);
+        self::assertTrue($payload['chat']['show_assistant_avatar']);
+    }
+
     public function test_update_rejects_invalid_color(): void
     {
         $token = $this->loginToken();

--- a/tests/Appearance/WidgetChatTest.php
+++ b/tests/Appearance/WidgetChatTest.php
@@ -37,6 +37,15 @@ final class WidgetChatTest extends TestCase
         self::assertSame(WidgetChat::USER_AVATAR_SILHOUETTE, $chat->userAvatarMode);
     }
 
+    public function test_from_array_parses_loose_boolean_values(): void
+    {
+        $chat = WidgetChat::fromArray([
+            'show_assistant_avatar' => 'false',
+        ]);
+
+        self::assertFalse($chat->showAssistantAvatar);
+    }
+
     public function test_to_array(): void
     {
         $chat = new WidgetChat(


### PR DESCRIPTION
## Summary

- `AppearanceBoolean` で hero/chat の boolean を正規化し、`chat` 欠落時はデフォルト merge（古い Admin PUT 互換）
- `fetch-json` が 422 Problem Details の `errors[].field` / `message` を UI に表示
- Admin「チャット吹き出し」ラベルに HERO トグル同様の literal key + locale fallback を追加

## Test plan

- [x] `composer check`
- [x] `npm run check --prefix frontend`
- [ ] Admin 外観で保存が 200 になる
- [ ] 422 時にフィールド名付きエラーが表示される
- [ ] チャット吹き出しのラジオ/チェックラベルが表示される

Closes #136

Self-review: backend-api

Made with [Cursor](https://cursor.com)