### PR TITLE
fix(widget): embed スニペットを script 1 行に簡略化 (#142)

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -36,8 +36,6 @@ Details: [`../development/docker.md`](../development/docker.md)
 After install, add the **embed widget** on any **same-origin** page. Replace `/nene-corpus` with your base path:
 
 ```html
-<link rel="stylesheet" href="/nene-corpus/widget.css" />
-<div id="nene-corpus-widget-root"></div>
 <script src="/nene-corpus/widget.js" data-endpoint="/nene-corpus" defer></script>
 ```
 

--- a/docs/deployment/developer.md
+++ b/docs/deployment/developer.md
@@ -60,8 +60,6 @@ The installer:
 After install, add the widget on any page served from the **same origin**:
 
 ```html
-<link rel="stylesheet" href="/nene-corpus/widget.css" />
-<div id="nene-corpus-widget-root"></div>
 <script src="/nene-corpus/widget.js" data-endpoint="/nene-corpus" defer></script>
 ```
 

--- a/docs/deployment/shared-hosting.md
+++ b/docs/deployment/shared-hosting.md
@@ -134,12 +134,10 @@ Add the following to any page on the **same origin** (WordPress custom HTML bloc
 Replace `/nene-corpus` with your **base path** if different (installer shows detected paths at `/install/`):
 
 ```html
-<link rel="stylesheet" href="/nene-corpus/widget.css" />
-<div id="nene-corpus-widget-root"></div>
 <script src="/nene-corpus/widget.js" data-endpoint="/nene-corpus" defer></script>
 ```
 
-- `data-endpoint` — public API base path (same as base path; **no** `/api` suffix). The widget **auto-starts** when the script loads — no extra init block required.
+- `data-endpoint` — public API base path (same as base path; **no** `/api` suffix). The widget **auto-starts** when the script loads — no extra init block required. The script also injects `widget.css` and the mount `<div>` when they are not already on the page.
 - Widget appearance (colors, default language) — configure in Admin → Appearance
 
 The **embed widget** uses **sync JSON chat** (full reply + citations). A loading indicator and CSS motion appear while waiting — no token streaming.

--- a/frontend/apps/admin/src/embedSnippet.ts
+++ b/frontend/apps/admin/src/embedSnippet.ts
@@ -3,7 +3,5 @@ export function buildEmbedSnippet(apiBase: string): string {
   const base = apiBase.replace(/\/+$/, '');
   const pathPrefix = base === '' ? '' : base;
 
-  return `<link rel="stylesheet" href="${pathPrefix}/widget.css" />
-<div id="nene-corpus-widget-root"></div>
-<script src="${pathPrefix}/widget.js" data-endpoint="${base}" defer></script>`;
+  return `<script src="${pathPrefix}/widget.js" data-endpoint="${base}" defer></script>`;
 }

--- a/frontend/apps/widget/src/embedBootstrap.ts
+++ b/frontend/apps/widget/src/embedBootstrap.ts
@@ -1,0 +1,65 @@
+const mountId = 'nene-corpus-widget-root';
+
+export function findWidgetScript(): HTMLScriptElement | null {
+  const scripts = document.querySelectorAll('script[data-endpoint]');
+  const last = scripts.item(scripts.length - 1);
+
+  return last instanceof HTMLScriptElement ? last : null;
+}
+
+export function resolveWidgetAssetBase(script: HTMLScriptElement): string | null {
+  const src = script.getAttribute('src');
+
+  if (src === null || src === '') {
+    return null;
+  }
+
+  if (!/\/widget\.js(?:\?.*)?$/.test(src)) {
+    return null;
+  }
+
+  return src.replace(/\/widget\.js(?:\?.*)?$/, '');
+}
+
+export function ensureStylesheet(base: string): void {
+  const href = `${base}/widget.css`;
+
+  if (document.querySelector(`link[rel="stylesheet"][href="${href}"]`) !== null) {
+    return;
+  }
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = href;
+  document.head.appendChild(link);
+}
+
+export function ensureMountContainer(script: HTMLScriptElement): HTMLElement {
+  const existing = document.getElementById(mountId);
+
+  if (existing instanceof HTMLElement) {
+    return existing;
+  }
+
+  const container = document.createElement('div');
+  container.id = mountId;
+  script.insertAdjacentElement('afterend', container);
+
+  return container;
+}
+
+export function prepareEmbedMount(): HTMLElement | null {
+  const script = findWidgetScript();
+
+  if (script === null) {
+    return document.getElementById(mountId);
+  }
+
+  const base = resolveWidgetAssetBase(script);
+
+  if (base !== null) {
+    ensureStylesheet(base);
+  }
+
+  return ensureMountContainer(script);
+}

--- a/frontend/apps/widget/src/main.tsx
+++ b/frontend/apps/widget/src/main.tsx
@@ -13,11 +13,11 @@ import {
 } from '@nene-corpus/i18n';
 import '../../../themes/default.css';
 import { EmbedWidget } from './EmbedWidget';
+import { prepareEmbedMount } from './embedBootstrap';
 import { resolveWidgetConfig } from './config';
 import { DEFAULT_WIDGET_THEME, readPreviewChatFromSearchParams, readPreviewHeroFromSearchParams, readPreviewThemeFromSearchParams } from './theme';
 import './widget.css';
 
-const mountId = 'nene-corpus-widget-root';
 const mountedAttr = 'data-nene-corpus-mounted';
 
 export interface WidgetInitOptions {
@@ -102,7 +102,7 @@ export async function init(target: HTMLElement, options?: WidgetInitOptions): Pr
 }
 
 function tryAutoInit(): void {
-  const container = document.getElementById(mountId);
+  const container = prepareEmbedMount();
 
   if (container === null || container.hasAttribute(mountedAttr)) {
     return;

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -144,7 +144,7 @@ export const en = defineMessages({
   'admin.appearance.previewTitle': 'Preview',
   'admin.appearance.embedTitle': 'Embed on your site',
   'admin.appearance.embedSubtitle':
-    'Copy this HTML into a WordPress custom HTML block, theme footer, or any same-origin page. The widget starts automatically.',
+    'Copy this single script tag into a WordPress custom HTML block, theme footer, or any same-origin page. The widget loads its CSS and starts automatically.',
   'admin.appearance.embedCopy': 'Copy snippet',
   'admin.appearance.embedCopied': 'Copied!',
   'admin.appearance.embedCopyFailed': 'Could not copy to clipboard.',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -143,7 +143,7 @@ export const ja = defineMessages({
   'admin.appearance.previewTitle': 'プレビュー',
   'admin.appearance.embedTitle': 'サイトへの埋め込み',
   'admin.appearance.embedSubtitle':
-    'この HTML を WordPress のカスタム HTML ブロック、テーマのフッター、同一オリジンのページに貼り付けてください。ウィジェットは自動で起動します。',
+    'WordPress のカスタム HTML ブロックやフッターなど、同一オリジンのページにこの script タグを 1 行貼るだけです。CSS の読み込みとチャット起動は widget.js が自動で行います。',
   'admin.appearance.embedCopy': 'スニペットをコピー',
   'admin.appearance.embedCopied': 'コピーしました',
   'admin.appearance.embedCopyFailed': 'クリップボードにコピーできませんでした。',


### PR DESCRIPTION
## Summary
- Admin の embed スニペットを `<script defer>` 1 行に変更
- `widget.js` が `widget.css` と `#nene-corpus-widget-root` を自動注入（従来 3 行も動作）
- デプロイ docs と i18n を更新

## Test plan
- [x] `npm run check`
- [ ] Admin 外観 → スニペット 1 行コピー → ページに貼ってチャット起動

Closes #142

Made with [Cursor](https://cursor.com)