### PR TITLE
fix(admin): Vite dev proxy に /guide を追加 (#217)

### DIFF
--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
       '/admin': 'http://localhost:8080',
       '/widget': 'http://localhost:8080',
       '/media': 'http://localhost:8080',
+      '/guide': 'http://localhost:8080',
     },
   },
   build: {


### PR DESCRIPTION
Closes なし（#217 フォローアップ）

## 問題

`localhost:5273/guide/ja/` にアクセスすると、Vite dev サーバーのプロキシに `/guide` が未設定のため SPA（管理画面）に吸い込まれてログイン画面が表示されていた。

## 修正

`vite.config.ts` のプロキシに `'/guide': 'http://localhost:8080'` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)