### PR TITLE
feat(admin): 共通 Modal・ConfirmDialog コンポーネントを追加し window.confirm を置換する (#193)

### DIFF
--- a/frontend/apps/admin/src/ConfirmDialog.tsx
+++ b/frontend/apps/admin/src/ConfirmDialog.tsx
@@ -1,0 +1,64 @@
+import { Modal } from './Modal';
+import { Msg, useMsg } from '@nene-corpus/i18n';
+
+interface ConfirmDialogProps {
+  /** ダイアログのタイトル */
+  title: string;
+  /** 本文（改行は <br> ではなく whitespace-pre-wrap で表示） */
+  description: string;
+  /** 確認ボタンのラベル（デフォルト: 確認） */
+  confirmLabel?: string;
+  /** キャンセルボタンのラベル（デフォルト: キャンセル） */
+  cancelLabel?: string;
+  /** 'danger': 赤い確認ボタン / 'default': プライマリカラー */
+  variant?: 'danger' | 'default';
+  /** 処理中フラグ（true のとき確認ボタンを disabled にする） */
+  isConfirming?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function ConfirmDialog({
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  variant = 'danger',
+  isConfirming = false,
+  onConfirm,
+  onClose,
+}: ConfirmDialogProps) {
+  const t = useMsg();
+
+  const confirmClass =
+    variant === 'danger'
+      ? 'rounded-admin bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50'
+      : 'nc-btn-primary';
+
+  return (
+    <Modal size="sm" onClose={onClose}>
+      <div className="px-6 py-5">
+        {/* タイトル */}
+        <h3 className="text-base font-semibold text-fg">{title}</h3>
+
+        {/* 本文 */}
+        <p className="mt-2 whitespace-pre-wrap text-sm text-fg-muted">{description}</p>
+
+        {/* ボタン行 */}
+        <div className="mt-5 flex justify-end gap-3">
+          <button className="nc-btn text-sm" type="button" onClick={onClose} disabled={isConfirming}>
+            {cancelLabel ?? t(Msg.common.cancel)}
+          </button>
+          <button
+            className={confirmClass}
+            type="button"
+            disabled={isConfirming}
+            onClick={onConfirm}
+          >
+            {confirmLabel ?? title}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/apps/admin/src/ConversationLogsPanel.tsx
+++ b/frontend/apps/admin/src/ConversationLogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   listChatSessionMessages,
   listChatSessions,
@@ -10,6 +10,7 @@ import { Msg, formatTimestamp, useLocale, useMsg } from '@nene-corpus/i18n';
 import { HelpLabel } from './HelpLabel';
 import { ROLE_MSG } from './i18nLabels';
 import { formatClientIp, hasSessionMetadata } from './conversationLogsFormat';
+import { Modal } from './Modal';
 
 // ───────────────────────────────────────────────
 // サマリーコンポーネント（ページ埋め込み用・最新 8 件）
@@ -163,8 +164,6 @@ interface ConversationLogsPanelProps {
 export function ConversationLogsPanel({ token, onClose }: ConversationLogsPanelProps) {
   const t = useMsg();
   const { locale } = useLocale();
-  const dialogRef = useRef<HTMLDialogElement>(null);
-
   // --- セッション一覧ステート ---
   const [sessions, setSessions] = useState<ChatSessionSummary[]>([]);
   const [total, setTotal] = useState(0);
@@ -192,11 +191,6 @@ export function ConversationLogsPanel({ token, onClose }: ConversationLogsPanelP
   useEffect(() => {
     setPageInput(String(currentPage));
   }, [currentPage]);
-
-  // モーダルをマウント時に開く
-  useEffect(() => {
-    dialogRef.current?.showModal();
-  }, []);
 
   const loadSessions = useCallback(
     async (currentOffset: number, currentPageSize: number, signal?: AbortSignal): Promise<void> => {
@@ -309,17 +303,7 @@ export function ConversationLogsPanel({ token, onClose }: ConversationLogsPanelP
   }
 
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click handled by dialog cancel
-    <dialog
-      ref={dialogRef}
-      className="m-auto w-full max-w-6xl rounded-admin bg-surface p-0 shadow-xl backdrop:bg-black/40"
-      onCancel={onClose}
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          onClose();
-        }
-      }}
-    >
+    <Modal size="xl" onClose={onClose}>
       {/* 内側コンテナ：デスクトップでは max-h で高さ制限し列ごとにスクロール */}
       <div className="flex flex-col md:max-h-[90vh] md:overflow-hidden">
 
@@ -586,6 +570,6 @@ export function ConversationLogsPanel({ token, onClose }: ConversationLogsPanelP
           </div>
         </div>
       </div>
-    </dialog>
+    </Modal>
   );
 }

--- a/frontend/apps/admin/src/Modal.tsx
+++ b/frontend/apps/admin/src/Modal.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * size:
+ *   'sm' — 確認ダイアログ等の小モーダル（max-w-md）
+ *   'lg' — ドキュメントパネル等（max-w-5xl）
+ *   'xl' — 会話ログ等（max-w-6xl）
+ */
+type ModalSize = 'sm' | 'lg' | 'xl';
+
+const SIZE_CLASS: Record<ModalSize, string> = {
+  sm: 'w-full max-w-md',
+  lg: 'w-full max-w-5xl',
+  xl: 'w-full max-w-6xl',
+};
+
+interface ModalProps {
+  size?: ModalSize;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function Modal({ size = 'sm', onClose, children }: ModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    dialogRef.current?.showModal();
+  }, []);
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click handled by dialog cancel
+    <dialog
+      ref={dialogRef}
+      className={`m-auto ${SIZE_CLASS[size]} rounded-admin bg-surface p-0 shadow-xl backdrop:bg-black/40`}
+      onCancel={onClose}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      {children}
+    </dialog>
+  );
+}

--- a/frontend/apps/admin/src/SourceDocumentsPanel.tsx
+++ b/frontend/apps/admin/src/SourceDocumentsPanel.tsx
@@ -10,6 +10,8 @@ import {
 } from '@nene-corpus/api-client';
 import { Msg, useMsg, type MessageParams, type MsgKey } from '@nene-corpus/i18n';
 import { adminApiBase } from './config';
+import { Modal } from './Modal';
+import { ConfirmDialog } from './ConfirmDialog';
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 200] as const;
 const DEFAULT_PAGE_SIZE = 50;
@@ -53,7 +55,6 @@ export function SourceDocumentsPanel({
   onClose,
 }: SourceDocumentsPanelProps) {
   const t = useMsg();
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // --- 一覧ステート ---
@@ -75,6 +76,7 @@ export function SourceDocumentsPanel({
   const [isLoadingDetail, setIsLoadingDetail] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
   const [editSuccess, setEditSuccess] = useState<string | null>(null);
 
@@ -93,11 +95,6 @@ export function SourceDocumentsPanel({
   const to = Math.min(offset + pageSize, total);
   const hasPrev = offset > 0;
   const hasNext = offset + pageSize < total;
-
-  // モーダルをマウント時に開く
-  useEffect(() => {
-    dialogRef.current?.showModal();
-  }, []);
 
   const loadDocuments = useCallback(
     async (
@@ -265,15 +262,12 @@ export function SourceDocumentsPanel({
     }
   }
 
-  async function handleDelete(): Promise<void> {
+  async function handleDeleteConfirmed(): Promise<void> {
     if (selectedId === null) {
       return;
     }
 
-    if (!window.confirm(t(Msg.admin.documents.deleteConfirm))) {
-      return;
-    }
-
+    setDeleteConfirmOpen(false);
     setIsDeleting(true);
     setEditError(null);
     setEditSuccess(null);
@@ -300,17 +294,19 @@ export function SourceDocumentsPanel({
   }
 
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click handled by dialog cancel
-    <dialog
-      ref={dialogRef}
-      className="m-auto w-full max-w-5xl rounded-admin bg-surface p-0 shadow-xl backdrop:bg-black/40"
-      onCancel={onClose}
-      onClick={(event) => {
-        if (event.target === event.currentTarget) {
-          onClose();
-        }
-      }}
-    >
+    <>
+      {deleteConfirmOpen && (
+        <ConfirmDialog
+          title={t(Msg.admin.documents.delete)}
+          description={t(Msg.admin.documents.deleteConfirm)}
+          confirmLabel={t(Msg.admin.documents.delete)}
+          variant="danger"
+          isConfirming={isDeleting}
+          onConfirm={() => void handleDeleteConfirmed()}
+          onClose={() => setDeleteConfirmOpen(false)}
+        />
+      )}
+      <Modal size="lg" onClose={onClose}>
       {/* 内側コンテナ：デスクトップでは max-h で高さ制限し列ごとにスクロール */}
       <div className="flex flex-col md:max-h-[90vh] md:overflow-hidden">
 
@@ -509,7 +505,7 @@ export function SourceDocumentsPanel({
                       className="nc-btn"
                       type="button"
                       disabled={isDeleting}
-                      onClick={() => void handleDelete()}
+                      onClick={() => setDeleteConfirmOpen(true)}
                     >
                       {isDeleting ? t(Msg.admin.documents.deleting) : t(Msg.admin.documents.delete)}
                     </button>
@@ -554,6 +550,7 @@ export function SourceDocumentsPanel({
           </div>
         </div>
       </div>
-    </dialog>
+      </Modal>
+    </>
   );
 }

--- a/frontend/apps/admin/src/SourcesPanel.tsx
+++ b/frontend/apps/admin/src/SourcesPanel.tsx
@@ -5,6 +5,7 @@ import { Msg, formatTimestamp, useLocale, useMsg } from '@nene-corpus/i18n';
 import { HelpLabel } from './HelpLabel';
 import { SOURCE_STATUS_MSG, SOURCE_TYPE_MSG } from './i18nLabels';
 import { SourceDocumentsPanel } from './SourceDocumentsPanel';
+import { ConfirmDialog } from './ConfirmDialog';
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100] as const;
 const DEFAULT_PAGE_SIZE = 25;
@@ -23,6 +24,7 @@ export function SourcesPanel({ token, reloadKey = 0, onDocumentsChanged }: Sourc
   const [offset, setOffset] = useState(0);
   const [pageSize, setPageSize] = useState<(typeof PAGE_SIZE_OPTIONS)[number]>(DEFAULT_PAGE_SIZE);
   const [managingSource, setManagingSource] = useState<{ id: number; name: string } | null>(null);
+  const [confirmTarget, setConfirmTarget] = useState<SourceListItem | null>(null);
   const [deletingId, setDeletingId] = useState<number | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -86,16 +88,18 @@ export function SourcesPanel({ token, reloadKey = 0, onDocumentsChanged }: Sourc
     };
   }, [load, offset, pageSize, reloadKey]);
 
-  async function handleDelete(source: SourceListItem): Promise<void> {
-    if (!window.confirm(t(Msg.admin.sources.deleteConfirm, { name: source.name }))) {
+  async function handleDeleteConfirmed(): Promise<void> {
+    if (confirmTarget === null) {
       return;
     }
 
-    setDeletingId(source.source_id);
+    const target = confirmTarget;
+    setDeletingId(target.source_id);
+    setConfirmTarget(null);
     setDeleteError(null);
 
     try {
-      await deleteSource(token, source.source_id, adminApiBase);
+      await deleteSource(token, target.source_id, adminApiBase);
       onDocumentsChanged?.();
       // 現在ページの件数が 1 件だった場合は前のページに戻る
       if (sources.length === 1 && offset > 0) {
@@ -214,7 +218,7 @@ export function SourcesPanel({ token, reloadKey = 0, onDocumentsChanged }: Sourc
                         className="nc-btn text-xs text-red-600 hover:bg-red-50 disabled:opacity-40 dark:hover:bg-red-950/30"
                         type="button"
                         disabled={deletingId === source.source_id}
-                        onClick={() => void handleDelete(source)}
+                        onClick={() => setConfirmTarget(source)}
                       >
                         {deletingId === source.source_id
                           ? t(Msg.admin.sources.deleting)
@@ -311,6 +315,17 @@ export function SourcesPanel({ token, reloadKey = 0, onDocumentsChanged }: Sourc
             </div>
           )}
         </>
+      )}
+      {confirmTarget !== null && (
+        <ConfirmDialog
+          title={t(Msg.admin.sources.delete)}
+          description={t(Msg.admin.sources.deleteConfirm, { name: confirmTarget.name })}
+          confirmLabel={t(Msg.admin.sources.delete)}
+          variant="danger"
+          isConfirming={deletingId === confirmTarget.source_id}
+          onConfirm={() => void handleDeleteConfirmed()}
+          onClose={() => setConfirmTarget(null)}
+        />
       )}
       {managingSource !== null && (
         <SourceDocumentsPanel

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -7,6 +7,7 @@ export const Msg = {
     signOut: 'common.signOut',
     genericError: 'common.genericError',
     showHelp: 'common.showHelp',
+    cancel: 'common.cancel',
   },
   locale: {
     en: 'locale.en',

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -5,6 +5,7 @@ export const de = defineMessages({
   'common.signOut': 'Abmelden',
   'common.genericError': 'Etwas ist schiefgelaufen.',
   'common.showHelp': 'Hilfe',
+  'common.cancel': 'Abbrechen',
   'locale.en': 'Englisch',
   'locale.ja': 'Japanisch',
   'locale.fr': 'Französisch',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -5,6 +5,7 @@ export const en = defineMessages({
   'common.signOut': 'Sign out',
   'common.genericError': 'Something went wrong.',
   'common.showHelp': 'Help',
+  'common.cancel': 'Cancel',
   'locale.en': 'English',
   'locale.ja': 'Japanese',
   'locale.fr': 'French',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -5,6 +5,7 @@ export const fr = defineMessages({
   'common.signOut': 'Se déconnecter',
   'common.genericError': 'Une erreur est survenue.',
   'common.showHelp': 'Aide',
+  'common.cancel': 'Annuler',
   'locale.en': 'Anglais',
   'locale.ja': 'Japonais',
   'locale.fr': 'Français',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -5,6 +5,7 @@ export const ja = defineMessages({
   'common.signOut': 'サインアウト',
   'common.genericError': '問題が発生しました。',
   'common.showHelp': 'ヘルプ',
+  'common.cancel': 'キャンセル',
   'locale.en': '英語',
   'locale.ja': '日本語',
   'locale.fr': 'フランス語',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -5,6 +5,7 @@ export const ptBr = defineMessages({
   'common.signOut': 'Sair',
   'common.genericError': 'Algo deu errado.',
   'common.showHelp': 'Ajuda',
+  'common.cancel': 'Cancelar',
   'locale.en': 'Inglês',
   'locale.ja': 'Japonês',
   'locale.fr': 'Francês',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -5,6 +5,7 @@ export const zhHans = defineMessages({
   'common.signOut': '退出登录',
   'common.genericError': '出现问题。',
   'common.showHelp': '帮助',
+  'common.cancel': '取消',
   'locale.en': '英语',
   'locale.ja': '日语',
   'locale.fr': '法语',


### PR DESCRIPTION
Closes #193

## 変更概要

- **Modal.tsx**（新規）: `size='sm'|'lg'|'xl'` を持つ共通 `<dialog>` ラッパー
  - マウント時に `showModal()` を呼び出し
  - ESC キー・バックドロップクリックで `onClose` を呼び出し
- **ConfirmDialog.tsx**（新規）: `Modal size='sm'` を使う確認ダイアログ
  - `variant='danger'|'default'`、`isConfirming`、`confirmLabel`、`cancelLabel` に対応
- **ConversationLogsPanel**: raw `<dialog>` + `dialogRef` + `showModal` useEffect を `Modal size='xl'` に置換
- **SourceDocumentsPanel**: raw `<dialog>` + `dialogRef` を `Modal size='lg'` に置換、`window.confirm` を `ConfirmDialog` に置換
- **SourcesPanel**: `window.confirm` を `ConfirmDialog` に置換
- **i18n**: `common.cancel` キーを `keys.ts` と全 6 ロケール（ja/en/de/fr/zh-Hans/pt-BR）に追加

## セルフレビュー

- [x] TypeScript チェック通過 (`npm run check --prefix frontend`)
- [x] `window.confirm` を全廃（ブラウザネイティブ依存を排除）
- [x] モーダルデザインを統一（全画面パネル・小確認ダイアログ共通コンポーネント使用）
- [x] `useRef` が必要な箇所（searchInputRef）のインポートを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)