### PR TITLE
feat(admin): HelpPanel ガイドリンクカード・フッター追加 (#217)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Msg, resolveMsgKey, applyLocaleFontFamily, toBcp47, useLocale, useMsg } from '@nene-corpus/i18n';
+import { Msg, resolveMsgKey, applyLocaleFontFamily, toBcp47, useLocale, useMsg, type MsgKey } from '@nene-corpus/i18n';
 import { getLlmSettings } from '@nene-corpus/api-client/llm-settings';
 import { LoginForm, SourcesPanel } from './SourcesPanel';
 import { IngestionPanel } from './IngestionPanel';
@@ -129,6 +129,39 @@ export function App() {
           onLlmConfiguredChange={setIsLlmConfigured}
         />
       )}
+
+      {/* ── フッター ── */}
+      <AdminFooter locale={locale} t={t} />
     </div>
+  );
+}
+
+const GUIDE_URL_MAP: Record<string, string> = {
+  ja: '/guide/ja/',
+  en: '/guide/en/',
+  de: '/guide/de/',
+  fr: '/guide/fr/',
+  'pt-BR': '/guide/pt-br/',
+  'zh-Hans': '/guide/zh-hans/',
+};
+
+function AdminFooter({ locale, t }: { locale: string; t: (key: MsgKey) => string }) {
+  const guideUrl = GUIDE_URL_MAP[locale] ?? '/guide/en/';
+  return (
+    <footer className="mt-12 border-t border-border px-6 py-6 text-center text-xs nc-text-muted">
+      <p>
+        {t(resolveMsgKey(Msg.admin.footer?.poweredBy, 'admin.footer.poweredBy'))}{' '}
+        <a
+          href={guideUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-brand hover:underline"
+        >
+          NeNe Corpus
+        </a>
+        {' · '}
+        {t(resolveMsgKey(Msg.admin.footer?.copyright, 'admin.footer.copyright'))}
+      </p>
+    </footer>
   );
 }

--- a/frontend/apps/admin/src/HelpPanel.tsx
+++ b/frontend/apps/admin/src/HelpPanel.tsx
@@ -1,8 +1,23 @@
-import { Msg, resolveMsgKey, useMsg } from '@nene-corpus/i18n';
+import { Msg, resolveMsgKey, useLocale, useMsg } from '@nene-corpus/i18n';
 import { ADMIN_HELP_SECTIONS } from './helpSections';
+
+/** ロケール → ガイド URL のマッピング */
+const GUIDE_URL_MAP: Record<string, string> = {
+  ja: '/guide/ja/',
+  en: '/guide/en/',
+  de: '/guide/de/',
+  fr: '/guide/fr/',
+  'pt-BR': '/guide/pt-br/',
+  'zh-Hans': '/guide/zh-hans/',
+};
+
+function guideUrl(locale: string): string {
+  return GUIDE_URL_MAP[locale] ?? '/guide/en/';
+}
 
 export function HelpPanel() {
   const t = useMsg();
+  const { locale } = useLocale();
 
   return (
     <section id="admin-help" className="nc-panel scroll-mt-24">
@@ -11,6 +26,26 @@ export function HelpPanel() {
         <p>{t(resolveMsgKey(Msg.admin.help?.subtitle, 'admin.help.subtitle'))}</p>
       </div>
       <div className="space-y-3 px-4 py-4">
+        {/* ガイドリンクカード */}
+        <a
+          href={guideUrl(locale)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-between rounded-admin border border-brand/40 bg-brand/10 px-4 py-3 text-sm font-medium text-brand transition-colors hover:bg-brand/20"
+        >
+          <span className="flex items-center gap-2">
+            <span aria-hidden>📖</span>
+            <span>
+              {t(resolveMsgKey(Msg.admin.help?.guideLink?.label, 'admin.help.guideLink.label'))}
+            </span>
+          </span>
+          <span aria-hidden className="text-xs opacity-70">→</span>
+        </a>
+        <p className="px-1 text-xs nc-text-muted">
+          {t(resolveMsgKey(Msg.admin.help?.guideLink?.description, 'admin.help.guideLink.description'))}
+        </p>
+
+        {/* アコーディオン */}
         {ADMIN_HELP_SECTIONS.map((section) => (
           <details
             key={section.titleKey}

--- a/frontend/packages/i18n/src/keys.ts
+++ b/frontend/packages/i18n/src/keys.ts
@@ -460,6 +460,14 @@ export const Msg = {
         title: 'admin.help.faq.title',
         body: 'admin.help.faq.body',
       },
+      guideLink: {
+        label: 'admin.help.guideLink.label',
+        description: 'admin.help.guideLink.description',
+      },
+    },
+    footer: {
+      poweredBy: 'admin.footer.poweredBy',
+      copyright: 'admin.footer.copyright',
     },
   },
   widget: {

--- a/frontend/packages/i18n/src/locales/de.ts
+++ b/frontend/packages/i18n/src/locales/de.ts
@@ -435,6 +435,10 @@ export const de = defineMessages({
   'admin.help.faq.title': 'FAQ',
   'admin.help.faq.body':
     'Verlassen Daten meinen Server? — Korpus bleibt in Ihrer DB. Nur relevante Textausschnitte gehen an die Claude-API.\n\nSubdomain? — Ja, Document Root auf public_html zeigen.\n\nStreaming? — Nur synchroner JSON-Chat, kein SSE-Streaming.\n\nMehr — Shared-Hosting-Docs im Release-ZIP.',
+  'admin.help.guideLink.label': 'Setup-Leitfaden ansehen',
+  'admin.help.guideLink.description': 'Schritt-für-Schritt-Anleitung von der Installation bis zur Einbettung',
+  'admin.footer.poweredBy': 'Powered by',
+  'admin.footer.copyright': '© AYANE All rights reserved.',
   'widget.chat.panelLabel': 'NeNe Corpus Chat',
   'widget.chat.emptyPrompt': 'Stellen Sie eine Frage zu unseren Produkten.',
   'widget.chat.loading': 'Korpus wird durchsucht…',

--- a/frontend/packages/i18n/src/locales/en.ts
+++ b/frontend/packages/i18n/src/locales/en.ts
@@ -435,6 +435,10 @@ export const en = defineMessages({
   'admin.help.faq.title': 'FAQ',
   'admin.help.faq.body':
     'Does data leave my server? — Your corpus stays in your database. Only retrieved text chunks are sent to the Claude API when visitors ask questions.\n\nCan I use a subdomain? — Yes. Point the subdomain document root at public_html and set the embed base path accordingly.\n\nStreaming responses? — NeNe Corpus uses sync JSON chat (loading indicator in the widget), not SSE token streaming.\n\nMore detail — see shared-hosting operator docs shipped with the release ZIP.',
+  'admin.help.guideLink.label': 'View Setup Guide',
+  'admin.help.guideLink.description': 'Step-by-step instructions from installation to embedding',
+  'admin.footer.poweredBy': 'Powered by',
+  'admin.footer.copyright': '© AYANE All rights reserved.',
   'widget.chat.panelLabel': 'NeNe Corpus chat',
   'widget.chat.emptyPrompt': 'Ask a question about our products.',
   'widget.chat.loading': 'Searching the corpus…',

--- a/frontend/packages/i18n/src/locales/fr.ts
+++ b/frontend/packages/i18n/src/locales/fr.ts
@@ -435,6 +435,10 @@ export const fr = defineMessages({
   'admin.help.faq.title': 'FAQ',
   'admin.help.faq.body':
     'Les données quittent-elles mon serveur ? — Le corpus reste dans votre base. Seuls les extraits pertinents partent vers l\'API Claude.\n\nSous-domaine ? — Oui, pointez la racine documentaire vers public_html.\n\nStreaming ? — Chat JSON synchrone uniquement, pas de streaming SSE.\n\nPlus de détails — docs hébergement mutualisé fournis avec le ZIP de release.',
+  'admin.help.guideLink.label': 'Voir le guide de configuration',
+  'admin.help.guideLink.description': "Instructions étape par étape, de l'installation à l'intégration",
+  'admin.footer.poweredBy': 'Powered by',
+  'admin.footer.copyright': '© AYANE All rights reserved.',
   'widget.chat.panelLabel': 'Chat NeNe Corpus',
   'widget.chat.emptyPrompt': 'Posez une question sur nos produits.',
   'widget.chat.loading': 'Recherche dans le corpus…',

--- a/frontend/packages/i18n/src/locales/ja.ts
+++ b/frontend/packages/i18n/src/locales/ja.ts
@@ -434,6 +434,10 @@ export const ja = defineMessages({
   'admin.help.faq.title': 'よくある質問',
   'admin.help.faq.body':
     'データは外部に出る？ — コーパスは自社 DB に保存。質問時に検索でヒットしたテキスト断片のみ Claude API に送られます。\n\nサブドメインは使える？ — 可能です。サブドメインの document root を public_html に向け、embed のベースパスを合わせてください。\n\nストリーミング応答は？ — sync JSON チャット（ローディング表示）のみ。SSE の逐次表示は非対応です。\n\n詳細 — リリース ZIP 同梱の shared-hosting 運用ドキュメントを参照。',
+  'admin.help.guideLink.label': 'セットアップガイドを見る',
+  'admin.help.guideLink.description': 'インストールから埋め込みまでの手順を確認できます',
+  'admin.footer.poweredBy': 'Powered by',
+  'admin.footer.copyright': '© AYANE All rights reserved.',
   'widget.chat.panelLabel': 'NeNe Corpus チャット',
   'widget.chat.emptyPrompt': '商品やサービスについて質問してみてください。',
   'widget.chat.loading': '資料を検索しています…',

--- a/frontend/packages/i18n/src/locales/pt-BR.ts
+++ b/frontend/packages/i18n/src/locales/pt-BR.ts
@@ -435,6 +435,10 @@ export const ptBr = defineMessages({
   'admin.help.faq.title': 'FAQ',
   'admin.help.faq.body':
     'Os dados saem do meu servidor? — O corpus fica no seu banco. Apenas trechos relevantes vão à API Claude.\n\nSubdomínio? — Sim, aponte o document root para public_html.\n\nStreaming? — Apenas chat JSON síncrono, sem SSE.\n\nMais detalhes — docs de shared hosting no ZIP de release.',
+  'admin.help.guideLink.label': 'Ver guia de configuração',
+  'admin.help.guideLink.description': 'Instruções passo a passo da instalação à incorporação',
+  'admin.footer.poweredBy': 'Powered by',
+  'admin.footer.copyright': '© AYANE All rights reserved.',
   'widget.chat.panelLabel': 'Chat NeNe Corpus',
   'widget.chat.emptyPrompt': 'Faça uma pergunta sobre nossos produtos.',
   'widget.chat.loading': 'Pesquisando no corpus…',

--- a/frontend/packages/i18n/src/locales/zh-Hans.ts
+++ b/frontend/packages/i18n/src/locales/zh-Hans.ts
@@ -429,6 +429,10 @@ export const zhHans = defineMessages({
   'admin.help.faq.title': '常见问题',
   'admin.help.faq.body':
     '数据会离开服务器吗？ — 语料库保存在您的数据库；仅将检索到的文本片段发送至 Claude API。\n\n可用子域名吗？ — 可以，将 document root 指向 public_html。\n\n流式响应？ — 仅同步 JSON 聊天，不支持 SSE 逐字流。\n\n更多说明 — 见发布 ZIP 中的共享主机运营文档。',
+  'admin.help.guideLink.label': '查看设置指南',
+  'admin.help.guideLink.description': '从安装到嵌入的分步说明',
+  'admin.footer.poweredBy': 'Powered by',
+  'admin.footer.copyright': '© AYANE All rights reserved.',
   'widget.chat.panelLabel': 'NeNe Corpus 聊天',
   'widget.chat.emptyPrompt': '请提问有关我们产品的问题。',
   'widget.chat.loading': '正在搜索语料库…',


### PR DESCRIPTION
Closes #217

## 変更内容

### HelpPanel — ガイドリンクカード
- アコーディオン上部に「View Setup Guide →」カードを追加
- URL はロケールに連動（`/guide/ja/`、`/guide/en/` など）
- ログイン画面（認証前）にも表示されるため公開ページとして機能

### フッター
- ログイン・管理画面共通で「Powered by NeNe Corpus · © AYANE All rights reserved.」を表示
- NeNe Corpus テキストはガイド LP へリンク

### i18n
- `admin.help.guideLink.label / description` キーを追加
- `admin.footer.poweredBy / copyright` キーを追加
- 全 6 ロケール対応（ja / en / de / fr / pt-BR / zh-Hans）

## セルフレビュー

- フロントエンドのみの変更。PHP / API 変更なし
- `npm run check --prefix frontend` → 型チェック・lint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)