### PR TITLE
fix(admin): テキストオーバーフロー対策 — 長い文字列の強制折り返し (#171)

### DIFF
--- a/frontend/apps/admin/src/ConversationLogsPanel.tsx
+++ b/frontend/apps/admin/src/ConversationLogsPanel.tsx
@@ -233,11 +233,11 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                         {formatTimestamp(message.created_at, locale)}
                       </time>
                     </div>
-                    <p className="whitespace-pre-wrap text-sm">{message.content}</p>
+                    <p className="whitespace-pre-wrap break-words text-sm">{message.content}</p>
                     {message.citations.length > 0 && (
                       <ul className="mt-2 space-y-1 border-t border-border pt-2 nc-text-muted">
                         {message.citations.map((citation) => (
-                          <li key={citation.chunk_id}>
+                          <li key={citation.chunk_id} className="min-w-0">
                             <span className="font-medium">
                               {t(Msg.admin.conversationLogs.citationChunk, { id: citation.chunk_id })}
                             </span>
@@ -248,9 +248,9 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                               </span>
                             )}
                             {citation.section_label !== undefined && (
-                              <span> · {citation.section_label}</span>
+                              <span className="break-words"> · {citation.section_label}</span>
                             )}
-                            <p className="mt-0.5 nc-text-subtle">{citation.excerpt}</p>
+                            <p className="mt-0.5 break-words nc-text-subtle">{citation.excerpt}</p>
                           </li>
                         ))}
                       </ul>

--- a/frontend/apps/admin/src/IngestionPanel.tsx
+++ b/frontend/apps/admin/src/IngestionPanel.tsx
@@ -326,7 +326,7 @@ export function IngestionPanel({ token, onUploaded }: IngestionPanelProps) {
           <p className="nc-text-muted">
             {t(Msg.admin.ingestion.pdfPageCount, { count: pdfPreview.page_count })}
           </p>
-          <pre className="max-h-40 overflow-auto rounded-admin bg-surface-muted p-3 nc-text-muted whitespace-pre-wrap">
+          <pre className="max-h-40 overflow-auto rounded-admin bg-surface-muted p-3 nc-text-muted whitespace-pre-wrap break-words">
             {pdfPreview.sample_text.slice(0, 800)}
             {pdfPreview.sample_text.length > 800 ? '…' : ''}
           </pre>

--- a/frontend/apps/admin/src/SourceDocumentsPanel.tsx
+++ b/frontend/apps/admin/src/SourceDocumentsPanel.tsx
@@ -426,8 +426,8 @@ export function SourceDocumentsPanel({
                           key={chunk.chunk_id}
                           className="rounded-admin border border-accent-border bg-surface/70 px-3 py-2"
                         >
-                          <div className="text-xs nc-text-muted">{formatChunkMeta(chunk, t)}</div>
-                          <pre className="mt-1 whitespace-pre-wrap font-mono text-xs text-fg">{chunk.content}</pre>
+                          <div className="break-words text-xs nc-text-muted">{formatChunkMeta(chunk, t)}</div>
+                          <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-fg">{chunk.content}</pre>
                         </li>
                       ))}
                     </ol>


### PR DESCRIPTION
## 概要

会話ログの緑ブロック（アシスタントメッセージ）内で URL などの長い文字列がはみ出る問題を修正。admin 全体で外部データが入りうる表示箇所に `break-words` を追加。

Closes #171

## 変更箇所

| ファイル | 修正内容 |
|---|---|
| `ConversationLogsPanel.tsx` | メッセージ本文 `<p>` に `break-words` を追加（`whitespace-pre-wrap` のみでは URL がはみ出ていた） |
| `ConversationLogsPanel.tsx` | 引用 excerpt `<p>` に `break-words` を追加 |
| `ConversationLogsPanel.tsx` | 引用 section_label `<span>` に `break-words`、`<li>` に `min-w-0` を追加 |
| `SourceDocumentsPanel.tsx` | チャンクプレビュー `<pre>` と chunk meta `<div>` に `break-words` を追加 |
| `IngestionPanel.tsx` | PDF サンプルテキスト `<pre>` に `break-words` を追加 |

## 方針

- **全文表示が必要な箇所**（メッセージ本文・引用・チャンク内容）→ `break-words` で強制折り返し
- **一覧でコンパクトに見せる箇所**（ドキュメントプレビュー）→ 既存の `line-clamp-2` を維持
- **コードとして意図的に横スクロールする箇所**（埋め込みスニペット・CSV プレビュー）→ 変更なし

## チェック

- [x] `npm run check --prefix frontend` グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)