### PR TITLE
fix(widget): スクロールバー非表示と Vite dev キャッシュ対策 (#139)

### DIFF
--- a/frontend/apps/admin/src/AppearancePanel.tsx
+++ b/frontend/apps/admin/src/AppearancePanel.tsx
@@ -5,12 +5,14 @@ import {
   updateAppearanceSettings,
   uploadHeroImage,
   uploadAvatarImage,
-  type AppearanceSettingsResponse,
-  type UserAvatarMode,
-  type WidgetChat,
-  type WidgetHero,
-  type WidgetTheme,
-} from '@nene-corpus/api-client';
+} from '@nene-corpus/api-client/appearance';
+import type {
+  AppearanceSettingsResponse,
+  UserAvatarMode,
+  WidgetChat,
+  WidgetHero,
+  WidgetTheme,
+} from '@nene-corpus/api-client/types';
 import { Msg, resolveMsgKey, useLocale, useMsg, isUnresolvedTranslation, type MsgKey } from '@nene-corpus/i18n';
 import { adminApiBase } from './config';
 import { APPEARANCE_CHAT_TOGGLE_FALLBACK } from './appearanceChatToggleFallback';

--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), workspacePackageFullReload(appRoot)],
   resolve: {
     alias: {
+      '@nene-corpus/api-client/appearance': resolve(appRoot, '../../packages/api-client/src/appearance.ts'),
+      '@nene-corpus/api-client/types': resolve(appRoot, '../../packages/api-client/src/types.ts'),
       '@nene-corpus/api-client': resolve(appRoot, '../../packages/api-client/src/index.ts'),
       '@nene-corpus/i18n': resolve(appRoot, '../../packages/i18n/src/index.ts'),
       '@nene-corpus/tokens': resolve(appRoot, '../../packages/tokens/src/index.ts'),

--- a/frontend/apps/widget/src/main.tsx
+++ b/frontend/apps/widget/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
-import { fetchWidgetAppearance, DEFAULT_WIDGET_CHAT, DEFAULT_WIDGET_HERO, type WidgetChat, type WidgetHero, type WidgetTheme } from '@nene-corpus/api-client';
+import { fetchWidgetAppearance } from '@nene-corpus/api-client/appearance';
+import { DEFAULT_WIDGET_CHAT, DEFAULT_WIDGET_HERO } from '@nene-corpus/api-client/types';
+import type { WidgetChat, WidgetHero, WidgetTheme } from '@nene-corpus/api-client/types';
 import {
   LocaleProvider,
   WIDGET_LOCALE_STORAGE_KEY,

--- a/frontend/apps/widget/src/theme.ts
+++ b/frontend/apps/widget/src/theme.ts
@@ -1,6 +1,6 @@
 import { cssVars } from '@nene-corpus/tokens';
-import type { WidgetChat, WidgetHero, WidgetTheme } from '@nene-corpus/api-client';
-import { DEFAULT_WIDGET_CHAT, DEFAULT_WIDGET_HERO } from '@nene-corpus/api-client';
+import type { WidgetChat, WidgetHero, WidgetTheme } from '@nene-corpus/api-client/types';
+import { DEFAULT_WIDGET_CHAT, DEFAULT_WIDGET_HERO } from '@nene-corpus/api-client/types';
 
 export const DEFAULT_WIDGET_THEME: WidgetTheme = {
   color_primary: '#2563eb',

--- a/frontend/apps/widget/src/widget.css
+++ b/frontend/apps/widget/src/widget.css
@@ -85,6 +85,12 @@
   max-height: 24rem;
   overflow-y: auto;
   scroll-behavior: smooth;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.nene-corpus-chat__messages::-webkit-scrollbar {
+  display: none;
 }
 
 .nene-corpus-chat__row {

--- a/frontend/apps/widget/vite.config.ts
+++ b/frontend/apps/widget/vite.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
   plugins: [react(), workspacePackageFullReload(appRoot)],
   resolve: {
     alias: {
+      '@nene-corpus/api-client/appearance': resolve(appRoot, '../../packages/api-client/src/appearance.ts'),
+      '@nene-corpus/api-client/types': resolve(appRoot, '../../packages/api-client/src/types.ts'),
       '@nene-corpus/api-client': resolve(appRoot, '../../packages/api-client/src/index.ts'),
       '@nene-corpus/i18n': resolve(appRoot, '../../packages/i18n/src/index.ts'),
       '@nene-corpus/tokens': resolve(appRoot, '../../packages/tokens/src/index.ts'),

--- a/frontend/packages/api-client/package.json
+++ b/frontend/packages/api-client/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./appearance": "./src/appearance.ts",
+    "./types": "./src/types.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json"


### PR DESCRIPTION
## Summary
- チャットメッセージ欄のスクロールバーを CSS で非表示（スクロールは維持）
- `@nene-corpus/api-client/appearance` と `/types` の subpath export + Vite alias で barrel stale cache による真っ白画面を防止

## Test plan
- [x] `npm run check -w @nene-corpus/widget`
- [ ] Widget dev server 再起動後、メッセージ欄スクロール・外観保存が動作すること

Closes #139

Made with [Cursor](https://cursor.com)