### PR TITLE
fix(admin): フッターの AYANE を ayane.co.jp にリンク (#217)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -159,8 +159,16 @@ function AdminFooter({ locale, t }: { locale: string; t: (key: MsgKey) => string
         >
           NeNe Corpus
         </a>
-        {' · '}
-        {t(resolveMsgKey(Msg.admin.footer?.copyright, 'admin.footer.copyright'))}
+        {' · © '}
+        <a
+          href="https://ayane.co.jp"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          AYANE
+        </a>
+        {' All rights reserved.'}
       </p>
     </footer>
   );


### PR DESCRIPTION
Closes なし（#217 フォローアップ）

AdminFooter の copyright テキストを分解し、AYANE に `https://ayane.co.jp` へのリンクを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)