### PR TITLE
fix(admin): Vite alias に chat-settings を追加、リリースビルド修正 (#173)

### DIFF
--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     alias: {
       '@nene-corpus/api-client/appearance': resolve(appRoot, '../../packages/api-client/src/appearance.ts'),
       '@nene-corpus/api-client/llm-settings': resolve(appRoot, '../../packages/api-client/src/llm-settings.ts'),
+      '@nene-corpus/api-client/chat-settings': resolve(appRoot, '../../packages/api-client/src/chat-settings.ts'),
       '@nene-corpus/api-client/types': resolve(appRoot, '../../packages/api-client/src/types.ts'),
       '@nene-corpus/api-client': resolve(appRoot, '../../packages/api-client/src/index.ts'),
       '@nene-corpus/i18n': resolve(appRoot, '../../packages/i18n/src/index.ts'),


### PR DESCRIPTION
## 問題

`npm run build:release` が以下のエラーで失敗。

```
[vite:load-fallback] Could not load .../src/index.ts/chat-settings
ENOTDIR: not a directory
```

`apps/admin/vite.config.ts` の `resolve.alias` に `@nene-corpus/api-client/chat-settings` の登録が漏れており、サブパスが catch-all の `@nene-corpus/api-client`（= `src/index.ts`）にマッチしていた。

TypeScript の `typecheck` は `package.json` の `exports` フィールドを参照するため通過していたが、Vite はファイルシステムパスを直接解決するため検出されなかった。

Closes #173

## 修正

`vite.config.ts` の alias に 1 行追加。

```ts
'@nene-corpus/api-client/chat-settings': resolve(appRoot, '../../packages/api-client/src/chat-settings.ts'),
```

## チェック

- [x] `npm run build:release --prefix frontend` グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)