### PR TITLE
feat(admin): AppearancePanel を設定モーダルへ移動し、メイン画面をスリム化 (#205)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -4,7 +4,6 @@ import { getLlmSettings } from '@nene-corpus/api-client/llm-settings';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
 import { ConversationLogsPanel, ConversationLogsSummary } from './ConversationLogsPanel';
-import { AppearancePanel } from './AppearancePanel';
 import { LlmUnconfiguredBanner } from './LlmUnconfiguredBanner';
 import { SettingsModal } from './SettingsModal';
 import type { SettingsSection } from './SettingsModal';
@@ -116,8 +115,6 @@ export function App() {
             {logsOpen && (
               <ConversationLogsPanel token={token} onClose={() => setLogsOpen(false)} />
             )}
-            {/* ── デザイン（Phase 2 で設定モーダルへ移動予定 #205） ── */}
-            <AppearancePanel token={token} />
             <HelpPanel />
           </>
         )}

--- a/frontend/apps/admin/src/SettingsModal.tsx
+++ b/frontend/apps/admin/src/SettingsModal.tsx
@@ -2,10 +2,11 @@ import { useEffect, useRef, useState } from 'react';
 import { Msg, useMsg } from '@nene-corpus/i18n';
 import { LlmSettingsPanel } from './LlmSettingsPanel';
 import { ChatSettingsPanel } from './ChatSettingsPanel';
+import { AppearancePanel } from './AppearancePanel';
 import { ChatLimitsPanel } from './ChatLimitsPanel';
 import { AccountPanel } from './AccountPanel';
 
-export type SettingsSection = 'llm' | 'chat' | 'limits' | 'account';
+export type SettingsSection = 'llm' | 'chat' | 'appearance' | 'limits' | 'account';
 
 interface SettingsModalProps {
   token: string;
@@ -19,15 +20,17 @@ interface NavItem {
   msgKey:
     | typeof Msg.admin.app.settingsNavLlm
     | typeof Msg.admin.app.settingsNavChat
+    | typeof Msg.admin.app.settingsNavAppearance
     | typeof Msg.admin.app.settingsNavLimits
     | typeof Msg.admin.app.settingsNavAccount;
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { id: 'llm',     msgKey: Msg.admin.app.settingsNavLlm },
-  { id: 'chat',    msgKey: Msg.admin.app.settingsNavChat },
-  { id: 'limits',  msgKey: Msg.admin.app.settingsNavLimits },
-  { id: 'account', msgKey: Msg.admin.app.settingsNavAccount },
+  { id: 'llm',        msgKey: Msg.admin.app.settingsNavLlm },
+  { id: 'chat',       msgKey: Msg.admin.app.settingsNavChat },
+  { id: 'appearance', msgKey: Msg.admin.app.settingsNavAppearance },
+  { id: 'limits',     msgKey: Msg.admin.app.settingsNavLimits },
+  { id: 'account',    msgKey: Msg.admin.app.settingsNavAccount },
 ];
 
 export function SettingsModal({ token, initialSection = 'llm', onClose, onLlmConfiguredChange }: SettingsModalProps) {
@@ -125,6 +128,9 @@ export function SettingsModal({ token, initialSection = 'llm', onClose, onLlmCon
             )}
             {activeSection === 'chat' && (
               <ChatSettingsPanel token={token} />
+            )}
+            {activeSection === 'appearance' && (
+              <AppearancePanel token={token} />
             )}
             {activeSection === 'limits' && (
               <ChatLimitsPanel

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -44,6 +44,7 @@ export const Msg = {
       settingsClose: 'admin.app.settingsClose',
       settingsNavLlm: 'admin.app.settingsNavLlm',
       settingsNavChat: 'admin.app.settingsNavChat',
+      settingsNavAppearance: 'admin.app.settingsNavAppearance',
       settingsNavLimits: 'admin.app.settingsNavLimits',
       settingsNavAccount: 'admin.app.settingsNavAccount',
     },

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -31,6 +31,7 @@ export const de = defineMessages({
   'admin.app.settingsClose': 'Schließen',
   'admin.app.settingsNavLlm': 'LLM',
   'admin.app.settingsNavChat': 'Chat-Einstellungen',
+  'admin.app.settingsNavAppearance': 'Darstellung',
   'admin.app.settingsNavLimits': 'Nutzungslimits',
   'admin.app.settingsNavAccount': 'Konto',
   'admin.auth.title': 'Admin-Anmeldung',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -31,6 +31,7 @@ export const en = defineMessages({
   'admin.app.settingsClose': 'Close',
   'admin.app.settingsNavLlm': 'LLM',
   'admin.app.settingsNavChat': 'Chat Settings',
+  'admin.app.settingsNavAppearance': 'Appearance',
   'admin.app.settingsNavLimits': 'Usage Limits',
   'admin.app.settingsNavAccount': 'Account',
   'admin.auth.title': 'Admin login',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -31,6 +31,7 @@ export const fr = defineMessages({
   'admin.app.settingsClose': 'Fermer',
   'admin.app.settingsNavLlm': 'LLM',
   'admin.app.settingsNavChat': 'Paramètres du chat',
+  'admin.app.settingsNavAppearance': 'Apparence',
   'admin.app.settingsNavLimits': "Limites d\'utilisation",
   'admin.app.settingsNavAccount': 'Compte',
   'admin.auth.title': 'Connexion admin',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -31,6 +31,7 @@ export const ja = defineMessages({
   'admin.app.settingsClose': '閉じる',
   'admin.app.settingsNavLlm': 'LLM',
   'admin.app.settingsNavChat': 'チャット設定',
+  'admin.app.settingsNavAppearance': 'デザイン',
   'admin.app.settingsNavLimits': '利用制限',
   'admin.app.settingsNavAccount': 'アカウント',
   'admin.auth.title': '管理者ログイン',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -31,6 +31,7 @@ export const ptBr = defineMessages({
   'admin.app.settingsClose': 'Fechar',
   'admin.app.settingsNavLlm': 'LLM',
   'admin.app.settingsNavChat': 'Config. do chat',
+  'admin.app.settingsNavAppearance': 'Aparência',
   'admin.app.settingsNavLimits': 'Limites de uso',
   'admin.app.settingsNavAccount': 'Conta',
   'admin.auth.title': 'Login admin',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -31,6 +31,7 @@ export const zhHans = defineMessages({
   'admin.app.settingsClose': '关闭',
   'admin.app.settingsNavLlm': 'LLM',
   'admin.app.settingsNavChat': '聊天设置',
+  'admin.app.settingsNavAppearance': '外観',
   'admin.app.settingsNavLimits': '使用限制',
   'admin.app.settingsNavAccount': '账户',
   'admin.auth.title': '管理员登录',


### PR DESCRIPTION
Closes #205

## 変更概要

AppearancePanel（デザイン設定）をメイン画面から設定モーダルへ移動し、常時表示をやめる。

## 変更内容

- **SettingsModal**: `appearance` タブを追加（LLM → Chat → **Appearance** → Limits → Account の順）
- **App.tsx**: メインエリアから `<AppearancePanel>` を削除、import も削除
- **i18n**: `settingsNavAppearance` キーを 6 ロケールに追加
  - ja: デザイン / en: Appearance / de: Darstellung / fr: Apparence / zh-Hans: 外観 / pt-BR: Aparência

## セルフレビューチェックリスト

- [x] `docs/review/backend-api.md` — バックエンド変更なし
- [x] TypeScript `npm run check --prefix frontend` 通過
- [x] `SettingsSection` 型に `'appearance'` 追加済み
- [x] `NavItem.msgKey` union 型に `typeof Msg.admin.app.settingsNavAppearance` 追加済み
- [x] 全 6 ロケールに `settingsNavAppearance` 追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)