### PR TITLE
feat(admin): 会話ログをモーダル化（SourceDocumentsPanelと同一インターフェースに統一） (#187)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -17,6 +17,7 @@ export function App() {
   const { locale } = useLocale();
   const { token, profile, isReady, error, login, logout } = useAdminAuth();
   const [sourcesReloadKey, setSourcesReloadKey] = useState(0);
+  const [logsOpen, setLogsOpen] = useState(false);
 
   useEffect(() => {
     document.documentElement.lang = toBcp47(locale);
@@ -67,7 +68,25 @@ export function App() {
               reloadKey={sourcesReloadKey}
               onDocumentsChanged={() => setSourcesReloadKey((key) => key + 1)}
             />
-            <ConversationLogsPanel token={token} />
+            {/* 会話ログ：モーダルトリガーセクション */}
+            <section className="nc-panel">
+              <div className="nc-panel-head flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <h2 className="font-medium">{t(Msg.admin.conversationLogs.title)}</h2>
+                  <p>{t(Msg.admin.conversationLogs.subtitle)}</p>
+                </div>
+                <button
+                  className="nc-btn shrink-0 text-sm"
+                  type="button"
+                  onClick={() => setLogsOpen(true)}
+                >
+                  {t(Msg.admin.conversationLogs.openLogs)}
+                </button>
+              </div>
+            </section>
+            {logsOpen && (
+              <ConversationLogsPanel token={token} onClose={() => setLogsOpen(false)} />
+            )}
             <LlmSettingsPanel token={token} />
             <ChatSettingsPanel token={token} />
             <AppearancePanel token={token} />

--- a/frontend/apps/admin/src/ConversationLogsPanel.tsx
+++ b/frontend/apps/admin/src/ConversationLogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   listChatSessionMessages,
   listChatSessions,
@@ -12,15 +12,17 @@ import { ROLE_MSG } from './i18nLabels';
 import { formatClientIp, hasSessionMetadata } from './conversationLogsFormat';
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100] as const;
-const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_PAGE_SIZE = 25;
 
 interface ConversationLogsPanelProps {
   token: string;
+  onClose: () => void;
 }
 
-export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
+export function ConversationLogsPanel({ token, onClose }: ConversationLogsPanelProps) {
   const t = useMsg();
   const { locale } = useLocale();
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
   // --- セッション一覧ステート ---
   const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
@@ -49,6 +51,11 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
   useEffect(() => {
     setPageInput(String(currentPage));
   }, [currentPage]);
+
+  // モーダルをマウント時に開く
+  useEffect(() => {
+    dialogRef.current?.showModal();
+  }, []);
 
   const loadSessions = useCallback(
     async (currentOffset: number, currentPageSize: number, signal?: AbortSignal): Promise<void> => {
@@ -161,85 +168,110 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
   }
 
   return (
-    <section className="nc-panel">
-      <div className="nc-panel-head">
-        <h2 className="font-medium">{t(Msg.admin.conversationLogs.title)}</h2>
-        <p>{t(Msg.admin.conversationLogs.subtitle)}</p>
-      </div>
+    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click handled by dialog cancel
+    <dialog
+      ref={dialogRef}
+      className="m-auto w-full max-w-6xl rounded-admin bg-surface p-0 shadow-xl backdrop:bg-black/40"
+      onCancel={onClose}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      {/* 内側コンテナ：デスクトップでは max-h で高さ制限し列ごとにスクロール */}
+      <div className="flex flex-col md:max-h-[90vh] md:overflow-hidden">
 
-      {isLoadingSessions && (
-        <p className="px-4 py-6 nc-text-muted">{t(Msg.admin.conversationLogs.loadingSessions)}</p>
-      )}
-      {listError !== null && <p className="px-4 py-6 text-sm text-red-600">{listError}</p>}
+        {/* ヘッダー */}
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-5 py-3">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-fg">{t(Msg.admin.conversationLogs.title)}</h2>
+            <p className="text-xs nc-text-muted">{t(Msg.admin.conversationLogs.subtitle)}</p>
+          </div>
+          <button
+            className="nc-btn ml-4 shrink-0 text-xs"
+            type="button"
+            onClick={onClose}
+            aria-label={t(Msg.admin.conversationLogs.close)}
+          >
+            ✕
+          </button>
+        </div>
 
-      {!isLoadingSessions && listError === null && sessions.length === 0 && (
-        <p className="px-4 py-6 nc-text-muted">{t(Msg.admin.conversationLogs.empty)}</p>
-      )}
-
-      {!isLoadingSessions && (sessions.length > 0 || total > 0) && (
-        <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
+        {/* ボディ：2 カラム */}
+        <div className="grid min-h-0 flex-1 grid-cols-1 md:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
 
           {/* 左カラム：セッション一覧 */}
-          <div className="flex flex-col border-b border-border lg:border-b-0 lg:border-r">
-            <div className="overflow-x-auto nc-scroll flex-1">
-              <table className="min-w-full text-sm">
-                <thead className="nc-table-head">
-                  <tr>
-                    <th className="px-4 py-2 font-medium">
-                      <HelpLabel
-                        label={t(Msg.admin.conversationLogs.columnSession)}
-                        help={t(Msg.admin.conversationLogs.columnSessionHelp)}
-                      />
-                    </th>
-                    <th className="px-4 py-2 font-medium">
-                      <HelpLabel
-                        label={t(Msg.admin.conversationLogs.columnMessages)}
-                        help={t(Msg.admin.conversationLogs.columnMessagesHelp)}
-                      />
-                    </th>
-                    <th className="px-4 py-2 font-medium">
-                      <HelpLabel
-                        label={t(Msg.admin.conversationLogs.columnClientIp)}
-                        help={t(Msg.admin.conversationLogs.columnClientIpHelp)}
-                      />
-                    </th>
-                    <th className="px-4 py-2 font-medium">
-                      <HelpLabel
-                        label={t(Msg.admin.conversationLogs.columnLastActivity)}
-                        help={t(Msg.admin.conversationLogs.columnLastActivityHelp)}
-                      />
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {sessions.map((session) => {
-                    const isSelected = selectedSessionId === session.session_id;
+          <div className="flex flex-col overflow-hidden border-b border-border md:border-b-0 md:border-r">
 
-                    return (
-                      <tr
-                        key={session.session_id}
-                        className={`nc-table-row cursor-pointer ${
-                          isSelected ? 'bg-accent' : 'hover:bg-surface-muted'
-                        }`}
-                        onClick={() => setSelectedSessionId(session.session_id)}
-                      >
-                        <td className="px-4 py-2 font-medium tabular-nums">#{session.session_id}</td>
-                        <td className="px-4 py-2 tabular-nums">{session.message_count}</td>
-                        <td className="px-4 py-2 font-mono text-xs nc-text-muted" title={session.client_ip ?? undefined}>
-                          {formatClientIp(session.client_ip)}
-                        </td>
-                        <td className="px-4 py-2 nc-text-timestamp">
-                          {formatTimestamp(session.last_message_at ?? session.updated_at, locale)}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+            {/* セッションテーブル */}
+            <div className="nc-scroll flex-1 overflow-y-auto">
+              {isLoadingSessions ? (
+                <p className="px-4 py-6 text-sm nc-text-muted">{t(Msg.admin.conversationLogs.loadingSessions)}</p>
+              ) : listError !== null ? (
+                <p className="px-4 py-6 text-sm text-red-600">{listError}</p>
+              ) : sessions.length === 0 ? (
+                <p className="px-4 py-6 text-sm nc-text-muted">{t(Msg.admin.conversationLogs.empty)}</p>
+              ) : (
+                <table className="min-w-full text-sm">
+                  <thead className="nc-table-head sticky top-0 z-10">
+                    <tr>
+                      <th className="px-4 py-2 font-medium">
+                        <HelpLabel
+                          label={t(Msg.admin.conversationLogs.columnSession)}
+                          help={t(Msg.admin.conversationLogs.columnSessionHelp)}
+                        />
+                      </th>
+                      <th className="px-4 py-2 font-medium">
+                        <HelpLabel
+                          label={t(Msg.admin.conversationLogs.columnMessages)}
+                          help={t(Msg.admin.conversationLogs.columnMessagesHelp)}
+                        />
+                      </th>
+                      <th className="px-4 py-2 font-medium">
+                        <HelpLabel
+                          label={t(Msg.admin.conversationLogs.columnClientIp)}
+                          help={t(Msg.admin.conversationLogs.columnClientIpHelp)}
+                        />
+                      </th>
+                      <th className="px-4 py-2 font-medium">
+                        <HelpLabel
+                          label={t(Msg.admin.conversationLogs.columnLastActivity)}
+                          help={t(Msg.admin.conversationLogs.columnLastActivityHelp)}
+                        />
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sessions.map((session) => {
+                      const isSelected = selectedSessionId === session.session_id;
+
+                      return (
+                        <tr
+                          key={session.session_id}
+                          className={`nc-table-row cursor-pointer ${
+                            isSelected ? 'bg-accent' : 'hover:bg-surface-muted'
+                          }`}
+                          onClick={() => setSelectedSessionId(session.session_id)}
+                        >
+                          <td className="px-4 py-2 font-medium tabular-nums">#{session.session_id}</td>
+                          <td className="px-4 py-2 tabular-nums">{session.message_count}</td>
+                          <td className="px-4 py-2 font-mono text-xs nc-text-muted" title={session.client_ip ?? undefined}>
+                            {formatClientIp(session.client_ip)}
+                          </td>
+                          <td className="px-4 py-2 nc-text-timestamp">
+                            {formatTimestamp(session.last_message_at ?? session.updated_at, locale)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              )}
             </div>
 
             {/* ページャフッター */}
-            {total > 0 && (
+            {!isLoadingSessions && total > 0 && (
               <div className="shrink-0 space-y-1.5 border-t border-border px-3 py-2">
                 {/* 行 1: 件数 + 表示件数セレクタ */}
                 <div className="flex items-center justify-between gap-2">
@@ -318,18 +350,18 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
             )}
           </div>
 
-          {/* 右カラム：メッセージ */}
-          <div className="px-4 py-4">
-            {selectedSessionId === null && (
-              <p className="nc-text-muted">{t(Msg.admin.conversationLogs.selectSession)}</p>
-            )}
-            {selectedSessionId !== null && (() => {
-              const selectedSession = sessions.find((s) => s.session_id === selectedSessionId);
+          {/* 右カラム：セッションメッセージ */}
+          <div className="nc-scroll flex flex-col overflow-y-auto px-5 py-4">
+            {selectedSessionId === null ? (
+              <p className="nc-text-muted text-sm">{t(Msg.admin.conversationLogs.selectSession)}</p>
+            ) : (
+              <>
+                {/* セッションメタデータ */}
+                {(() => {
+                  const selectedSession = sessions.find((s) => s.session_id === selectedSessionId);
 
-              return (
-                <>
-                  {selectedSession !== undefined && hasSessionMetadata(selectedSession) && (
-                    <div className="mb-4 rounded-admin border border-border bg-surface-muted px-3 py-3 text-sm">
+                  return selectedSession !== undefined && hasSessionMetadata(selectedSession) ? (
+                    <div className="mb-4 shrink-0 rounded-admin border border-border bg-surface-muted px-3 py-3 text-sm">
                       <dl className="space-y-2">
                         {selectedSession.user_agent !== null && selectedSession.user_agent.trim() !== '' && (
                           <div>
@@ -355,65 +387,64 @@ export function ConversationLogsPanel({ token }: ConversationLogsPanelProps) {
                         )}
                       </dl>
                     </div>
-                  )}
-                </>
-              );
-            })()}
-            {selectedSessionId !== null && isLoadingMessages && (
-              <p className="nc-text-muted">{t(Msg.admin.conversationLogs.loadingMessages)}</p>
-            )}
-            {messagesError !== null && (
-              <p className="text-sm text-red-600">{messagesError}</p>
-            )}
-            {selectedSessionId !== null && !isLoadingMessages && messages.length === 0 && messagesError === null && (
-              <p className="nc-text-muted">{t(Msg.admin.conversationLogs.emptyMessages)}</p>
-            )}
-            {selectedSessionId !== null && !isLoadingMessages && messages.length > 0 && (
-              <ul className="nc-scroll max-h-[60vh] space-y-4 overflow-y-auto pr-1">
-                {messages.map((message) => (
-                  <li
-                    key={message.message_id}
-                    className={`rounded-admin border px-3 py-2 ${
-                      message.role === 'assistant'
-                        ? 'border-accent-border bg-accent'
-                        : 'border-border bg-surface-muted'
-                    }`}
-                  >
-                    <div className="mb-1 flex items-center justify-between gap-2 nc-text-timestamp uppercase tracking-wide">
-                      <span>{t(ROLE_MSG[message.role])}</span>
-                      <time dateTime={message.created_at}>
-                        {formatTimestamp(message.created_at, locale)}
-                      </time>
-                    </div>
-                    <p className="whitespace-pre-wrap break-words text-sm">{message.content}</p>
-                    {message.citations.length > 0 && (
-                      <ul className="mt-2 space-y-1 border-t border-border pt-2 nc-text-muted">
-                        {message.citations.map((citation) => (
-                          <li key={citation.chunk_id} className="min-w-0">
-                            <span className="font-medium">
-                              {t(Msg.admin.conversationLogs.citationChunk, { id: citation.chunk_id })}
-                            </span>
-                            {citation.page_number !== undefined && (
-                              <span>
-                                {' '}
-                                · {t(Msg.admin.conversationLogs.citationPage, { page: citation.page_number })}
-                              </span>
-                            )}
-                            {citation.section_label !== undefined && (
-                              <span className="break-words"> · {citation.section_label}</span>
-                            )}
-                            <p className="mt-0.5 break-words nc-text-subtle">{citation.excerpt}</p>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </li>
-                ))}
-              </ul>
+                  ) : null;
+                })()}
+
+                {/* メッセージ */}
+                {isLoadingMessages ? (
+                  <p className="nc-text-muted text-sm">{t(Msg.admin.conversationLogs.loadingMessages)}</p>
+                ) : messagesError !== null ? (
+                  <p className="text-sm text-red-600">{messagesError}</p>
+                ) : messages.length === 0 ? (
+                  <p className="nc-text-muted text-sm">{t(Msg.admin.conversationLogs.emptyMessages)}</p>
+                ) : (
+                  <ul className="space-y-4">
+                    {messages.map((message) => (
+                      <li
+                        key={message.message_id}
+                        className={`rounded-admin border px-3 py-2 ${
+                          message.role === 'assistant'
+                            ? 'border-accent-border bg-accent'
+                            : 'border-border bg-surface-muted'
+                        }`}
+                      >
+                        <div className="mb-1 flex items-center justify-between gap-2 nc-text-timestamp uppercase tracking-wide">
+                          <span>{t(ROLE_MSG[message.role])}</span>
+                          <time dateTime={message.created_at}>
+                            {formatTimestamp(message.created_at, locale)}
+                          </time>
+                        </div>
+                        <p className="whitespace-pre-wrap break-words text-sm">{message.content}</p>
+                        {message.citations.length > 0 && (
+                          <ul className="mt-2 space-y-1 border-t border-border pt-2 nc-text-muted">
+                            {message.citations.map((citation) => (
+                              <li key={citation.chunk_id} className="min-w-0">
+                                <span className="font-medium">
+                                  {t(Msg.admin.conversationLogs.citationChunk, { id: citation.chunk_id })}
+                                </span>
+                                {citation.page_number !== undefined && (
+                                  <span>
+                                    {' '}
+                                    · {t(Msg.admin.conversationLogs.citationPage, { page: citation.page_number })}
+                                  </span>
+                                )}
+                                {citation.section_label !== undefined && (
+                                  <span className="break-words"> · {citation.section_label}</span>
+                                )}
+                                <p className="mt-0.5 break-words nc-text-subtle">{citation.excerpt}</p>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </>
             )}
           </div>
         </div>
-      )}
-    </section>
+      </div>
+    </dialog>
   );
 }

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -177,6 +177,8 @@ export const Msg = {
       pageNext: 'admin.conversationLogs.pageNext',
       pageLast: 'admin.conversationLogs.pageLast',
       perPageLabel: 'admin.conversationLogs.perPageLabel',
+      openLogs: 'admin.conversationLogs.openLogs',
+      close: 'admin.conversationLogs.close',
     },
     llm: {
       title: 'admin.llm.title',

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -174,6 +174,8 @@ export const de = defineMessages({
   'admin.conversationLogs.pageNext': 'Weiter',
   'admin.conversationLogs.pageLast': 'Letzte Seite',
   'admin.conversationLogs.perPageLabel': 'Sitzungen pro Seite',
+  'admin.conversationLogs.openLogs': 'Gesprächsprotokolle öffnen',
+  'admin.conversationLogs.close': 'Schließen',
   'admin.llm.title': 'LLM-Einstellungen',
   'admin.llm.subtitle': 'Anthropic-API-Schlüssel und Modell aktualisieren. Verbindung vor dem Speichern testen.',
   'admin.llm.currentKey': 'Aktueller Schlüssel',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -175,6 +175,8 @@ export const en = defineMessages({
   'admin.conversationLogs.pageNext': 'Next',
   'admin.conversationLogs.pageLast': 'Last',
   'admin.conversationLogs.perPageLabel': 'Sessions per page',
+  'admin.conversationLogs.openLogs': 'Open conversation logs',
+  'admin.conversationLogs.close': 'Close',
   'admin.llm.title': 'LLM settings',
   'admin.llm.subtitle': 'Update your Anthropic API key and model. Test connectivity before saving.',
   'admin.llm.currentKey': 'Current key',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -174,6 +174,8 @@ export const fr = defineMessages({
   'admin.conversationLogs.pageNext': 'Suivant',
   'admin.conversationLogs.pageLast': 'Dernière',
   'admin.conversationLogs.perPageLabel': 'Sessions par page',
+  'admin.conversationLogs.openLogs': 'Ouvrir les journaux de conversation',
+  'admin.conversationLogs.close': 'Fermer',
   'admin.llm.title': 'Paramètres LLM',
   'admin.llm.subtitle': 'Mettez à jour la clé API Anthropic et le modèle. Testez la connexion avant d\'enregistrer.',
   'admin.llm.currentKey': 'Clé actuelle',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -174,6 +174,8 @@ export const ja = defineMessages({
   'admin.conversationLogs.pageNext': '次へ',
   'admin.conversationLogs.pageLast': '最後へ',
   'admin.conversationLogs.perPageLabel': '表示件数',
+  'admin.conversationLogs.openLogs': '会話ログを開く',
+  'admin.conversationLogs.close': '閉じる',
   'admin.llm.title': 'LLM 設定',
   'admin.llm.subtitle': 'Anthropic API キーとモデルを更新します。保存前に接続テストできます。',
   'admin.llm.currentKey': '現在のキー',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -174,6 +174,8 @@ export const ptBr = defineMessages({
   'admin.conversationLogs.pageNext': 'Próximo',
   'admin.conversationLogs.pageLast': 'Última',
   'admin.conversationLogs.perPageLabel': 'Sessões por página',
+  'admin.conversationLogs.openLogs': 'Abrir registros de conversa',
+  'admin.conversationLogs.close': 'Fechar',
   'admin.llm.title': 'Configurações de LLM',
   'admin.llm.subtitle': 'Atualize a chave da API Anthropic e o modelo. Teste a conexão antes de salvar.',
   'admin.llm.currentKey': 'Chave atual',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -170,6 +170,8 @@ export const zhHans = defineMessages({
   'admin.conversationLogs.pageNext': '下一页',
   'admin.conversationLogs.pageLast': '末页',
   'admin.conversationLogs.perPageLabel': '每页会话数',
+  'admin.conversationLogs.openLogs': '打开会话记录',
+  'admin.conversationLogs.close': '关闭',
   'admin.llm.title': 'LLM 设置',
   'admin.llm.subtitle': '更新 Anthropic API 密钥与模型。保存前可先测试连接。',
   'admin.llm.currentKey': '当前密钥',


### PR DESCRIPTION
Closes #187

## 変更内容

### Before
会話ログパネルがページ内に埋め込まれており、セッション数が増えるとページが縦に伸び続ける問題があった。

### After
SourceDocumentsPanel と同じ `<dialog>` 全画面 2 カラムモーダルに統一。

**ページ上の表示（App.tsx）**
- `nc-panel` セクションにタイトル + 「会話ログを開く」ボタンのみ配置
- ボタンクリックでモーダルをマウント → `showModal()`
- 閉じると `onClose` でアンマウント（ステート・リクエストがリセットされる）

**モーダル内（ConversationLogsPanel）**
- `md:max-h-[90vh]` で高さ制限 + 列ごとに独立スクロール（`nc-scroll`）
- 左列: セッションテーブル（`sticky thead`）+ ページャ（25/50/100 件・デフォルト 25）
- 右列: セッションメタデータ（UA/Referer）+ メッセージリスト
- backdrop クリック / ESC で閉じる

**i18n**
- `openLogs` / `close` キーを全 6 ロケールに追加

## セルフレビューチェックリスト
- [x] TypeScript エラーなし（`npm run check --prefix frontend`）
- [x] SourceDocumentsPanel と同じ backdrop/ESC 閉じパターン
- [x] sticky thead でスクロール時もヘッダが固定される
- [x] ページサイズ変更時に選択セッションをリセット

🤖 Generated with [Claude Code](https://claude.com/claude-code)