### PR TITLE
feat(admin): ドキュメント一覧ページャを強化 — 表示件数・ページ直接入力 (#179)

### DIFF
--- a/frontend/apps/admin/src/SourceDocumentsPanel.tsx
+++ b/frontend/apps/admin/src/SourceDocumentsPanel.tsx
@@ -11,7 +11,8 @@ import {
 import { Msg, useMsg, type MessageParams, type MsgKey } from '@nene-corpus/i18n';
 import { adminApiBase } from './config';
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
+const DEFAULT_PAGE_SIZE = 50;
 
 interface SourceDocumentsPanelProps {
   token: string;
@@ -59,6 +60,7 @@ export function SourceDocumentsPanel({
   const [documents, setDocuments] = useState<DocumentListItem[]>([]);
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
+  const [pageSize, setPageSize] = useState<(typeof PAGE_SIZE_OPTIONS)[number]>(DEFAULT_PAGE_SIZE);
   const [searchQuery, setSearchQuery] = useState('');
   const [draftQuery, setDraftQuery] = useState('');
   const [isLoading, setIsLoading] = useState(true);
@@ -76,19 +78,32 @@ export function SourceDocumentsPanel({
   const [editError, setEditError] = useState<string | null>(null);
   const [editSuccess, setEditSuccess] = useState<string | null>(null);
 
+  // ページネーション派生値
+  const currentPage = total === 0 ? 1 : Math.floor(offset / pageSize) + 1;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const from = total === 0 ? 0 : offset + 1;
+  const to = Math.min(offset + pageSize, total);
+  const hasPrev = offset > 0;
+  const hasNext = offset + pageSize < total;
+
   // モーダルをマウント時に開く
   useEffect(() => {
     dialogRef.current?.showModal();
   }, []);
 
   const loadDocuments = useCallback(
-    async (currentOffset: number, currentQuery: string, signal?: AbortSignal): Promise<void> => {
+    async (
+      currentOffset: number,
+      currentQuery: string,
+      currentPageSize: number,
+      signal?: AbortSignal,
+    ): Promise<void> => {
       setIsLoading(true);
       setListError(null);
 
       try {
         const response = await listDocuments(token, sourceId, adminApiBase, {
-          limit: PAGE_SIZE,
+          limit: currentPageSize,
           offset: currentOffset,
           q: currentQuery,
         });
@@ -114,12 +129,12 @@ export function SourceDocumentsPanel({
 
   useEffect(() => {
     const controller = new AbortController();
-    void loadDocuments(offset, searchQuery, controller.signal);
+    void loadDocuments(offset, searchQuery, pageSize, controller.signal);
 
     return () => {
       controller.abort();
     };
-  }, [loadDocuments, offset, searchQuery]);
+  }, [loadDocuments, offset, searchQuery, pageSize]);
 
   function clearSelection(): void {
     setSelectedId(null);
@@ -143,6 +158,27 @@ export function SourceDocumentsPanel({
     setOffset(0);
     setSearchQuery('');
     searchInputRef.current?.focus();
+  }
+
+  function handlePageSizeChange(newSize: (typeof PAGE_SIZE_OPTIONS)[number]): void {
+    setPageSize(newSize);
+    setOffset(0);
+    clearSelection();
+  }
+
+  function handlePageInputBlur(event: React.FocusEvent<HTMLInputElement>): void {
+    const parsed = parseInt(event.target.value, 10);
+
+    if (!isNaN(parsed)) {
+      const clamped = Math.max(1, Math.min(totalPages, parsed));
+      setOffset((clamped - 1) * pageSize);
+    }
+  }
+
+  function handlePageInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'Enter') {
+      event.currentTarget.blur();
+    }
   }
 
   async function loadDocumentDetail(documentId: number): Promise<void> {
@@ -191,7 +227,7 @@ export function SourceDocumentsPanel({
 
       const [response, chunkResponse] = await Promise.all([
         listDocuments(token, sourceId, adminApiBase, {
-          limit: PAGE_SIZE,
+          limit: pageSize,
           offset,
           q: searchQuery,
         }),
@@ -227,7 +263,7 @@ export function SourceDocumentsPanel({
       onChanged();
 
       const response = await listDocuments(token, sourceId, adminApiBase, {
-        limit: PAGE_SIZE,
+        limit: pageSize,
         offset,
         q: searchQuery,
       });
@@ -241,11 +277,6 @@ export function SourceDocumentsPanel({
       setIsDeleting(false);
     }
   }
-
-  const from = total === 0 ? 0 : offset + 1;
-  const to = Math.min(offset + PAGE_SIZE, total);
-  const hasPrev = offset > 0;
-  const hasNext = offset + PAGE_SIZE < total;
 
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click handled by dialog cancel
@@ -334,25 +365,59 @@ export function SourceDocumentsPanel({
               )}
             </div>
 
-            {/* フッター：件数 + ページング */}
+            {/* フッター：件数 + 表示件数 + ページナビ */}
             {total > 0 && (
-              <div className="shrink-0 border-t border-border px-3 py-2 flex flex-wrap items-center justify-between gap-2 text-xs nc-text-muted">
-                <span>{t(Msg.admin.documents.pageInfo, { from, to, total })}</span>
-                {total > PAGE_SIZE && (
-                  <div className="flex gap-1">
+              <div className="shrink-0 space-y-1.5 border-t border-border px-3 py-2">
+                {/* 行 1: 件数 + 表示件数セレクタ */}
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs nc-text-muted">
+                    {t(Msg.admin.documents.pageInfo, { from, to, total })}
+                  </span>
+                  <select
+                    aria-label={t(Msg.admin.documents.perPageLabel)}
+                    className="rounded-admin border border-border bg-surface py-0.5 pl-1.5 pr-6 text-xs text-fg"
+                    value={pageSize}
+                    onChange={(event) =>
+                      handlePageSizeChange(
+                        Number(event.target.value) as (typeof PAGE_SIZE_OPTIONS)[number],
+                      )
+                    }
+                  >
+                    {PAGE_SIZE_OPTIONS.map((n) => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* 行 2: ページナビ（複数ページの場合のみ） */}
+                {totalPages > 1 && (
+                  <div className="flex items-center gap-1">
                     <button
                       className="nc-btn text-xs disabled:opacity-40"
                       type="button"
                       disabled={!hasPrev}
-                      onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                      onClick={() => setOffset(Math.max(0, offset - pageSize))}
                     >
                       {t(Msg.admin.documents.pagePrev)}
                     </button>
+                    <input
+                      key={currentPage}
+                      type="number"
+                      defaultValue={currentPage}
+                      min={1}
+                      max={totalPages}
+                      className="w-12 rounded-admin border border-border bg-surface px-1 py-0.5 text-center text-xs text-fg"
+                      onBlur={handlePageInputBlur}
+                      onKeyDown={handlePageInputKeyDown}
+                    />
+                    <span className="text-xs nc-text-muted">/ {totalPages}</span>
                     <button
                       className="nc-btn text-xs disabled:opacity-40"
                       type="button"
                       disabled={!hasNext}
-                      onClick={() => setOffset(offset + PAGE_SIZE)}
+                      onClick={() => setOffset(offset + pageSize)}
                     >
                       {t(Msg.admin.documents.pageNext)}
                     </button>
@@ -360,6 +425,7 @@ export function SourceDocumentsPanel({
                 )}
               </div>
             )}
+
             {listError !== null && (
               <p className="shrink-0 px-3 pb-3 text-sm text-red-600">{listError}</p>
             )}

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -93,6 +93,7 @@ export const Msg = {
       pagePrev: 'admin.documents.pagePrev',
       pageNext: 'admin.documents.pageNext',
       selectDocument: 'admin.documents.selectDocument',
+      perPageLabel: 'admin.documents.perPageLabel',
     },
     ingestion: {
       title: 'admin.ingestion.title',

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -77,6 +77,7 @@ export const de = defineMessages({
   'admin.documents.pagePrev': 'Zurück',
   'admin.documents.pageNext': 'Weiter',
   'admin.documents.selectDocument': 'Wählen Sie ein Dokument aus der Liste aus, um es zu bearbeiten.',
+  'admin.documents.perPageLabel': 'Elemente pro Seite',
   'admin.ingestion.title': 'Quelle hochladen',
   'admin.ingestion.subtitle': 'CSV-, PDF-Dateien oder eingefügten Text zum Korpus hinzufügen.',
   'admin.ingestion.sourceName': 'Quellenname',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -77,6 +77,7 @@ export const en = defineMessages({
   'admin.documents.pagePrev': 'Previous',
   'admin.documents.pageNext': 'Next',
   'admin.documents.selectDocument': 'Select a document from the list to edit.',
+  'admin.documents.perPageLabel': 'Items per page',
   'admin.ingestion.title': 'Upload source',
   'admin.ingestion.subtitle': 'Add CSV, PDF, or pasted text to the corpus.',
   'admin.ingestion.sourceName': 'Source name',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -77,6 +77,7 @@ export const fr = defineMessages({
   'admin.documents.pagePrev': 'Précédent',
   'admin.documents.pageNext': 'Suivant',
   'admin.documents.selectDocument': 'Sélectionnez un document dans la liste pour le modifier.',
+  'admin.documents.perPageLabel': 'Éléments par page',
   'admin.ingestion.title': 'Téléverser une source',
   'admin.ingestion.subtitle': 'Ajoutez des fichiers CSV, PDF ou du texte collé au corpus.',
   'admin.ingestion.sourceName': 'Nom de la source',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -77,6 +77,7 @@ export const ja = defineMessages({
   'admin.documents.pagePrev': '前へ',
   'admin.documents.pageNext': '次へ',
   'admin.documents.selectDocument': 'リストからドキュメントを選択して編集します。',
+  'admin.documents.perPageLabel': '表示件数',
   'admin.ingestion.title': 'ソースをアップロード',
   'admin.ingestion.subtitle': 'CSV・PDF・テキストをコーパスに追加します。',
   'admin.ingestion.sourceName': 'ソース名',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -77,6 +77,7 @@ export const ptBr = defineMessages({
   'admin.documents.pagePrev': 'Anterior',
   'admin.documents.pageNext': 'Próximo',
   'admin.documents.selectDocument': 'Selecione um documento da lista para editar.',
+  'admin.documents.perPageLabel': 'Itens por página',
   'admin.ingestion.title': 'Enviar fonte',
   'admin.ingestion.subtitle': 'Adicione arquivos CSV, PDF ou texto colado ao corpus.',
   'admin.ingestion.sourceName': 'Nome da fonte',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -77,6 +77,7 @@ export const zhHans = defineMessages({
   'admin.documents.pagePrev': '上一页',
   'admin.documents.pageNext': '下一页',
   'admin.documents.selectDocument': '从列表中选择文档进行编辑。',
+  'admin.documents.perPageLabel': '每页条数',
   'admin.ingestion.title': '上传数据源',
   'admin.ingestion.subtitle': '将 CSV、PDF 或粘贴文本添加到语料库。',
   'admin.ingestion.sourceName': '数据源名称',


### PR DESCRIPTION
## 概要

数千〜数万件のドキュメントでも快適に操作できるよう、ページャを強化。

Closes #179

## フッターの変更

**行 1: 件数 + 表示件数セレクタ**
```
1–50 / 3,241件     [50 ▼]
```
- 25 / 50 / 100 / 200 から選択
- 変更時は 1 ページ目にリセット・選択解除

**行 2: ページナビ（totalPages > 1 の場合のみ表示）**
```
[←]  [_3_] / 130  [→]
```
- `<input type=number>` で直接入力 → Enter または フォーカスアウトで確定
- 範囲外 (< 1 or > totalPages) は自動クランプ
- 1ページのみの場合は行ごと非表示

## 実装変更

- `pageSize` state を追加（型 `(typeof PAGE_SIZE_OPTIONS)[number]`）
- `loadDocuments` に `currentPageSize` を引数追加（useCallback 依存を増やさない）
- `handleSubmit` / `handleDelete` 内の `listDocuments` 呼び出しも `pageSize` state を参照
- `<input key={currentPage}>` の uncontrolled パターンで prev/next 押下時に表示値を自動リセット

## i18n

- `admin.documents.perPageLabel` を 6 言語追加（セレクタの aria-label）

## チェック

- [x] `npm run check --prefix frontend` グリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)