### PR TITLE
fix(admin): ドキュメント編集モーダルを画面中央に表示 (#175)

### DIFF
--- a/frontend/apps/admin/src/SourceDocumentsPanel.tsx
+++ b/frontend/apps/admin/src/SourceDocumentsPanel.tsx
@@ -355,7 +355,7 @@ export function SourceDocumentsPanel({
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click handled by dialog cancel */}
       <dialog
         ref={dialogRef}
-        className="w-full max-w-2xl rounded-admin bg-surface p-0 shadow-xl backdrop:bg-black/40"
+        className="m-auto w-full max-w-2xl rounded-admin bg-surface p-0 shadow-xl backdrop:bg-black/40"
         onCancel={handleDialogCancel}
         onClick={handleDialogClick}
       >


### PR DESCRIPTION
## 問題

ドキュメント編集モーダルが画面左上に表示されていた。

## 原因

Tailwind CSS v4 の preflight が `<dialog>` 要素のデフォルトスタイル（`margin: auto`）をリセットしていた。ネイティブ `showModal()` は viewport 基準で配置されるが、`margin: auto` がなければ左上に固定される。

## 修正

`dialog` の className に `m-auto` を 1 語追加。

Closes #175

## チェック

- [x] `npm run check --prefix frontend` グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)