### PR TITLE
feat(admin): LLM 未設定時にメイン画面へ警告バナーを表示する (#203)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Msg, resolveMsgKey, applyLocaleFontFamily, toBcp47, useLocale, useMsg } from '@nene-corpus/i18n';
+import { getLlmSettings } from '@nene-corpus/api-client/llm-settings';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
 import { ConversationLogsPanel, ConversationLogsSummary } from './ConversationLogsPanel';
 import { AppearancePanel } from './AppearancePanel';
 import { LlmSettingsPanel } from './LlmSettingsPanel';
+import { LlmUnconfiguredBanner } from './LlmUnconfiguredBanner';
 import { ChatSettingsPanel } from './ChatSettingsPanel';
 import { ChatLimitsPanel } from './ChatLimitsPanel';
 import { HelpPanel } from './HelpPanel';
@@ -12,6 +14,7 @@ import { LocaleSelector } from './LocaleSelector';
 import { ThemeToggle } from './ThemeToggle';
 import { scrollToHelp } from './scrollToHelp';
 import { useAdminAuth } from './useAdminAuth';
+import { adminApiBase } from './config';
 
 export function App() {
   const t = useMsg();
@@ -20,10 +23,39 @@ export function App() {
   const [sourcesReloadKey, setSourcesReloadKey] = useState(0);
   const [logsOpen, setLogsOpen] = useState(false);
 
+  // LLM 設定済みフラグ（null = ロード中 / 未チェック）
+  const [isLlmConfigured, setIsLlmConfigured] = useState<boolean | null>(null);
+  // LLM アコーディオン外部制御用
+  const [llmPanelOpen, setLlmPanelOpen] = useState(false);
+  const llmPanelRef = useRef<HTMLElement | null>(null);
+
   useEffect(() => {
     document.documentElement.lang = toBcp47(locale);
     applyLocaleFontFamily(locale);
   }, [locale]);
+
+  // ログイン直後に LLM 設定状態を取得してバナー表示を決定
+  useEffect(() => {
+    if (token === null) {
+      setIsLlmConfigured(null);
+      return;
+    }
+
+    let cancelled = false;
+    getLlmSettings(token, adminApiBase)
+      .then((s) => { if (!cancelled) setIsLlmConfigured(s.configured); })
+      .catch(() => { /* 取得失敗時はバナーを出さない */ });
+
+    return () => { cancelled = true; };
+  }, [token]);
+
+  function openLlmPanel(): void {
+    setLlmPanelOpen(true);
+    // DOM レンダリング後にスクロール
+    requestAnimationFrame(() => {
+      llmPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
 
   if (!isReady) {
     return (
@@ -63,8 +95,19 @@ export function App() {
           </>
         ) : (
           <>
+            {/* ── LLM 未設定アラート ── */}
+            {isLlmConfigured === false && (
+              <LlmUnconfiguredBanner onConfigureLlm={openLlmPanel} />
+            )}
             {/* ── AI 設定（LLM 未設定だとチャット不可のため最優先） ── */}
-            <LlmSettingsPanel token={token} />
+            <section ref={llmPanelRef}>
+              <LlmSettingsPanel
+                token={token}
+                isOpen={llmPanelOpen}
+                onOpenChange={setLlmPanelOpen}
+                onConfiguredChange={setIsLlmConfigured}
+              />
+            </section>
             <ChatSettingsPanel token={token} />
             <ChatLimitsPanel token={token} />
             {/* ── コンテンツ管理 ── */}

--- a/frontend/apps/admin/src/LlmSettingsPanel.tsx
+++ b/frontend/apps/admin/src/LlmSettingsPanel.tsx
@@ -6,11 +6,22 @@ import { adminApiBase } from './config';
 
 interface LlmSettingsPanelProps {
   token: string;
+  /** 外部から開閉を制御する場合に渡す（未指定時は内部 state で管理） */
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** API キー設定済み状態が変化したときに通知する */
+  onConfiguredChange?: (configured: boolean) => void;
 }
 
-export function LlmSettingsPanel({ token }: LlmSettingsPanelProps) {
+export function LlmSettingsPanel({ token, isOpen: isOpenProp, onOpenChange, onConfiguredChange }: LlmSettingsPanelProps) {
   const t = useMsg();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpenInternal, setIsOpenInternal] = useState(false);
+  const isOpen = isOpenProp !== undefined ? isOpenProp : isOpenInternal;
+  function setIsOpen(next: boolean | ((prev: boolean) => boolean)): void {
+    const value = typeof next === 'function' ? next(isOpen) : next;
+    setIsOpenInternal(value);
+    onOpenChange?.(value);
+  }
   const [hasLoaded, setHasLoaded] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -64,6 +75,7 @@ export function LlmSettingsPanel({ token }: LlmSettingsPanelProps) {
     setModel(loaded.model);
     setMaxTokens(String(loaded.max_tokens));
     setApiKeyDraft('');
+    onConfiguredChange?.(loaded.configured);
   }
 
   function buildTestPayload() {

--- a/frontend/apps/admin/src/LlmUnconfiguredBanner.tsx
+++ b/frontend/apps/admin/src/LlmUnconfiguredBanner.tsx
@@ -1,0 +1,25 @@
+import { Msg, useMsg } from '@nene-corpus/i18n';
+
+interface LlmUnconfiguredBannerProps {
+  onConfigureLlm: () => void;
+}
+
+export function LlmUnconfiguredBanner({ onConfigureLlm }: LlmUnconfiguredBannerProps) {
+  const t = useMsg();
+
+  return (
+    <div
+      role="alert"
+      className="flex flex-wrap items-center justify-between gap-3 rounded-admin border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
+    >
+      <span>⚠ {t(Msg.admin.llm.alertBody)}</span>
+      <button
+        type="button"
+        className="shrink-0 rounded border border-amber-400 bg-amber-100 px-3 py-1 text-xs font-medium hover:bg-amber-200 dark:border-amber-600 dark:bg-amber-900 dark:hover:bg-amber-800"
+        onClick={onConfigureLlm}
+      >
+        {t(Msg.admin.llm.alertCta)}
+      </button>
+    </div>
+  );
+}

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -211,6 +211,8 @@ export const Msg = {
       saveSuccess: 'admin.llm.saveSuccess',
       saveFailed: 'admin.llm.saveFailed',
       loadFailed: 'admin.llm.loadFailed',
+      alertBody: 'admin.llm.alertBody',
+      alertCta: 'admin.llm.alertCta',
     },
     chatLimits: {
       title: 'admin.chatLimits.title',

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -206,6 +206,8 @@ export const de = defineMessages({
   'admin.llm.saveSuccess': 'LLM-Einstellungen gespeichert.',
   'admin.llm.saveFailed': 'LLM-Einstellungen konnten nicht gespeichert werden.',
   'admin.llm.loadFailed': 'LLM-Einstellungen konnten nicht geladen werden.',
+  'admin.llm.alertBody': 'Chat ist nicht verfügbar, da der Anthropic-API-Schlüssel nicht konfiguriert ist.',
+  'admin.llm.alertCta': 'LLM konfigurieren',
   'admin.chatLimits.title': 'Nutzungslimits',
   'admin.chatLimits.subtitle': 'Ratenlimits zur Missbrauchsverhinderung und Kostenkontrolle. 0 bedeutet kein Limit.',
   'admin.chatLimits.maxMessageChars': 'Max. Nachrichtenlänge (Zeichen)',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -207,6 +207,8 @@ export const en = defineMessages({
   'admin.llm.saveSuccess': 'LLM settings saved.',
   'admin.llm.saveFailed': 'Failed to save LLM settings.',
   'admin.llm.loadFailed': 'Failed to load LLM settings.',
+  'admin.llm.alertBody': 'Chat is unavailable because the Anthropic API key has not been configured.',
+  'admin.llm.alertCta': 'Configure LLM',
   'admin.chatLimits.title': 'Usage limits',
   'admin.chatLimits.subtitle': 'Configure rate limits to prevent abuse and control costs. Set 0 for no limit.',
   'admin.chatLimits.maxMessageChars': 'Max message length (characters)',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -206,6 +206,8 @@ export const fr = defineMessages({
   'admin.llm.saveSuccess': 'Paramètres LLM enregistrés.',
   'admin.llm.saveFailed': 'Échec de l\'enregistrement des paramètres LLM.',
   'admin.llm.loadFailed': 'Impossible de charger les paramètres LLM.',
+  'admin.llm.alertBody': 'Le chat est indisponible car la clé API Anthropic n\'est pas configurée.',
+  'admin.llm.alertCta': 'Configurer le LLM',
   'admin.chatLimits.title': 'Limites d\'utilisation',
   'admin.chatLimits.subtitle': 'Configurez les limites de débit pour prévenir les abus et maîtriser les coûts. 0 = illimité.',
   'admin.chatLimits.maxMessageChars': 'Longueur max. du message (caractères)',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -206,6 +206,8 @@ export const ja = defineMessages({
   'admin.llm.saveSuccess': 'LLM 設定を保存しました。',
   'admin.llm.saveFailed': 'LLM 設定の保存に失敗しました。',
   'admin.llm.loadFailed': 'LLM 設定の読み込みに失敗しました。',
+  'admin.llm.alertBody': 'Anthropic API キーが未設定のため、チャットは利用できません。',
+  'admin.llm.alertCta': 'LLM を設定する',
   'admin.chatLimits.title': '利用制限',
   'admin.chatLimits.subtitle': 'チャットの悪用防止とコスト管理のための制限を設定します。0 は無制限です。',
   'admin.chatLimits.maxMessageChars': '最大入力文字数',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -206,6 +206,8 @@ export const ptBr = defineMessages({
   'admin.llm.saveSuccess': 'Configurações de LLM salvas.',
   'admin.llm.saveFailed': 'Falha ao salvar configurações de LLM.',
   'admin.llm.loadFailed': 'Falha ao carregar configurações de LLM.',
+  'admin.llm.alertBody': 'O chat está indisponível porque a chave da API Anthropic não foi configurada.',
+  'admin.llm.alertCta': 'Configurar LLM',
   'admin.chatLimits.title': 'Limites de uso',
   'admin.chatLimits.subtitle': 'Configure limites de taxa para prevenir abusos e controlar custos. 0 = sem limite.',
   'admin.chatLimits.maxMessageChars': 'Comprimento máximo da mensagem (caracteres)',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -202,6 +202,8 @@ export const zhHans = defineMessages({
   'admin.llm.saveSuccess': 'LLM 设置已保存。',
   'admin.llm.saveFailed': 'LLM 设置保存失败。',
   'admin.llm.loadFailed': 'LLM 设置加载失败。',
+  'admin.llm.alertBody': '由于未设置 Anthropic API 密钥，聊天功能不可用。',
+  'admin.llm.alertCta': '配置 LLM',
   'admin.chatLimits.title': '使用限制',
   'admin.chatLimits.subtitle': '配置速率限制以防止滥用并控制成本。0 表示无限制。',
   'admin.chatLimits.maxMessageChars': '最大消息长度（字符）',


### PR DESCRIPTION
Closes #203

## 変更内容

- ログイン直後に `GET /admin/settings/llm` を fetch して `configured` フラグを確認
- `configured === false` のとき、メイン画面最上部にアンバー警告バナーを表示
- バナーの「設定する」ボタンで LLM アコーディオンを展開しスムーズスクロール
- API キー保存後は `onConfiguredChange` コールバックでバナーを自動消去

## 実装詳細

- `LlmUnconfiguredBanner` コンポーネント（新規）
- `LlmSettingsPanel` に `isOpen` / `onOpenChange` / `onConfiguredChange` props 追加（制御・非制御の両対応）
- `App.tsx` で LLM 設定済み状態を管理・バナーとアコーディオンを連動

## i18n
6 ロケール（ja / en / de / fr / zh-Hans / pt-BR）に `alertBody` / `alertCta` 追加

## セルフレビュー
- [x] `docs/review/docs-policy.md`

## 品質チェック
- `npm run check --prefix frontend` ✅  
- `composer check` → 118 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)