### PR TITLE
feat(appearance): カスタム CSS サポート (#169)

### DIFF
--- a/database/migrations/20260526240000_add_custom_css_to_appearance_settings.php
+++ b/database/migrations/20260526240000_add_custom_css_to_appearance_settings.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddCustomCssToAppearanceSettings extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('appearance_settings')
+            ->addColumn('custom_css', 'text', ['null' => true, 'after' => 'layout_json'])
+            ->update();
+    }
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1506,6 +1506,12 @@ components:
           $ref: '#/components/schemas/WidgetChat'
         layout:
           $ref: '#/components/schemas/WidgetLayout'
+        custom_css:
+          type:
+            - string
+            - 'null'
+          maxLength: 4000
+          description: Operator-injected CSS scoped to the widget. Forbidden patterns (url, expression, javascript:, HTML tags) are rejected.
     LlmSettingsResponse:
       type: object
       required:
@@ -1623,6 +1629,12 @@ components:
           $ref: '#/components/schemas/WidgetChat'
         layout:
           $ref: '#/components/schemas/WidgetLayout'
+        custom_css:
+          type:
+            - string
+            - 'null'
+          maxLength: 4000
+          description: Operator-injected CSS scoped to the widget. Pass null or empty string to clear.
     PreviewCsvIngestionRequest:
       type: object
       required:

--- a/frontend/apps/admin/src/AppearancePanel.tsx
+++ b/frontend/apps/admin/src/AppearancePanel.tsx
@@ -254,6 +254,7 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
   const [heroForm, setHeroForm] = useState<HeroFormState>(EMPTY_HERO_FORM);
   const [chatForm, setChatForm] = useState<ChatFormState>(EMPTY_CHAT_FORM);
   const [layoutForm, setLayoutForm] = useState<WidgetLayout>(DEFAULT_WIDGET_LAYOUT);
+  const [customCss, setCustomCss] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
@@ -316,6 +317,7 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
       assistant_avatar_alt: settings.chat.assistant_avatar_alt ?? '',
     });
     setLayoutForm(settings.layout);
+    setCustomCss(settings.custom_css ?? '');
   }
 
   function updateHeroField<K extends keyof HeroFormState>(field: K, value: HeroFormState[K]): void {
@@ -452,6 +454,7 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
         hero: heroPayload(),
         chat: chatPayload(),
         layout: layoutPayload(),
+        custom_css: customCss.trim() === '' ? null : customCss.trim(),
       }, adminApiBase);
       applySettings(saved);
       setSuccess(t(Msg.admin.appearance.saveSuccess));
@@ -932,6 +935,19 @@ export function AppearancePanel({ token }: AppearancePanelProps) {
                 value={theme.max_width}
                 onChange={(event) => updateThemeField('max_width', event.target.value)}
                 placeholder="480px"
+              />
+            </label>
+          </div>
+          <div className="space-y-2">
+            <label className="block text-sm">
+              <span className="font-medium text-fg">{t(Msg.admin.appearance.customCssTitle)}</span>
+              <span className="mt-0.5 block text-xs nc-text-muted">{t(Msg.admin.appearance.customCssHelp)}</span>
+              <textarea
+                className="nc-input mt-1 min-h-32 resize-y font-mono text-xs"
+                value={customCss}
+                onChange={(event) => setCustomCss(event.target.value)}
+                placeholder=".nene-corpus-root .nene-corpus-chat__bubble--assistant { background: #f0f4ff; }"
+                spellCheck={false}
               />
             </label>
           </div>

--- a/frontend/apps/widget/src/main.tsx
+++ b/frontend/apps/widget/src/main.tsx
@@ -89,6 +89,13 @@ export async function init(target: HTMLElement, options?: WidgetInitOptions): Pr
     chat = appearance.chat;
     layout = appearance.layout;
     configuredLocale = appearance.widget_locale;
+
+    if (appearance.custom_css !== null && appearance.custom_css !== '') {
+      const style = document.createElement('style');
+      style.setAttribute('data-nene-corpus-custom', '');
+      style.textContent = appearance.custom_css;
+      document.head.appendChild(style);
+    }
   } catch {
     // Keep defaults when appearance API is unavailable.
   }

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -246,6 +246,7 @@ export interface AppearanceSettingsResponse {
   hero: WidgetHero;
   chat: WidgetChat;
   layout: WidgetLayout;
+  custom_css: string | null;
 }
 
 export type UpdateAppearanceSettingsRequest = AppearanceSettingsResponse;

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -284,6 +284,8 @@ export const Msg = {
       assistantAvatarImageRemove: 'admin.appearance.assistantAvatarImageRemove',
       assistantAvatarImageUploadFailed: 'admin.appearance.assistantAvatarImageUploadFailed',
       assistantAvatarImageTooLarge: 'admin.appearance.assistantAvatarImageTooLarge',
+      customCssTitle: 'admin.appearance.customCssTitle',
+      customCssHelp: 'admin.appearance.customCssHelp',
       save: 'admin.appearance.save',
       saving: 'admin.appearance.saving',
       saveSuccess: 'admin.appearance.saveSuccess',

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -276,6 +276,8 @@ export const de = defineMessages({
   'admin.appearance.assistantAvatarImageRemove': 'Bild entfernen',
   'admin.appearance.assistantAvatarImageUploadFailed': 'Bild konnte nicht hochgeladen werden.',
   'admin.appearance.assistantAvatarImageTooLarge': 'Das Bild darf höchstens 2 MB groß sein.',
+  'admin.appearance.customCssTitle': 'Benutzerdefiniertes CSS',
+  'admin.appearance.customCssHelp': 'Operator-CSS, das innerhalb des Widgets angewendet wird. Präfixieren Sie Regeln mit .nene-corpus-root. Verboten: url(), expression(), javascript:, HTML-Tags.',
   'admin.appearance.save': 'Speichern',
   'admin.appearance.saving': 'Speichern…',
   'admin.appearance.saveSuccess': 'Einstellungen gespeichert.',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -277,6 +277,8 @@ export const en = defineMessages({
   'admin.appearance.assistantAvatarImageRemove': 'Remove image',
   'admin.appearance.assistantAvatarImageUploadFailed': 'Failed to upload image.',
   'admin.appearance.assistantAvatarImageTooLarge': 'Image must be 2 MB or smaller.',
+  'admin.appearance.customCssTitle': 'Custom CSS',
+  'admin.appearance.customCssHelp': 'Operator-injected CSS applied inside the widget. Scope your rules with .nene-corpus-root. Forbidden: url(), expression(), javascript:, HTML tags.',
   'admin.appearance.save': 'Save settings',
   'admin.appearance.saving': 'Saving…',
   'admin.appearance.saveSuccess': 'Appearance settings saved.',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -276,6 +276,8 @@ export const fr = defineMessages({
   'admin.appearance.assistantAvatarImageRemove': 'Supprimer l\'image',
   'admin.appearance.assistantAvatarImageUploadFailed': 'Échec du téléversement de l\'image.',
   'admin.appearance.assistantAvatarImageTooLarge': 'L\'image doit faire 2 Mo ou moins.',
+  'admin.appearance.customCssTitle': 'CSS personnalisé',
+  'admin.appearance.customCssHelp': 'CSS opérateur appliqué à l\'intérieur du widget. Préfixez vos règles avec .nene-corpus-root. Interdit : url(), expression(), javascript:, balises HTML.',
   'admin.appearance.save': 'Enregistrer',
   'admin.appearance.saving': 'Enregistrement…',
   'admin.appearance.saveSuccess': 'Paramètres enregistrés.',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -276,6 +276,8 @@ export const ja = defineMessages({
   'admin.appearance.assistantAvatarImageRemove': '画像を削除',
   'admin.appearance.assistantAvatarImageUploadFailed': '画像のアップロードに失敗しました。',
   'admin.appearance.assistantAvatarImageTooLarge': '画像は 2 MB 以下にしてください。',
+  'admin.appearance.customCssTitle': 'カスタム CSS',
+  'admin.appearance.customCssHelp': 'ウィジェット内に適用するオペレーター用 CSS です。ルールは .nene-corpus-root でスコープしてください。禁止: url()、expression()、javascript:、HTML タグ。',
   'admin.appearance.save': '保存',
   'admin.appearance.saving': '保存中…',
   'admin.appearance.saveSuccess': '設定を保存しました。',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -276,6 +276,8 @@ export const ptBr = defineMessages({
   'admin.appearance.assistantAvatarImageRemove': 'Remover imagem',
   'admin.appearance.assistantAvatarImageUploadFailed': 'Falha ao enviar a imagem.',
   'admin.appearance.assistantAvatarImageTooLarge': 'A imagem deve ter no máximo 2 MB.',
+  'admin.appearance.customCssTitle': 'CSS personalizado',
+  'admin.appearance.customCssHelp': 'CSS do operador aplicado dentro do widget. Prefixe suas regras com .nene-corpus-root. Proibido: url(), expression(), javascript:, tags HTML.',
   'admin.appearance.save': 'Salvar',
   'admin.appearance.saving': 'Salvando…',
   'admin.appearance.saveSuccess': 'Configurações salvas.',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -270,6 +270,8 @@ export const zhHans = defineMessages({
   'admin.appearance.assistantAvatarImageRemove': '删除图片',
   'admin.appearance.assistantAvatarImageUploadFailed': '图片上传失败。',
   'admin.appearance.assistantAvatarImageTooLarge': '图片不得超过 2 MB。',
+  'admin.appearance.customCssTitle': '自定义 CSS',
+  'admin.appearance.customCssHelp': '运营商注入的 CSS，应用于 widget 内部。请使用 .nene-corpus-root 限定作用域。禁止：url()、expression()、javascript:、HTML 标签。',
   'admin.appearance.save': '保存设置',
   'admin.appearance.saving': '保存中…',
   'admin.appearance.saveSuccess': '外观设置已保存。',

--- a/src/Appearance/AppearanceSettings.php
+++ b/src/Appearance/AppearanceSettings.php
@@ -12,6 +12,7 @@ final readonly class AppearanceSettings
         public WidgetHero $hero,
         public WidgetChat $chat,
         public WidgetLayout $layout,
+        public ?string $customCss = null,
     ) {
     }
 
@@ -23,6 +24,7 @@ final readonly class AppearanceSettings
             hero: WidgetHero::defaults(),
             chat: WidgetChat::defaults(),
             layout: WidgetLayout::defaults(),
+            customCss: null,
         );
     }
 
@@ -56,7 +58,8 @@ final readonly class AppearanceSettings
      *         offset_x: int,
      *         offset_y: int,
      *         floating_launcher: bool
-     *     }
+     *     },
+     *     custom_css: string|null
      * }
      */
     public function toArray(): array
@@ -67,6 +70,7 @@ final readonly class AppearanceSettings
             'hero' => $this->hero->toArray(),
             'chat' => $this->chat->toArray(),
             'layout' => $this->layout->toArray(),
+            'custom_css' => $this->customCss,
         ];
     }
 }

--- a/src/Appearance/AppearanceSettingsValidator.php
+++ b/src/Appearance/AppearanceSettingsValidator.php
@@ -85,8 +85,48 @@ final readonly class AppearanceSettingsValidator
         }
 
         $errors = [...$errors, ...$this->validateLayout($layout)];
+        $errors = [...$errors, ...$this->validateCustomCss($body)];
 
         return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     * @return list<ValidationError>
+     */
+    private function validateCustomCss(array $body): array
+    {
+        if (!array_key_exists('custom_css', $body)) {
+            return [];
+        }
+
+        $value = $body['custom_css'];
+
+        if ($value === null || $value === '') {
+            return [];
+        }
+
+        if (!is_string($value)) {
+            return [new ValidationError('custom_css', 'custom_css must be a string or null.', 'invalid_type')];
+        }
+
+        if (mb_strlen($value) > 4000) {
+            return [new ValidationError('custom_css', 'custom_css must not exceed 4000 characters.', 'too_long')];
+        }
+
+        $lower = strtolower($value);
+
+        foreach (['url(', 'expression(', 'javascript:', '<', '>'] as $forbidden) {
+            if (str_contains($lower, $forbidden)) {
+                return [new ValidationError(
+                    'custom_css',
+                    'custom_css must not contain forbidden patterns (url, expression, javascript:, HTML tags).',
+                    'forbidden_content',
+                )];
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/src/Appearance/PdoAppearanceSettingsRepository.php
+++ b/src/Appearance/PdoAppearanceSettingsRepository.php
@@ -16,7 +16,7 @@ final readonly class PdoAppearanceSettingsRepository implements AppearanceSettin
     public function get(): AppearanceSettings
     {
         $row = $this->query->fetchOne(
-            'SELECT widget_locale, theme_json, hero_json, chat_json, layout_json FROM appearance_settings ORDER BY id ASC LIMIT 1',
+            'SELECT widget_locale, theme_json, hero_json, chat_json, layout_json, custom_css FROM appearance_settings ORDER BY id ASC LIMIT 1',
         );
 
         if ($row === null) {
@@ -34,6 +34,7 @@ final readonly class PdoAppearanceSettingsRepository implements AppearanceSettin
             hero: WidgetHero::fromArray(is_array($heroDecoded) ? $heroDecoded : []),
             chat: WidgetChat::fromArray(is_array($chatDecoded) ? $chatDecoded : []),
             layout: WidgetLayout::fromArray(is_array($layoutDecoded) ? $layoutDecoded : []),
+            customCss: is_string($row['custom_css'] ?? null) ? $row['custom_css'] : null,
         );
     }
 
@@ -48,16 +49,16 @@ final readonly class PdoAppearanceSettingsRepository implements AppearanceSettin
 
         if ($existing === null) {
             $this->query->execute(
-                'INSERT INTO appearance_settings (widget_locale, theme_json, hero_json, chat_json, layout_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
-                [$settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $now, $now],
+                'INSERT INTO appearance_settings (widget_locale, theme_json, hero_json, chat_json, layout_json, custom_css, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                [$settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $settings->customCss, $now, $now],
             );
 
             return;
         }
 
         $this->query->execute(
-            'UPDATE appearance_settings SET widget_locale = ?, theme_json = ?, hero_json = ?, chat_json = ?, layout_json = ?, updated_at = ? WHERE id = ?',
-            [$settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $now, (int) $existing['id']],
+            'UPDATE appearance_settings SET widget_locale = ?, theme_json = ?, hero_json = ?, chat_json = ?, layout_json = ?, custom_css = ?, updated_at = ? WHERE id = ?',
+            [$settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $settings->customCss, $now, (int) $existing['id']],
         );
     }
 }

--- a/src/Appearance/UpdateAppearanceSettingsUseCase.php
+++ b/src/Appearance/UpdateAppearanceSettingsUseCase.php
@@ -35,12 +35,16 @@ final readonly class UpdateAppearanceSettingsUseCase implements UpdateAppearance
         /** @var array<string, mixed> $layoutData */
         $layoutData = is_array($body['layout'] ?? null) ? $body['layout'] : [];
 
+        $rawCustomCss = $body['custom_css'] ?? null;
+        $customCss = is_string($rawCustomCss) && trim($rawCustomCss) !== '' ? trim($rawCustomCss) : null;
+
         $settings = new AppearanceSettings(
             widgetLocale: $normalizedLocale,
             theme: WidgetTheme::fromArray($themeData),
             hero: WidgetHero::fromArray($heroData),
             chat: WidgetChat::fromArray($chatData),
             layout: WidgetLayout::fromArray($layoutData),
+            customCss: $customCss,
         );
 
         $this->repository->save($settings);

--- a/tests/Appearance/AppearanceHttpTest.php
+++ b/tests/Appearance/AppearanceHttpTest.php
@@ -519,6 +519,77 @@ final class AppearanceHttpTest extends TestCase
         self::assertSame(422, $response->getStatusCode());
     }
 
+    public function test_admin_can_save_and_retrieve_custom_css(): void
+    {
+        $token = $this->loginToken();
+
+        $css = '.nene-corpus-root { --test: 1; }';
+
+        $response = $this->authorizedPut($token, [
+            'widget_locale' => null,
+            'theme' => self::defaultThemePayload(),
+            'hero' => self::defaultHeroPayload(),
+            'chat' => self::defaultChatPayload(),
+            'layout' => self::defaultLayoutPayload(),
+            'custom_css' => $css,
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $payload = $this->decodeJson($response);
+
+        self::assertSame($css, $payload['custom_css']);
+
+        $public = $this->decodeJson($this->dispatch('GET', '/widget/appearance'));
+
+        self::assertSame($css, $public['custom_css']);
+    }
+
+    public function test_update_rejects_forbidden_css_pattern(): void
+    {
+        $token = $this->loginToken();
+
+        $response = $this->authorizedPut($token, [
+            'widget_locale' => null,
+            'theme' => self::defaultThemePayload(),
+            'hero' => self::defaultHeroPayload(),
+            'chat' => self::defaultChatPayload(),
+            'layout' => self::defaultLayoutPayload(),
+            'custom_css' => '.x { background: url(https://evil.example/img.png); }',
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    public function test_custom_css_null_clears_value(): void
+    {
+        $token = $this->loginToken();
+
+        $this->authorizedPut($token, [
+            'widget_locale' => null,
+            'theme' => self::defaultThemePayload(),
+            'hero' => self::defaultHeroPayload(),
+            'chat' => self::defaultChatPayload(),
+            'layout' => self::defaultLayoutPayload(),
+            'custom_css' => '.nene-corpus-root { color: red; }',
+        ]);
+
+        $response = $this->authorizedPut($token, [
+            'widget_locale' => null,
+            'theme' => self::defaultThemePayload(),
+            'hero' => self::defaultHeroPayload(),
+            'chat' => self::defaultChatPayload(),
+            'layout' => self::defaultLayoutPayload(),
+            'custom_css' => null,
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $payload = $this->decodeJson($response);
+
+        self::assertNull($payload['custom_css']);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -111,6 +111,7 @@ final class CorpusSchemaSetup
                     hero_json TEXT NULL,
                     chat_json TEXT NULL,
                     layout_json TEXT NULL,
+                    custom_css TEXT NULL,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 )


### PR DESCRIPTION
## 概要

Appearance 設定にオペレーター用カスタム CSS フィールドを追加。ウィジェット内に適用され、WordPress など既存サイトの CSS との競合を最小化するために `.nene-corpus-root` でスコープする。

Closes #169

## 変更内容

### Backend
- **マイグレーション**: `appearance_settings` に `custom_css TEXT NULL` カラムを追加
- **`AppearanceSettings`**: `customCss` フィールドを追加、`defaults()`・`toArray()` を更新
- **`AppearanceSettingsValidator`**: `validateCustomCss()` を追加
  - 最大 4000 文字
  - 禁止パターン: `url(`・`expression(`・`javascript:`・HTML タグ (`<`・`>`)
- **`PdoAppearanceSettingsRepository`**: SELECT・INSERT・UPDATE に `custom_css` を追加
- **`UpdateAppearanceSettingsUseCase`**: `customCss` を `AppearanceSettings` コンストラクタに渡す
- **OpenAPI**: 両スキーマ（Response・Request）に `custom_css` フィールドを追加

### Frontend
- **`types.ts`**: `AppearanceSettingsResponse` に `custom_css: string | null` を追加
- **`AppearancePanel.tsx`**: カスタム CSS テキストエリアを追加（モノスペース・リサイズ可・6 言語 i18n）
- **`main.tsx` (widget)**: `custom_css` を `<style data-nene-corpus-custom>` として `document.head` に注入

### テスト
- 保存・公開エンドポイントからの取得
- 禁止パターン（`url(`）を含む CSS で 422
- `null` で既存値をクリア

## チェックリスト

- [x] `composer check` グリーン (118 tests, 655 assertions)
- [x] `npm run check --prefix frontend` グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)