### PR TITLE
fix(admin): ソース表とドキュメント一覧の長いテキスト折り返しを修正する (#159)

### DIFF
--- a/frontend/apps/admin/src/SourceDocumentsPanel.tsx
+++ b/frontend/apps/admin/src/SourceDocumentsPanel.tsx
@@ -211,7 +211,7 @@ export function SourceDocumentsPanel({
                   type="button"
                   onClick={() => void loadDocumentDetail(document.document_id)}
                 >
-                  <div className="font-medium text-fg">{document.title}</div>
+                  <div className="font-medium text-fg break-words">{document.title}</div>
                   <div className="mt-1 line-clamp-2 text-xs nc-text-muted">{document.content_preview}</div>
                 </button>
               </li>

--- a/frontend/apps/admin/src/SourcesPanel.tsx
+++ b/frontend/apps/admin/src/SourcesPanel.tsx
@@ -95,7 +95,7 @@ export function SourcesPanel({ token, reloadKey = 0, onDocumentsChanged }: Sourc
               {sources.map((source) => (
                 <Fragment key={source.source_id}>
                   <tr className="nc-table-row">
-                    <td className="px-4 py-2 font-medium">{source.name}</td>
+                    <td className="px-4 py-2 font-medium break-all min-w-0 max-w-xs">{source.name}</td>
                     <td className="px-4 py-2 uppercase nc-text-subtle tracking-wide">
                       {t(SOURCE_TYPE_MSG[source.source_type])}
                     </td>


### PR DESCRIPTION
## 変更内容

- `SourcesPanel`: ソース名セルに `break-all min-w-0 max-w-xs` を追加。長いソース名でも「ドキュメント」列が常に視野に収まる
- `SourceDocumentsPanel`: ドキュメントタイトルに `break-words` を追加。長いタイトルが枠外にはみ出さない

## 検証

`npm run check --prefix frontend` — PASS（TypeScript エラーなし）

Self-review: docs-policy

Closes #159