### PR TITLE
feat(guide): ペルソナ駆動 HOWTO セットアップガイドを追加 (#222)

### DIFF
--- a/frontend/apps/admin/src/HelpPanel.tsx
+++ b/frontend/apps/admin/src/HelpPanel.tsx
@@ -1,14 +1,14 @@
 import { Msg, resolveMsgKey, useLocale, useMsg } from '@nene-corpus/i18n';
 import { ADMIN_HELP_SECTIONS } from './helpSections';
 
-/** ロケール → ガイド URL のマッピング */
+/** ロケール → HOWTO セットアップガイド URL のマッピング */
 const GUIDE_URL_MAP: Record<string, string> = {
-  ja: '/guide/ja/',
-  en: '/guide/en/',
-  de: '/guide/de/',
-  fr: '/guide/fr/',
-  'pt-BR': '/guide/pt-br/',
-  'zh-Hans': '/guide/zh-hans/',
+  ja: '/guide/howto/ja/',
+  en: '/guide/howto/en/',
+  de: '/guide/howto/de/',
+  fr: '/guide/howto/fr/',
+  'pt-BR': '/guide/howto/pt-br/',
+  'zh-Hans': '/guide/howto/zh-hans/',
 };
 
 function guideUrl(locale: string): string {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "check": "npm run typecheck --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
-    "build:release": "npm run build:release:admin && npm run build -w @nene-corpus/widget && node ../scripts/build-guide.mjs",
+    "build:release": "npm run build:release:admin && npm run build -w @nene-corpus/widget && node ../scripts/build-guide.mjs && node ../scripts/build-howto.mjs",
     "build:release:admin": "NENE_CORPUS_ADMIN_OUT=../../../public_html/admin npm run build -w @nene-corpus/admin",
     "dev:admin": "npm run dev -w @nene-corpus/admin",
     "dev:widget": "npm run dev -w @nene-corpus/widget"

--- a/public_html/guide/howto/de/index.html
+++ b/public_html/guide/howto/de/index.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Einrichtungsanleitung — NeNe Corpus HOWTO</title>
+  <meta name="description" content="Folge Sakura, einer Café-Besitzerin, und richte NeNe Corpus in 4 Schritten ein — von der Installation bis zum Live-Chat."/>
+  <meta property="og:title" content="Einrichtungsanleitung — NeNe Corpus HOWTO"/>
+  <meta property="og:description" content="Folge Sakura, einer Café-Besitzerin, und richte NeNe Corpus in 4 Schritten ein — von der Installation bis zum Live-Chat."/>
+  <meta property="og:type" content="website"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>
+  <!-- ダークモード初期化: flash を防ぐため CDN より先に実行 -->
+  <script>
+    (function(){
+      var s = localStorage.getItem('guide-theme');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <!-- Tailwind Play CDN v3: CDN を先に読み込み、その後 tailwind.config を設定する -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    /* Tailwind Play CDN v3: tailwind.config は CDN 読み込み後に設定する */
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:'#4d8f7f', dark:'#3a6e62', light:'#e6f2ef' },
+          },
+          fontFamily: {
+            sans: ['Inter','system-ui','sans-serif'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    html { scroll-behavior:smooth; }
+    body { font-family: "Inter", system-ui, sans-serif, sans-serif; }
+    details summary::-webkit-details-marker { display:none; }
+    pre code { font-family:'Menlo','Monaco','Consolas',monospace; }
+    /* lang dropdown */
+    #lang-menu { display:none; }
+    #lang-menu.open { display:block; }
+    /* デモチャット吹き出し装飾 */
+    .chat-phone { background:white; border-radius:2rem; overflow:hidden; border:2px solid #e2e8f0; box-shadow:0 25px 60px -10px rgba(0,0,0,.18); }
+    html.dark .chat-phone { background:#1e293b; border-color:#334155; }
+    /* persona card */
+    .persona-card { background:linear-gradient(135deg,#e6f2ef 0%,#e6f2ef80 100%); }
+    html.dark .persona-card { background:linear-gradient(135deg,rgba(77,143,127,.18) 0%,rgba(77,143,127,.06) 100%); border-color:rgba(77,143,127,.35); }
+  </style>
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased transition-colors duration-200">
+
+  <!-- ── Nav ── -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+      <!-- ロゴ -->
+      <a href="../../de/" class="flex items-center gap-2 font-bold text-gray-900 dark:text-white text-base shrink-0 hover:opacity-80 transition-opacity">
+        <span class="w-7 h-7 rounded-lg flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+        NeNe Corpus
+      </a>
+      <!-- 戻るリンク -->
+      <a href="../../de/" class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Zurück zum Guide
+      </a>
+
+      <div class="flex items-center gap-1.5 sm:gap-2 ml-auto">
+        <!-- 言語プルダウン -->
+        <div class="relative" id="lang-dropdown">
+          <button onclick="toggleLangMenu(event)"
+                  class="flex items-center gap-1 px-2.5 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+            <span class="hidden sm:inline font-medium">Deutsch</span>
+            <svg class="w-3 h-3 shrink-0 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+          </button>
+          <div id="lang-menu"
+               class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-36 z-50">
+            <a href="../ja/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>日本語
+         </a><a href="../en/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>English
+         </a><span class="flex items-center gap-2 px-4 py-2 text-sm font-semibold" style="color:#4d8f7f">
+           <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>Deutsch
+         </span><a href="../fr/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Français
+         </a><a href="../zh-hans/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>中文
+         </a><a href="../pt-br/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Português
+         </a>
+          </div>
+        </div>
+
+        <!-- ダークモードトグル -->
+        <button onclick="toggleTheme()"
+                class="p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode">
+          <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          <svg id="icon-sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        </button>
+
+        <!-- GitHub -->
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ── Hero ── -->
+    <section class="pt-14 pb-12 sm:pt-20 sm:pb-16 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- テキスト -->
+          <div>
+            <span class="inline-flex items-center gap-2 mb-5 px-3.5 py-1.5 rounded-full text-sm font-medium border"
+                  style="color:#4d8f7f;border-color:#e6f2ef;background:#e6f2ef">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+              Einrichtungsanleitung · ca. 15 Minuten
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-gray-950 dark:text-white leading-[1.15] tracking-tight mb-5">
+              NeNe Corpus Einrichten<br>Mit Persona
+            </h1>
+            <p class="text-lg text-gray-500 dark:text-gray-400 leading-relaxed mb-8">
+              Begleite Sakura, eine Café-Besitzerin, und richte den KI-Chat in 4 einfachen Schritten ein.
+            </p>
+            <a href="#steps"
+               class="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl text-white text-base font-semibold shadow-lg transition-all hover:opacity-90 hover:shadow-xl hover:-translate-y-0.5"
+               style="background:#4d8f7f">
+              Einrichtung starten
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            </a>
+          </div>
+
+          <!-- ペルソナカード -->
+          <div class="flex justify-center lg:justify-end">
+            <div class="persona-card border rounded-3xl p-8 max-w-xs w-full shadow-xl">
+              <!-- アバター + 名前 -->
+              <div class="flex items-center gap-4 mb-5">
+                <div class="w-16 h-16 rounded-2xl text-white text-2xl font-black flex items-center justify-center shadow-lg" style="background:#4d8f7f">
+                  S
+                </div>
+                <div>
+                  <p class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakura</p>
+                  <span class="inline-block mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold text-white" style="background:#4d8f7f">Café-Besitzerin</span>
+                </div>
+              </div>
+              <!-- 店名 -->
+              <p class="text-sm font-medium mb-4" style="color:#4d8f7f">📍 Sakura Café</p>
+              <!-- 吹き出しイントロ -->
+              <div class="relative rounded-2xl rounded-tl-none bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 px-4 py-3 shadow-sm">
+                <span class="absolute -top-2.5 left-4 text-white text-base leading-none" style="text-shadow:0 1px 2px rgba(0,0,0,.1)">▾</span>
+                <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Hallo! Ich bin Sakura und führe das Sakura Café. Ich wollte einen KI-Chat auf meiner Website einrichten, damit Besucher jederzeit Fragen stellen können. Lass uns das zusammen angehen!</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── セットアップステップ ── -->
+    <section id="steps" class="py-16 sm:py-24 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-14">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">In 4 Schritten fertig</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg">Folge Sakura von der Installation bis zur Veröffentlichung des Widgets.</p>
+        </div>
+        <!-- タイムライン -->
+        <div>
+          
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">1</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Installieren</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Zuerst lädst du die Dateien einfach auf deinen Server hoch. Klingt technisch, geht aber per FTP — kein Programmieren nötig! 😊
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Lade das neueste Release-ZIP von GitHub Releases herunter</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Entpacke das ZIP und lade den Inhalt in <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">public_html</code> hoch</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Öffne <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">https://deine-domain.de/install</code> im Browser</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Gib deine Datenbankdaten ein und klicke auf „Installation ausführen"</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">2</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">API-Schlüssel konfigurieren</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Erstelle ein Anthropic-Konto und hole dir einen API-Schlüssel. Danach ist die KI einsatzbereit! ✨
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Erstelle ein Konto bei Anthropic (console.anthropic.com)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Erstelle einen neuen API-Schlüssel und kopiere ihn</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Öffne Admin → Einstellungen → LLM-Tab</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Füge den Schlüssel ein, klicke „Verbindung testen" → „Speichern"</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">3</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Inhalte hochladen</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Lade einfach deine Menü-PDF oder FAQ-Datei hoch. Das wird zur Wissensbasis deiner KI! 📄
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Klicke im Admin-Bereich auf „Inhalt hinzufügen"</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Wähle deine PDF-, CSV- oder Textdateien aus und lade sie hoch</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Warte, bis der Status „Fertig" anzeigt (Sekunden bis Minuten)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Du kannst Menüs, FAQs, Storeinfos hochladen — so viele Dateien du willst</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">4</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Widget einbetten</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Kopiere eine Zeile Code und füge sie in deine Website ein! Das war's — der Chat ist live! 🎉
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Öffne Admin → Einstellungen → Design-Tab</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Kopiere den Code aus dem Abschnitt „Einbettungscode"</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Füge ihn direkt vor <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">&lt;/body&gt;</code> in dein Website-HTML ein</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Lade die Seite neu — unten rechts sollte ein Chat-Symbol erscheinen!</span>
+      </li>
+            </ul>
+            
+      <div class="mt-5">
+        <pre class="rounded-2xl bg-gray-900 text-green-300 text-xs p-5 overflow-x-auto leading-relaxed font-mono shadow-inner border border-gray-800"><code>&lt;script
+  src="https://your-domain.com/widget.js"
+  data-nene-corpus
+&gt;&lt;/script&gt;</code></pre>
+      </div>
+          </div>
+        </div>
+      </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── デモチャット ── -->
+    <section class="py-16 sm:py-24 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-12">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">So sieht es in Aktion aus</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg max-w-xl mx-auto">So erleben Besucher das Sakura Café. Fragen werden sofort mit Quellenangabe beantwortet.</p>
+        </div>
+
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- 説明テキスト -->
+          <div class="space-y-5 order-2 lg:order-1">
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">📄</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Antworten stammen aus Ihren hochgeladenen Dateien</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Menü, FAQ, Storeinformationen — alles Hochgeladene wird zur Wissensbasis der KI.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">🔖</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Jede Antwort enthält Quellen</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Zitatbadges zeigen genau, aus welchem Dokument und welcher Seite die Antwort stammt.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">⚡</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">24/7 automatische Antworten</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Besucher erhalten jederzeit sofortige Antworten aus Ihren Inhalten.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- デモチャット画面 -->
+          <div class="order-1 lg:order-2 flex justify-center">
+            <div class="chat-phone w-full max-w-sm">
+              <!-- チャットヘッダー -->
+              <div class="px-5 py-4 flex items-center gap-3" style="background:#4d8f7f">
+                <div class="w-9 h-9 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-black">N</div>
+                <div>
+                  <p class="text-white font-bold text-sm">NeNe Corpus</p>
+                  <p class="text-white/75 text-xs">Sakura Café</p>
+                </div>
+              </div>
+              <!-- チャットボディ -->
+              <div class="px-4 py-5 space-y-5 bg-white dark:bg-gray-900 min-h-64">
+                
+    <!-- Q1 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Was kostet der Matcha Latte?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Der Matcha Latte kostet 5,80 € inkl. MwSt.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [1] Menü S.2
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q2 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Kann ich einen Terrassenplatz reservieren?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Terrassenplätze können für bis zu 4 Personen reserviert werden. Per Telefon oder Web-Formular.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [2] Storeinfo S.1
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q3 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Gibt es kostenloses WLAN?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Ja! Kostenloses WLAN ist verfügbar. Das Passwort erhalten Sie beim Personal.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [3] FAQ S.3
+          </div>
+        </div>
+      </div>
+    </div>
+              </div>
+              <!-- 入力欄 -->
+              <div class="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex gap-2">
+                <div class="flex-1 rounded-xl bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm text-gray-400">…</div>
+                <div class="w-9 h-9 rounded-xl flex items-center justify-center text-white shrink-0" style="background:#4d8f7f">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CTA ── -->
+    <section class="py-20 sm:py-28 text-white" style="background:#4d8f7f">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">Richte es auf deiner Website ein</h2>
+        <p class="text-lg mb-8 opacity-85">Dieselben Schritte wie Sakura. Kostenlos und Open Source.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="#steps"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-white font-semibold text-base transition-all hover:bg-gray-50 hover:-translate-y-0.5 shadow-xl"
+             style="color:#4d8f7f">
+            Loslegen
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+          </a>
+          <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl font-semibold text-base border border-white/30 hover:bg-white/10 transition-all">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ── Footer ── -->
+  <footer class="bg-gray-950 text-gray-400 py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 text-sm">
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+          <span class="text-white font-bold">NeNe Corpus</span>
+        </div>
+        <p class="text-gray-500">Powered by <a href="https://nene2.dev" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">NENE2</a> · © <a href="https://ayane.co.jp" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">AYANE</a> All rights reserved.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener" class="flex items-center gap-1.5 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+        <span class="text-gray-700">·</span>
+        <span>MIT-Lizenz</span>
+        <span class="text-gray-700">·</span>
+        <a href="#" class="hover:text-white transition-colors">Nach oben ↑</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // ── ダークモードトグル ──────────────────────────────────
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('guide-theme', isDark ? 'dark' : 'light');
+      document.getElementById('icon-moon').classList.toggle('hidden', isDark);
+      document.getElementById('icon-sun').classList.toggle('hidden', !isDark);
+    }
+    (function(){
+      if (document.documentElement.classList.contains('dark')) {
+        document.getElementById('icon-moon').classList.add('hidden');
+        document.getElementById('icon-sun').classList.remove('hidden');
+      }
+    })();
+
+    // ── 言語プルダウン ──────────────────────────────────────
+    function toggleLangMenu(e) {
+      e.stopPropagation();
+      document.getElementById('lang-menu').classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      var dd = document.getElementById('lang-dropdown');
+      if (dd && !dd.contains(e.target)) {
+        document.getElementById('lang-menu').classList.remove('open');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public_html/guide/howto/en/index.html
+++ b/public_html/guide/howto/en/index.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Setup Guide — NeNe Corpus HOWTO</title>
+  <meta name="description" content="Follow along with Sakura, a café owner, and set up NeNe Corpus in 4 steps — from install to AI chat going live."/>
+  <meta property="og:title" content="Setup Guide — NeNe Corpus HOWTO"/>
+  <meta property="og:description" content="Follow along with Sakura, a café owner, and set up NeNe Corpus in 4 steps — from install to AI chat going live."/>
+  <meta property="og:type" content="website"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>
+  <!-- ダークモード初期化: flash を防ぐため CDN より先に実行 -->
+  <script>
+    (function(){
+      var s = localStorage.getItem('guide-theme');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <!-- Tailwind Play CDN v3: CDN を先に読み込み、その後 tailwind.config を設定する -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    /* Tailwind Play CDN v3: tailwind.config は CDN 読み込み後に設定する */
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:'#4d8f7f', dark:'#3a6e62', light:'#e6f2ef' },
+          },
+          fontFamily: {
+            sans: ['Inter','system-ui','sans-serif'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    html { scroll-behavior:smooth; }
+    body { font-family: "Inter", system-ui, sans-serif, sans-serif; }
+    details summary::-webkit-details-marker { display:none; }
+    pre code { font-family:'Menlo','Monaco','Consolas',monospace; }
+    /* lang dropdown */
+    #lang-menu { display:none; }
+    #lang-menu.open { display:block; }
+    /* デモチャット吹き出し装飾 */
+    .chat-phone { background:white; border-radius:2rem; overflow:hidden; border:2px solid #e2e8f0; box-shadow:0 25px 60px -10px rgba(0,0,0,.18); }
+    html.dark .chat-phone { background:#1e293b; border-color:#334155; }
+    /* persona card */
+    .persona-card { background:linear-gradient(135deg,#e6f2ef 0%,#e6f2ef80 100%); }
+    html.dark .persona-card { background:linear-gradient(135deg,rgba(77,143,127,.18) 0%,rgba(77,143,127,.06) 100%); border-color:rgba(77,143,127,.35); }
+  </style>
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased transition-colors duration-200">
+
+  <!-- ── Nav ── -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+      <!-- ロゴ -->
+      <a href="../../en/" class="flex items-center gap-2 font-bold text-gray-900 dark:text-white text-base shrink-0 hover:opacity-80 transition-opacity">
+        <span class="w-7 h-7 rounded-lg flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+        NeNe Corpus
+      </a>
+      <!-- 戻るリンク -->
+      <a href="../../en/" class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Back to Guide
+      </a>
+
+      <div class="flex items-center gap-1.5 sm:gap-2 ml-auto">
+        <!-- 言語プルダウン -->
+        <div class="relative" id="lang-dropdown">
+          <button onclick="toggleLangMenu(event)"
+                  class="flex items-center gap-1 px-2.5 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+            <span class="hidden sm:inline font-medium">English</span>
+            <svg class="w-3 h-3 shrink-0 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+          </button>
+          <div id="lang-menu"
+               class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-36 z-50">
+            <a href="../ja/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>日本語
+         </a><span class="flex items-center gap-2 px-4 py-2 text-sm font-semibold" style="color:#4d8f7f">
+           <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>English
+         </span><a href="../de/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Deutsch
+         </a><a href="../fr/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Français
+         </a><a href="../zh-hans/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>中文
+         </a><a href="../pt-br/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Português
+         </a>
+          </div>
+        </div>
+
+        <!-- ダークモードトグル -->
+        <button onclick="toggleTheme()"
+                class="p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode">
+          <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          <svg id="icon-sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        </button>
+
+        <!-- GitHub -->
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ── Hero ── -->
+    <section class="pt-14 pb-12 sm:pt-20 sm:pb-16 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- テキスト -->
+          <div>
+            <span class="inline-flex items-center gap-2 mb-5 px-3.5 py-1.5 rounded-full text-sm font-medium border"
+                  style="color:#4d8f7f;border-color:#e6f2ef;background:#e6f2ef">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+              Setup Guide · ~15 minutes
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-gray-950 dark:text-white leading-[1.15] tracking-tight mb-5">
+              NeNe Corpus Setup<br>With Persona
+            </h1>
+            <p class="text-lg text-gray-500 dark:text-gray-400 leading-relaxed mb-8">
+              Join Sakura, a café owner, and set up AI chat on your website in 4 easy steps.
+            </p>
+            <a href="#steps"
+               class="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl text-white text-base font-semibold shadow-lg transition-all hover:opacity-90 hover:shadow-xl hover:-translate-y-0.5"
+               style="background:#4d8f7f">
+              Start Setup
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            </a>
+          </div>
+
+          <!-- ペルソナカード -->
+          <div class="flex justify-center lg:justify-end">
+            <div class="persona-card border rounded-3xl p-8 max-w-xs w-full shadow-xl">
+              <!-- アバター + 名前 -->
+              <div class="flex items-center gap-4 mb-5">
+                <div class="w-16 h-16 rounded-2xl text-white text-2xl font-black flex items-center justify-center shadow-lg" style="background:#4d8f7f">
+                  S
+                </div>
+                <div>
+                  <p class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakura</p>
+                  <span class="inline-block mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold text-white" style="background:#4d8f7f">Café Owner</span>
+                </div>
+              </div>
+              <!-- 店名 -->
+              <p class="text-sm font-medium mb-4" style="color:#4d8f7f">📍 Sakura Café</p>
+              <!-- 吹き出しイントロ -->
+              <div class="relative rounded-2xl rounded-tl-none bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 px-4 py-3 shadow-sm">
+                <span class="absolute -top-2.5 left-4 text-white text-base leading-none" style="text-shadow:0 1px 2px rgba(0,0,0,.1)">▾</span>
+                <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Hi there! I'm Sakura and I run Sakura Café. I wanted to add an AI chat to my website so visitors can ask questions anytime. Let's set it up together!</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── セットアップステップ ── -->
+    <section id="steps" class="py-16 sm:py-24 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-14">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">Done in 4 Steps</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg">Follow along with Sakura from installation to publishing your widget.</p>
+        </div>
+        <!-- タイムライン -->
+        <div>
+          
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">1</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Install</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              First you just upload the files to your server. It sounds technical but you can do it all with FTP — no coding required! 😊
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Download the latest release ZIP from GitHub Releases</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Extract the ZIP and upload the contents to <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">public_html</code></span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Open <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">https://your-domain.com/install</code> in your browser</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Enter your database credentials and click "Run Install"</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">2</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Configure API Key</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Create an Anthropic account and get an API key. Once that's set, the AI powers up! ✨
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Create an account at Anthropic (console.anthropic.com)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Generate a new API key and copy it</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Open Admin → Settings → LLM tab</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Paste the key, click "Test Connection" → "Save"</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">3</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Upload Content</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Just upload your menu PDF or FAQ file. That becomes the knowledge your AI answers from! 📄
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">In the Admin panel, click "Add Content"</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Select your PDF, CSV, or text files and upload them</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Wait for the status to show "Done" (takes a few seconds to minutes)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">You can upload menus, FAQs, store info — as many files as you like</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">4</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Embed the Widget</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Just copy one line of code and paste it into your site! That's all it takes to go live. 🎉
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Open Admin → Settings → Design tab</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Copy the code from the "Embed Code" section</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Paste it just before <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">&lt;/body&gt;</code> in your website HTML</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Reload your page — a chat icon should appear in the bottom-right!</span>
+      </li>
+            </ul>
+            
+      <div class="mt-5">
+        <pre class="rounded-2xl bg-gray-900 text-green-300 text-xs p-5 overflow-x-auto leading-relaxed font-mono shadow-inner border border-gray-800"><code>&lt;script
+  src="https://your-domain.com/widget.js"
+  data-nene-corpus
+&gt;&lt;/script&gt;</code></pre>
+      </div>
+          </div>
+        </div>
+      </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── デモチャット ── -->
+    <section class="py-16 sm:py-24 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-12">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">See It in Action</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg max-w-xl mx-auto">Here's what Sakura Café visitors experience. Questions answered with citations instantly.</p>
+        </div>
+
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- 説明テキスト -->
+          <div class="space-y-5 order-2 lg:order-1">
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">📄</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Answers come from your uploaded files</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Menu, FAQ, store info — whatever you upload becomes the AI's knowledge base.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">🔖</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Every answer includes citations</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Citation badges show exactly which document and page the answer comes from.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">⚡</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">24/7 automatic responses</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Visitors get instant answers any time of day, automatically from your content.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- デモチャット画面 -->
+          <div class="order-1 lg:order-2 flex justify-center">
+            <div class="chat-phone w-full max-w-sm">
+              <!-- チャットヘッダー -->
+              <div class="px-5 py-4 flex items-center gap-3" style="background:#4d8f7f">
+                <div class="w-9 h-9 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-black">N</div>
+                <div>
+                  <p class="text-white font-bold text-sm">NeNe Corpus</p>
+                  <p class="text-white/75 text-xs">Sakura Café</p>
+                </div>
+              </div>
+              <!-- チャットボディ -->
+              <div class="px-4 py-5 space-y-5 bg-white dark:bg-gray-900 min-h-64">
+                
+    <!-- Q1 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          How much is the matcha latte?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            The matcha latte is $5.80 including tax.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [1] Menu p.2
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q2 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Can I reserve a terrace seat?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Terrace seats can be reserved for up to 4 guests. You can book by phone or via the web form.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [2] Store Info p.1
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q3 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Is there free Wi-Fi?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Yes! Free Wi-Fi is available. Just ask a staff member for the password when you arrive.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [3] FAQ p.3
+          </div>
+        </div>
+      </div>
+    </div>
+              </div>
+              <!-- 入力欄 -->
+              <div class="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex gap-2">
+                <div class="flex-1 rounded-xl bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm text-gray-400">…</div>
+                <div class="w-9 h-9 rounded-xl flex items-center justify-center text-white shrink-0" style="background:#4d8f7f">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CTA ── -->
+    <section class="py-20 sm:py-28 text-white" style="background:#4d8f7f">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">Set It Up on Your Site</h2>
+        <p class="text-lg mb-8 opacity-85">Same steps as Sakura used. Free and open source.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="#steps"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-white font-semibold text-base transition-all hover:bg-gray-50 hover:-translate-y-0.5 shadow-xl"
+             style="color:#4d8f7f">
+            Get Started
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+          </a>
+          <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl font-semibold text-base border border-white/30 hover:bg-white/10 transition-all">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ── Footer ── -->
+  <footer class="bg-gray-950 text-gray-400 py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 text-sm">
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+          <span class="text-white font-bold">NeNe Corpus</span>
+        </div>
+        <p class="text-gray-500">Powered by <a href="https://nene2.dev" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">NENE2</a> · © <a href="https://ayane.co.jp" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">AYANE</a> All rights reserved.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener" class="flex items-center gap-1.5 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+        <span class="text-gray-700">·</span>
+        <span>MIT License</span>
+        <span class="text-gray-700">·</span>
+        <a href="#" class="hover:text-white transition-colors">Back to top ↑</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // ── ダークモードトグル ──────────────────────────────────
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('guide-theme', isDark ? 'dark' : 'light');
+      document.getElementById('icon-moon').classList.toggle('hidden', isDark);
+      document.getElementById('icon-sun').classList.toggle('hidden', !isDark);
+    }
+    (function(){
+      if (document.documentElement.classList.contains('dark')) {
+        document.getElementById('icon-moon').classList.add('hidden');
+        document.getElementById('icon-sun').classList.remove('hidden');
+      }
+    })();
+
+    // ── 言語プルダウン ──────────────────────────────────────
+    function toggleLangMenu(e) {
+      e.stopPropagation();
+      document.getElementById('lang-menu').classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      var dd = document.getElementById('lang-dropdown');
+      if (dd && !dd.contains(e.target)) {
+        document.getElementById('lang-menu').classList.remove('open');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public_html/guide/howto/fr/index.html
+++ b/public_html/guide/howto/fr/index.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Guide d'installation — NeNe Corpus HOWTO</title>
+  <meta name="description" content="Suivez Sakura, propriétaire d'un café, et configurez NeNe Corpus en 4 étapes — de l'installation à la mise en ligne du chat IA."/>
+  <meta property="og:title" content="Guide d'installation — NeNe Corpus HOWTO"/>
+  <meta property="og:description" content="Suivez Sakura, propriétaire d'un café, et configurez NeNe Corpus en 4 étapes — de l'installation à la mise en ligne du chat IA."/>
+  <meta property="og:type" content="website"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>
+  <!-- ダークモード初期化: flash を防ぐため CDN より先に実行 -->
+  <script>
+    (function(){
+      var s = localStorage.getItem('guide-theme');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <!-- Tailwind Play CDN v3: CDN を先に読み込み、その後 tailwind.config を設定する -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    /* Tailwind Play CDN v3: tailwind.config は CDN 読み込み後に設定する */
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:'#4d8f7f', dark:'#3a6e62', light:'#e6f2ef' },
+          },
+          fontFamily: {
+            sans: ['Inter','system-ui','sans-serif'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    html { scroll-behavior:smooth; }
+    body { font-family: "Inter", system-ui, sans-serif, sans-serif; }
+    details summary::-webkit-details-marker { display:none; }
+    pre code { font-family:'Menlo','Monaco','Consolas',monospace; }
+    /* lang dropdown */
+    #lang-menu { display:none; }
+    #lang-menu.open { display:block; }
+    /* デモチャット吹き出し装飾 */
+    .chat-phone { background:white; border-radius:2rem; overflow:hidden; border:2px solid #e2e8f0; box-shadow:0 25px 60px -10px rgba(0,0,0,.18); }
+    html.dark .chat-phone { background:#1e293b; border-color:#334155; }
+    /* persona card */
+    .persona-card { background:linear-gradient(135deg,#e6f2ef 0%,#e6f2ef80 100%); }
+    html.dark .persona-card { background:linear-gradient(135deg,rgba(77,143,127,.18) 0%,rgba(77,143,127,.06) 100%); border-color:rgba(77,143,127,.35); }
+  </style>
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased transition-colors duration-200">
+
+  <!-- ── Nav ── -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+      <!-- ロゴ -->
+      <a href="../../fr/" class="flex items-center gap-2 font-bold text-gray-900 dark:text-white text-base shrink-0 hover:opacity-80 transition-opacity">
+        <span class="w-7 h-7 rounded-lg flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+        NeNe Corpus
+      </a>
+      <!-- 戻るリンク -->
+      <a href="../../fr/" class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Retour au Guide
+      </a>
+
+      <div class="flex items-center gap-1.5 sm:gap-2 ml-auto">
+        <!-- 言語プルダウン -->
+        <div class="relative" id="lang-dropdown">
+          <button onclick="toggleLangMenu(event)"
+                  class="flex items-center gap-1 px-2.5 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+            <span class="hidden sm:inline font-medium">Français</span>
+            <svg class="w-3 h-3 shrink-0 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+          </button>
+          <div id="lang-menu"
+               class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-36 z-50">
+            <a href="../ja/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>日本語
+         </a><a href="../en/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>English
+         </a><a href="../de/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Deutsch
+         </a><span class="flex items-center gap-2 px-4 py-2 text-sm font-semibold" style="color:#4d8f7f">
+           <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>Français
+         </span><a href="../zh-hans/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>中文
+         </a><a href="../pt-br/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Português
+         </a>
+          </div>
+        </div>
+
+        <!-- ダークモードトグル -->
+        <button onclick="toggleTheme()"
+                class="p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode">
+          <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          <svg id="icon-sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        </button>
+
+        <!-- GitHub -->
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ── Hero ── -->
+    <section class="pt-14 pb-12 sm:pt-20 sm:pb-16 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- テキスト -->
+          <div>
+            <span class="inline-flex items-center gap-2 mb-5 px-3.5 py-1.5 rounded-full text-sm font-medium border"
+                  style="color:#4d8f7f;border-color:#e6f2ef;background:#e6f2ef">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+              Guide d'installation · ~15 minutes
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-gray-950 dark:text-white leading-[1.15] tracking-tight mb-5">
+              Configurer NeNe Corpus<br>Avec un Persona
+            </h1>
+            <p class="text-lg text-gray-500 dark:text-gray-400 leading-relaxed mb-8">
+              Accompagnez Sakura, propriétaire d'un café, et ajoutez un chat IA à votre site en 4 étapes simples.
+            </p>
+            <a href="#steps"
+               class="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl text-white text-base font-semibold shadow-lg transition-all hover:opacity-90 hover:shadow-xl hover:-translate-y-0.5"
+               style="background:#4d8f7f">
+              Commencer l'installation
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            </a>
+          </div>
+
+          <!-- ペルソナカード -->
+          <div class="flex justify-center lg:justify-end">
+            <div class="persona-card border rounded-3xl p-8 max-w-xs w-full shadow-xl">
+              <!-- アバター + 名前 -->
+              <div class="flex items-center gap-4 mb-5">
+                <div class="w-16 h-16 rounded-2xl text-white text-2xl font-black flex items-center justify-center shadow-lg" style="background:#4d8f7f">
+                  S
+                </div>
+                <div>
+                  <p class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakura</p>
+                  <span class="inline-block mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold text-white" style="background:#4d8f7f">Propriétaire du café</span>
+                </div>
+              </div>
+              <!-- 店名 -->
+              <p class="text-sm font-medium mb-4" style="color:#4d8f7f">📍 Café Sakura</p>
+              <!-- 吹き出しイントロ -->
+              <div class="relative rounded-2xl rounded-tl-none bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 px-4 py-3 shadow-sm">
+                <span class="absolute -top-2.5 left-4 text-white text-base leading-none" style="text-shadow:0 1px 2px rgba(0,0,0,.1)">▾</span>
+                <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Bonjour ! Je suis Sakura et je gère le Café Sakura. Je voulais ajouter un chat IA sur mon site pour que les visiteurs puissent poser des questions à tout moment. Faisons-le ensemble !</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── セットアップステップ ── -->
+    <section id="steps" class="py-16 sm:py-24 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-14">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">Terminé en 4 étapes</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg">Suivez Sakura de l'installation à la publication du widget.</p>
+        </div>
+        <!-- タイムライン -->
+        <div>
+          
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">1</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Installer</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              D'abord, il faut juste déposer les fichiers sur le serveur. Ça semble technique, mais on peut tout faire avec FTP — sans coder ! 😊
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Téléchargez le dernier ZIP depuis GitHub Releases</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Décompressez le ZIP et déposez le contenu dans <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">public_html</code></span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Ouvrez <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">https://votre-domaine.fr/install</code> dans le navigateur</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Saisissez vos informations de base de données et cliquez sur « Installer »</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">2</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Configurer la clé API</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Créez un compte Anthropic et obtenez une clé API. Une fois configurée, l'IA est opérationnelle ! ✨
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Créez un compte sur Anthropic (console.anthropic.com)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Générez une nouvelle clé API et copiez-la</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Ouvrez Admin → Paramètres → onglet LLM</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Collez la clé, cliquez « Tester la connexion » → « Enregistrer »</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">3</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Ajouter du contenu</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Déposez simplement votre menu PDF ou votre FAQ. C'est ça qui devient la base de connaissance de l'IA ! 📄
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Dans l'interface Admin, cliquez sur « Ajouter du contenu »</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Sélectionnez vos fichiers PDF, CSV ou texte et envoyez-les</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Attendez que le statut affiche « Terminé » (quelques secondes à minutes)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Menus, FAQ, infos boutique — ajoutez autant de fichiers que nécessaire</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">4</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Intégrer le widget</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Copiez une seule ligne de code et collez-la sur votre site ! Le chat est en ligne. 🎉
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Ouvrez Admin → Paramètres → onglet Design</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Copiez le code dans la section « Code d'intégration »</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Collez-le juste avant <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">&lt;/body&gt;</code> dans votre HTML</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Rechargez la page — une icône de chat apparaît en bas à droite !</span>
+      </li>
+            </ul>
+            
+      <div class="mt-5">
+        <pre class="rounded-2xl bg-gray-900 text-green-300 text-xs p-5 overflow-x-auto leading-relaxed font-mono shadow-inner border border-gray-800"><code>&lt;script
+  src="https://your-domain.com/widget.js"
+  data-nene-corpus
+&gt;&lt;/script&gt;</code></pre>
+      </div>
+          </div>
+        </div>
+      </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── デモチャット ── -->
+    <section class="py-16 sm:py-24 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-12">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">Voyez-le en action</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg max-w-xl mx-auto">Voici ce que vivent les visiteurs du Café Sakura. Questions répondues avec citations instantanément.</p>
+        </div>
+
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- 説明テキスト -->
+          <div class="space-y-5 order-2 lg:order-1">
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">📄</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Les réponses viennent de vos fichiers chargés</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Menu, FAQ, infos boutique — tout ce que vous chargez devient la base de connaissances.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">🔖</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Chaque réponse inclut des citations</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Les badges de citation indiquent exactement de quel document et quelle page provient la réponse.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">⚡</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Réponses automatiques 24h/24</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Les visiteurs obtiennent des réponses instantanées à tout moment depuis votre contenu.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- デモチャット画面 -->
+          <div class="order-1 lg:order-2 flex justify-center">
+            <div class="chat-phone w-full max-w-sm">
+              <!-- チャットヘッダー -->
+              <div class="px-5 py-4 flex items-center gap-3" style="background:#4d8f7f">
+                <div class="w-9 h-9 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-black">N</div>
+                <div>
+                  <p class="text-white font-bold text-sm">NeNe Corpus</p>
+                  <p class="text-white/75 text-xs">Café Sakura</p>
+                </div>
+              </div>
+              <!-- チャットボディ -->
+              <div class="px-4 py-5 space-y-5 bg-white dark:bg-gray-900 min-h-64">
+                
+    <!-- Q1 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Combien coûte le latte matcha ?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Le latte matcha est à 5,80 € TTC.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [1] Menu p.2
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q2 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Peut-on réserver une table en terrasse ?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Les tables en terrasse peuvent être réservées pour 4 personnes maximum, par téléphone ou formulaire web.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [2] Infos p.1
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q3 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Y a-t-il le Wi-Fi gratuit ?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Oui ! Le Wi-Fi gratuit est disponible. Demandez le mot de passe à notre personnel à l'accueil.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [3] FAQ p.3
+          </div>
+        </div>
+      </div>
+    </div>
+              </div>
+              <!-- 入力欄 -->
+              <div class="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex gap-2">
+                <div class="flex-1 rounded-xl bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm text-gray-400">…</div>
+                <div class="w-9 h-9 rounded-xl flex items-center justify-center text-white shrink-0" style="background:#4d8f7f">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CTA ── -->
+    <section class="py-20 sm:py-28 text-white" style="background:#4d8f7f">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">Installez-le sur votre site</h2>
+        <p class="text-lg mb-8 opacity-85">Mêmes étapes que Sakura. Gratuit et open source.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="#steps"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-white font-semibold text-base transition-all hover:bg-gray-50 hover:-translate-y-0.5 shadow-xl"
+             style="color:#4d8f7f">
+            Commencer
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+          </a>
+          <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl font-semibold text-base border border-white/30 hover:bg-white/10 transition-all">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ── Footer ── -->
+  <footer class="bg-gray-950 text-gray-400 py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 text-sm">
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+          <span class="text-white font-bold">NeNe Corpus</span>
+        </div>
+        <p class="text-gray-500">Powered by <a href="https://nene2.dev" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">NENE2</a> · © <a href="https://ayane.co.jp" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">AYANE</a> All rights reserved.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener" class="flex items-center gap-1.5 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+        <span class="text-gray-700">·</span>
+        <span>Licence MIT</span>
+        <span class="text-gray-700">·</span>
+        <a href="#" class="hover:text-white transition-colors">Haut de page ↑</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // ── ダークモードトグル ──────────────────────────────────
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('guide-theme', isDark ? 'dark' : 'light');
+      document.getElementById('icon-moon').classList.toggle('hidden', isDark);
+      document.getElementById('icon-sun').classList.toggle('hidden', !isDark);
+    }
+    (function(){
+      if (document.documentElement.classList.contains('dark')) {
+        document.getElementById('icon-moon').classList.add('hidden');
+        document.getElementById('icon-sun').classList.remove('hidden');
+      }
+    })();
+
+    // ── 言語プルダウン ──────────────────────────────────────
+    function toggleLangMenu(e) {
+      e.stopPropagation();
+      document.getElementById('lang-menu').classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      var dd = document.getElementById('lang-dropdown');
+      if (dd && !dd.contains(e.target)) {
+        document.getElementById('lang-menu').classList.remove('open');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public_html/guide/howto/index.html
+++ b/public_html/guide/howto/index.html
@@ -1,0 +1,7 @@
+<!doctype html><html><head><meta charset="UTF-8"/><title>NeNe Corpus — Setup Guide</title>
+<script>(function(){var l=(navigator.language||'en').toLowerCase(),locale='en';
+if(l.startsWith('ja'))locale='ja';else if(l.startsWith('de'))locale='de';
+else if(l.startsWith('fr'))locale='fr';else if(l.startsWith('zh'))locale='zh-hans';
+else if(l.startsWith('pt'))locale='pt-br';
+window.location.replace(locale+'/');})();</script>
+</head><body></body></html>

--- a/public_html/guide/howto/ja/index.html
+++ b/public_html/guide/howto/ja/index.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>セットアップガイド — NeNe Corpus HOWTO</title>
+  <meta name="description" content="カフェオーナーのさくらさんといっしょに NeNe Corpus のセットアップを体験。インストールから AI チャット公開まで 4 ステップで完了。"/>
+  <meta property="og:title" content="セットアップガイド — NeNe Corpus HOWTO"/>
+  <meta property="og:description" content="カフェオーナーのさくらさんといっしょに NeNe Corpus のセットアップを体験。インストールから AI チャット公開まで 4 ステップで完了。"/>
+  <meta property="og:type" content="website"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet"/>
+  <!-- ダークモード初期化: flash を防ぐため CDN より先に実行 -->
+  <script>
+    (function(){
+      var s = localStorage.getItem('guide-theme');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <!-- Tailwind Play CDN v3: CDN を先に読み込み、その後 tailwind.config を設定する -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    /* Tailwind Play CDN v3: tailwind.config は CDN 読み込み後に設定する */
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:'#4d8f7f', dark:'#3a6e62', light:'#e6f2ef' },
+          },
+          fontFamily: {
+            sans: ['Noto Sans JP','system-ui','sans-serif'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    html { scroll-behavior:smooth; }
+    body { font-family: "Noto Sans JP", system-ui, sans-serif, sans-serif; }
+    details summary::-webkit-details-marker { display:none; }
+    pre code { font-family:'Menlo','Monaco','Consolas',monospace; }
+    /* lang dropdown */
+    #lang-menu { display:none; }
+    #lang-menu.open { display:block; }
+    /* デモチャット吹き出し装飾 */
+    .chat-phone { background:white; border-radius:2rem; overflow:hidden; border:2px solid #e2e8f0; box-shadow:0 25px 60px -10px rgba(0,0,0,.18); }
+    html.dark .chat-phone { background:#1e293b; border-color:#334155; }
+    /* persona card */
+    .persona-card { background:linear-gradient(135deg,#e6f2ef 0%,#e6f2ef80 100%); }
+    html.dark .persona-card { background:linear-gradient(135deg,rgba(77,143,127,.18) 0%,rgba(77,143,127,.06) 100%); border-color:rgba(77,143,127,.35); }
+  </style>
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased transition-colors duration-200">
+
+  <!-- ── Nav ── -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+      <!-- ロゴ -->
+      <a href="../../ja/" class="flex items-center gap-2 font-bold text-gray-900 dark:text-white text-base shrink-0 hover:opacity-80 transition-opacity">
+        <span class="w-7 h-7 rounded-lg flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+        NeNe Corpus
+      </a>
+      <!-- 戻るリンク -->
+      <a href="../../ja/" class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        ガイドに戻る
+      </a>
+
+      <div class="flex items-center gap-1.5 sm:gap-2 ml-auto">
+        <!-- 言語プルダウン -->
+        <div class="relative" id="lang-dropdown">
+          <button onclick="toggleLangMenu(event)"
+                  class="flex items-center gap-1 px-2.5 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+            <span class="hidden sm:inline font-medium">日本語</span>
+            <svg class="w-3 h-3 shrink-0 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+          </button>
+          <div id="lang-menu"
+               class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-36 z-50">
+            <span class="flex items-center gap-2 px-4 py-2 text-sm font-semibold" style="color:#4d8f7f">
+           <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>日本語
+         </span><a href="../en/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>English
+         </a><a href="../de/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Deutsch
+         </a><a href="../fr/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Français
+         </a><a href="../zh-hans/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>中文
+         </a><a href="../pt-br/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Português
+         </a>
+          </div>
+        </div>
+
+        <!-- ダークモードトグル -->
+        <button onclick="toggleTheme()"
+                class="p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode">
+          <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          <svg id="icon-sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        </button>
+
+        <!-- GitHub -->
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ── Hero ── -->
+    <section class="pt-14 pb-12 sm:pt-20 sm:pb-16 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- テキスト -->
+          <div>
+            <span class="inline-flex items-center gap-2 mb-5 px-3.5 py-1.5 rounded-full text-sm font-medium border"
+                  style="color:#4d8f7f;border-color:#e6f2ef;background:#e6f2ef">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+              セットアップガイド · 所要時間 約15分
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-gray-950 dark:text-white leading-[1.15] tracking-tight mb-5">
+              ペルソナで学ぶ<br>NeNe Corpus セットアップ
+            </h1>
+            <p class="text-lg text-gray-500 dark:text-gray-400 leading-relaxed mb-8">
+              カフェオーナーのさくらさんといっしょに、4 つのステップでウェブサイトに AI チャットを設置してみましょう。
+            </p>
+            <a href="#steps"
+               class="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl text-white text-base font-semibold shadow-lg transition-all hover:opacity-90 hover:shadow-xl hover:-translate-y-0.5"
+               style="background:#4d8f7f">
+              セットアップをはじめる
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            </a>
+          </div>
+
+          <!-- ペルソナカード -->
+          <div class="flex justify-center lg:justify-end">
+            <div class="persona-card border rounded-3xl p-8 max-w-xs w-full shadow-xl">
+              <!-- アバター + 名前 -->
+              <div class="flex items-center gap-4 mb-5">
+                <div class="w-16 h-16 rounded-2xl text-white text-2xl font-black flex items-center justify-center shadow-lg" style="background:#4d8f7f">
+                  S
+                </div>
+                <div>
+                  <p class="text-xl font-bold text-gray-900 dark:text-gray-100">さくら</p>
+                  <span class="inline-block mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold text-white" style="background:#4d8f7f">カフェオーナー</span>
+                </div>
+              </div>
+              <!-- 店名 -->
+              <p class="text-sm font-medium mb-4" style="color:#4d8f7f">📍 さくらカフェ</p>
+              <!-- 吹き出しイントロ -->
+              <div class="relative rounded-2xl rounded-tl-none bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 px-4 py-3 shadow-sm">
+                <span class="absolute -top-2.5 left-4 text-white text-base leading-none" style="text-shadow:0 1px 2px rgba(0,0,0,.1)">▾</span>
+                <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">はじめまして！さくらカフェを経営しているさくらです。ホームページに AI チャットを設置してみたくて、NeNe Corpus を使ってみることにしました。いっしょにやってみましょう！</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── セットアップステップ ── -->
+    <section id="steps" class="py-16 sm:py-24 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-14">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">4 ステップで完了</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg">インストールからウィジェット公開まで、さくらさんに付き合いながら進めましょう。</p>
+        </div>
+        <!-- タイムライン -->
+        <div>
+          
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">1</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">インストールしよう</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              まずはファイルをサーバーにアップロードするだけ！難しそうに聞こえるけど、FTP でできるから大丈夫よ 😊
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">GitHub の Releases から最新の ZIP をダウンロードします</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">ZIP を展開して、中身を <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">public_html</code> にアップロードします</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">ブラウザで <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">https://あなたのドメイン/install</code> を開きます</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">データベース接続情報を入力して「インストール実行」をクリックします</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">2</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">API キーを設定しよう</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Anthropic のアカウントを作って API キーを取得するだけ。これを設定すれば AI が動くようになるよ ✨
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Anthropic (console.anthropic.com) でアカウントを作成・ログインします</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">API Keys ページで新しいキーを発行してコピーします</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">管理画面 → 設定アイコン → LLM タブを開きます</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">API キーを貼り付けて「接続テスト」→「保存」をクリックします</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">3</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">コンテンツをアップロードしよう</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              メニュー PDF や FAQ テキストをアップロードするだけ！これが AI が答えてくれるコンテンツになるの 📄
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">管理画面 → 「コンテンツ追加」ボタンをクリックします</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">PDF・CSV・テキストファイルを選択してアップロードします</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">ステータスが「完了」になるまで待ちます（数秒〜数分）</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">メニュー・FAQ・店舗情報などを複数まとめて追加できます</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">4</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">ウィジェットを埋め込もう</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              たった 1 行のコードをコピペするだけ！これでホームページにチャットが現れるよ 🎉
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">管理画面 → 設定 → デザインタブを開きます</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">「埋め込みコード」セクションのコードをコピーします</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">ホームページの HTML の <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">&lt;/body&gt;</code> 直前に貼り付けます</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">ページをリロード → 右下にチャットアイコンが現れたら完了です！</span>
+      </li>
+            </ul>
+            
+      <div class="mt-5">
+        <pre class="rounded-2xl bg-gray-900 text-green-300 text-xs p-5 overflow-x-auto leading-relaxed font-mono shadow-inner border border-gray-800"><code>&lt;script
+  src="https://your-domain.com/widget.js"
+  data-nene-corpus
+&gt;&lt;/script&gt;</code></pre>
+      </div>
+          </div>
+        </div>
+      </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── デモチャット ── -->
+    <section class="py-16 sm:py-24 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-12">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">こんな会話ができます</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg max-w-xl mx-auto">さくらカフェに設置したらこんな感じ。訪問者の質問に出典付きで即答します。</p>
+        </div>
+
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- 説明テキスト -->
+          <div class="space-y-5 order-2 lg:order-1">
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">📄</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">アップロードしたファイルから答えます</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">メニュー・FAQ・店舗情報など、アップロードしたドキュメントの内容をもとに回答します。</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">🔖</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">出典が必ず付きます</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">どのドキュメントの何ページに書いてあるかを引用バッジで表示。信頼性を担保します。</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">⚡</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">24時間自動応答</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">訪問者がいつ来ても、設置したコンテンツから自動で回答します。</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- デモチャット画面 -->
+          <div class="order-1 lg:order-2 flex justify-center">
+            <div class="chat-phone w-full max-w-sm">
+              <!-- チャットヘッダー -->
+              <div class="px-5 py-4 flex items-center gap-3" style="background:#4d8f7f">
+                <div class="w-9 h-9 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-black">N</div>
+                <div>
+                  <p class="text-white font-bold text-sm">NeNe Corpus</p>
+                  <p class="text-white/75 text-xs">さくらカフェ</p>
+                </div>
+              </div>
+              <!-- チャットボディ -->
+              <div class="px-4 py-5 space-y-5 bg-white dark:bg-gray-900 min-h-64">
+                
+    <!-- Q1 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          抹茶ラテって何円ですか？
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            抹茶ラテは税込 580 円でご提供しています。
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [1] メニュー p.2
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q2 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          テラス席の予約はできますか？
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            テラス席は4名様まで事前予約を承っています。お電話またはウェブフォームからどうぞ。
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [2] 店舗情報 p.1
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q3 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Wi-Fi はありますか？
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            フリー Wi-Fi をご利用いただけます。パスワードはご来店時にスタッフまでお声がけください。
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [3] FAQ p.3
+          </div>
+        </div>
+      </div>
+    </div>
+              </div>
+              <!-- 入力欄 -->
+              <div class="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex gap-2">
+                <div class="flex-1 rounded-xl bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm text-gray-400">…</div>
+                <div class="w-9 h-9 rounded-xl flex items-center justify-center text-white shrink-0" style="background:#4d8f7f">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CTA ── -->
+    <section class="py-20 sm:py-28 text-white" style="background:#4d8f7f">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">あなたのサイトにも設置してみよう</h2>
+        <p class="text-lg mb-8 opacity-85">さくらさんと同じ手順で、今すぐはじめられます。無料の OSS です。</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="#steps"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-white font-semibold text-base transition-all hover:bg-gray-50 hover:-translate-y-0.5 shadow-xl"
+             style="color:#4d8f7f">
+            はじめる
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+          </a>
+          <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl font-semibold text-base border border-white/30 hover:bg-white/10 transition-all">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ── Footer ── -->
+  <footer class="bg-gray-950 text-gray-400 py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 text-sm">
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+          <span class="text-white font-bold">NeNe Corpus</span>
+        </div>
+        <p class="text-gray-500">Powered by <a href="https://nene2.dev" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">NENE2</a> · © <a href="https://ayane.co.jp" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">AYANE</a> All rights reserved.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener" class="flex items-center gap-1.5 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+        <span class="text-gray-700">·</span>
+        <span>MIT ライセンス</span>
+        <span class="text-gray-700">·</span>
+        <a href="#" class="hover:text-white transition-colors">ページ上部へ ↑</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // ── ダークモードトグル ──────────────────────────────────
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('guide-theme', isDark ? 'dark' : 'light');
+      document.getElementById('icon-moon').classList.toggle('hidden', isDark);
+      document.getElementById('icon-sun').classList.toggle('hidden', !isDark);
+    }
+    (function(){
+      if (document.documentElement.classList.contains('dark')) {
+        document.getElementById('icon-moon').classList.add('hidden');
+        document.getElementById('icon-sun').classList.remove('hidden');
+      }
+    })();
+
+    // ── 言語プルダウン ──────────────────────────────────────
+    function toggleLangMenu(e) {
+      e.stopPropagation();
+      document.getElementById('lang-menu').classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      var dd = document.getElementById('lang-dropdown');
+      if (dd && !dd.contains(e.target)) {
+        document.getElementById('lang-menu').classList.remove('open');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public_html/guide/howto/pt-br/index.html
+++ b/public_html/guide/howto/pt-br/index.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Guia de Instalação — NeNe Corpus HOWTO</title>
+  <meta name="description" content="Siga a Sakura, dona de um café, e configure o NeNe Corpus em 4 passos — da instalação ao chat de IA no ar."/>
+  <meta property="og:title" content="Guia de Instalação — NeNe Corpus HOWTO"/>
+  <meta property="og:description" content="Siga a Sakura, dona de um café, e configure o NeNe Corpus em 4 passos — da instalação ao chat de IA no ar."/>
+  <meta property="og:type" content="website"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>
+  <!-- ダークモード初期化: flash を防ぐため CDN より先に実行 -->
+  <script>
+    (function(){
+      var s = localStorage.getItem('guide-theme');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <!-- Tailwind Play CDN v3: CDN を先に読み込み、その後 tailwind.config を設定する -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    /* Tailwind Play CDN v3: tailwind.config は CDN 読み込み後に設定する */
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:'#4d8f7f', dark:'#3a6e62', light:'#e6f2ef' },
+          },
+          fontFamily: {
+            sans: ['Inter','system-ui','sans-serif'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    html { scroll-behavior:smooth; }
+    body { font-family: "Inter", system-ui, sans-serif, sans-serif; }
+    details summary::-webkit-details-marker { display:none; }
+    pre code { font-family:'Menlo','Monaco','Consolas',monospace; }
+    /* lang dropdown */
+    #lang-menu { display:none; }
+    #lang-menu.open { display:block; }
+    /* デモチャット吹き出し装飾 */
+    .chat-phone { background:white; border-radius:2rem; overflow:hidden; border:2px solid #e2e8f0; box-shadow:0 25px 60px -10px rgba(0,0,0,.18); }
+    html.dark .chat-phone { background:#1e293b; border-color:#334155; }
+    /* persona card */
+    .persona-card { background:linear-gradient(135deg,#e6f2ef 0%,#e6f2ef80 100%); }
+    html.dark .persona-card { background:linear-gradient(135deg,rgba(77,143,127,.18) 0%,rgba(77,143,127,.06) 100%); border-color:rgba(77,143,127,.35); }
+  </style>
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased transition-colors duration-200">
+
+  <!-- ── Nav ── -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+      <!-- ロゴ -->
+      <a href="../../pt-br/" class="flex items-center gap-2 font-bold text-gray-900 dark:text-white text-base shrink-0 hover:opacity-80 transition-opacity">
+        <span class="w-7 h-7 rounded-lg flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+        NeNe Corpus
+      </a>
+      <!-- 戻るリンク -->
+      <a href="../../pt-br/" class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Voltar ao Guia
+      </a>
+
+      <div class="flex items-center gap-1.5 sm:gap-2 ml-auto">
+        <!-- 言語プルダウン -->
+        <div class="relative" id="lang-dropdown">
+          <button onclick="toggleLangMenu(event)"
+                  class="flex items-center gap-1 px-2.5 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+            <span class="hidden sm:inline font-medium">Português</span>
+            <svg class="w-3 h-3 shrink-0 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+          </button>
+          <div id="lang-menu"
+               class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-36 z-50">
+            <a href="../ja/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>日本語
+         </a><a href="../en/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>English
+         </a><a href="../de/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Deutsch
+         </a><a href="../fr/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Français
+         </a><a href="../zh-hans/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>中文
+         </a><span class="flex items-center gap-2 px-4 py-2 text-sm font-semibold" style="color:#4d8f7f">
+           <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>Português
+         </span>
+          </div>
+        </div>
+
+        <!-- ダークモードトグル -->
+        <button onclick="toggleTheme()"
+                class="p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode">
+          <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          <svg id="icon-sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        </button>
+
+        <!-- GitHub -->
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ── Hero ── -->
+    <section class="pt-14 pb-12 sm:pt-20 sm:pb-16 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- テキスト -->
+          <div>
+            <span class="inline-flex items-center gap-2 mb-5 px-3.5 py-1.5 rounded-full text-sm font-medium border"
+                  style="color:#4d8f7f;border-color:#e6f2ef;background:#e6f2ef">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+              Guia de Instalação · ~15 minutos
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-gray-950 dark:text-white leading-[1.15] tracking-tight mb-5">
+              Configure o NeNe Corpus<br>Com Persona
+            </h1>
+            <p class="text-lg text-gray-500 dark:text-gray-400 leading-relaxed mb-8">
+              Acompanhe a Sakura, dona de um café, e adicione o chat de IA ao seu site em 4 passos simples.
+            </p>
+            <a href="#steps"
+               class="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl text-white text-base font-semibold shadow-lg transition-all hover:opacity-90 hover:shadow-xl hover:-translate-y-0.5"
+               style="background:#4d8f7f">
+              Iniciar Configuração
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            </a>
+          </div>
+
+          <!-- ペルソナカード -->
+          <div class="flex justify-center lg:justify-end">
+            <div class="persona-card border rounded-3xl p-8 max-w-xs w-full shadow-xl">
+              <!-- アバター + 名前 -->
+              <div class="flex items-center gap-4 mb-5">
+                <div class="w-16 h-16 rounded-2xl text-white text-2xl font-black flex items-center justify-center shadow-lg" style="background:#4d8f7f">
+                  S
+                </div>
+                <div>
+                  <p class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakura</p>
+                  <span class="inline-block mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold text-white" style="background:#4d8f7f">Dona do Café</span>
+                </div>
+              </div>
+              <!-- 店名 -->
+              <p class="text-sm font-medium mb-4" style="color:#4d8f7f">📍 Café Sakura</p>
+              <!-- 吹き出しイントロ -->
+              <div class="relative rounded-2xl rounded-tl-none bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 px-4 py-3 shadow-sm">
+                <span class="absolute -top-2.5 left-4 text-white text-base leading-none" style="text-shadow:0 1px 2px rgba(0,0,0,.1)">▾</span>
+                <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Olá! Eu sou a Sakura e administro o Café Sakura. Queria adicionar um chat de IA ao meu site para que os visitantes possam tirar dúvidas a qualquer hora. Vamos fazer isso juntos!</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── セットアップステップ ── -->
+    <section id="steps" class="py-16 sm:py-24 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-14">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">Pronto em 4 Passos</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg">Siga a Sakura da instalação até a publicação do widget.</p>
+        </div>
+        <!-- タイムライン -->
+        <div>
+          
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">1</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Instalar</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Primeiro você só faz o upload dos arquivos para o servidor. Parece técnico, mas dá para fazer pelo FTP — sem programar! 😊
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Baixe o ZIP mais recente do GitHub Releases</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Extraia o ZIP e envie o conteúdo para <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">public_html</code></span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Abra <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">https://seu-dominio.com.br/install</code> no navegador</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Informe os dados do banco de dados e clique em "Executar Instalação"</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">2</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Configurar Chave de API</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Crie uma conta na Anthropic e obtenha uma chave de API. Com ela configurada, a IA entra em ação! ✨
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Crie uma conta na Anthropic (console.anthropic.com)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Gere uma nova chave de API e copie-a</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Abra o Admin → Configurações → aba LLM</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Cole a chave, clique em "Testar Conexão" → "Salvar"</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">3</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Adicionar Conteúdo</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Só fazer upload do seu cardápio em PDF ou arquivo de FAQ. Isso vira a base de conhecimento da IA! 📄
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">No painel Admin, clique em "Adicionar Conteúdo"</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Selecione seus arquivos PDF, CSV ou de texto e envie</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Aguarde o status mostrar "Concluído" (leva segundos a minutos)</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Cardápios, FAQs, info da loja — envie quantos arquivos quiser</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">4</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Incorporar o Widget</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              Copie uma linha de código e cole no seu site! O chat vai ao ar na hora. 🎉
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Abra o Admin → Configurações → aba Design</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Copie o código da seção "Código de Incorporação"</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Cole-o logo antes do <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">&lt;/body&gt;</code> no HTML do seu site</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">Recarregue a página — um ícone de chat deve aparecer no canto inferior direito!</span>
+      </li>
+            </ul>
+            
+      <div class="mt-5">
+        <pre class="rounded-2xl bg-gray-900 text-green-300 text-xs p-5 overflow-x-auto leading-relaxed font-mono shadow-inner border border-gray-800"><code>&lt;script
+  src="https://your-domain.com/widget.js"
+  data-nene-corpus
+&gt;&lt;/script&gt;</code></pre>
+      </div>
+          </div>
+        </div>
+      </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── デモチャット ── -->
+    <section class="py-16 sm:py-24 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-12">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">Veja em Ação</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg max-w-xl mx-auto">É assim que os visitantes do Café Sakura experienciam. Perguntas respondidas com citações instantaneamente.</p>
+        </div>
+
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- 説明テキスト -->
+          <div class="space-y-5 order-2 lg:order-1">
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">📄</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Respostas vêm dos seus arquivos carregados</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Menu, FAQ, infos da loja — tudo que você envia vira a base de conhecimento da IA.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">🔖</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Cada resposta inclui citações</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Badges de citação mostram exatamente de qual documento e página vem a resposta.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">⚡</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">Respostas automáticas 24h</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">Visitantes recebem respostas instantâneas a qualquer hora do seu conteúdo.</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- デモチャット画面 -->
+          <div class="order-1 lg:order-2 flex justify-center">
+            <div class="chat-phone w-full max-w-sm">
+              <!-- チャットヘッダー -->
+              <div class="px-5 py-4 flex items-center gap-3" style="background:#4d8f7f">
+                <div class="w-9 h-9 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-black">N</div>
+                <div>
+                  <p class="text-white font-bold text-sm">NeNe Corpus</p>
+                  <p class="text-white/75 text-xs">Café Sakura</p>
+                </div>
+              </div>
+              <!-- チャットボディ -->
+              <div class="px-4 py-5 space-y-5 bg-white dark:bg-gray-900 min-h-64">
+                
+    <!-- Q1 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Quanto custa o latte de matcha?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            O latte de matcha custa R$ 18,90 com impostos.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [1] Cardápio p.2
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q2 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Posso reservar uma mesa na varanda?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            As mesas na varanda comportam até 4 pessoas e podem ser reservadas por telefone ou formulário online.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [2] Info da Loja p.1
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q3 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          Tem Wi-Fi gratuito?
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            Sim! Wi-Fi gratuito disponível. Solicite a senha ao chegar — nossos atendentes terão o prazer em informar.
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [3] FAQ p.3
+          </div>
+        </div>
+      </div>
+    </div>
+              </div>
+              <!-- 入力欄 -->
+              <div class="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex gap-2">
+                <div class="flex-1 rounded-xl bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm text-gray-400">…</div>
+                <div class="w-9 h-9 rounded-xl flex items-center justify-center text-white shrink-0" style="background:#4d8f7f">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CTA ── -->
+    <section class="py-20 sm:py-28 text-white" style="background:#4d8f7f">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">Instale no Seu Site</h2>
+        <p class="text-lg mb-8 opacity-85">Os mesmos passos que a Sakura usou. Gratuito e open source.</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="#steps"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-white font-semibold text-base transition-all hover:bg-gray-50 hover:-translate-y-0.5 shadow-xl"
+             style="color:#4d8f7f">
+            Começar
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+          </a>
+          <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl font-semibold text-base border border-white/30 hover:bg-white/10 transition-all">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ── Footer ── -->
+  <footer class="bg-gray-950 text-gray-400 py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 text-sm">
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+          <span class="text-white font-bold">NeNe Corpus</span>
+        </div>
+        <p class="text-gray-500">Powered by <a href="https://nene2.dev" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">NENE2</a> · © <a href="https://ayane.co.jp" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">AYANE</a> All rights reserved.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener" class="flex items-center gap-1.5 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+        <span class="text-gray-700">·</span>
+        <span>Licença MIT</span>
+        <span class="text-gray-700">·</span>
+        <a href="#" class="hover:text-white transition-colors">Voltar ao topo ↑</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // ── ダークモードトグル ──────────────────────────────────
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('guide-theme', isDark ? 'dark' : 'light');
+      document.getElementById('icon-moon').classList.toggle('hidden', isDark);
+      document.getElementById('icon-sun').classList.toggle('hidden', !isDark);
+    }
+    (function(){
+      if (document.documentElement.classList.contains('dark')) {
+        document.getElementById('icon-moon').classList.add('hidden');
+        document.getElementById('icon-sun').classList.remove('hidden');
+      }
+    })();
+
+    // ── 言語プルダウン ──────────────────────────────────────
+    function toggleLangMenu(e) {
+      e.stopPropagation();
+      document.getElementById('lang-menu').classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      var dd = document.getElementById('lang-dropdown');
+      if (dd && !dd.contains(e.target)) {
+        document.getElementById('lang-menu').classList.remove('open');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public_html/guide/howto/zh-hans/index.html
+++ b/public_html/guide/howto/zh-hans/index.html
@@ -1,0 +1,573 @@
+<!doctype html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>安装指南 — NeNe Corpus HOWTO</title>
+  <meta name="description" content="跟随咖啡馆老板 Sakura，4 步完成 NeNe Corpus 的安装与配置，从安装到 AI 聊天上线。"/>
+  <meta property="og:title" content="安装指南 — NeNe Corpus HOWTO"/>
+  <meta property="og:description" content="跟随咖啡馆老板 Sakura，4 步完成 NeNe Corpus 的安装与配置，从安装到 AI 聊天上线。"/>
+  <meta property="og:type" content="website"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700;900&display=swap" rel="stylesheet"/>
+  <!-- ダークモード初期化: flash を防ぐため CDN より先に実行 -->
+  <script>
+    (function(){
+      var s = localStorage.getItem('guide-theme');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <!-- Tailwind Play CDN v3: CDN を先に読み込み、その後 tailwind.config を設定する -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    /* Tailwind Play CDN v3: tailwind.config は CDN 読み込み後に設定する */
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:'#4d8f7f', dark:'#3a6e62', light:'#e6f2ef' },
+          },
+          fontFamily: {
+            sans: ['Noto Sans SC','system-ui','sans-serif'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    html { scroll-behavior:smooth; }
+    body { font-family: "Noto Sans SC", system-ui, sans-serif, sans-serif; }
+    details summary::-webkit-details-marker { display:none; }
+    pre code { font-family:'Menlo','Monaco','Consolas',monospace; }
+    /* lang dropdown */
+    #lang-menu { display:none; }
+    #lang-menu.open { display:block; }
+    /* デモチャット吹き出し装飾 */
+    .chat-phone { background:white; border-radius:2rem; overflow:hidden; border:2px solid #e2e8f0; box-shadow:0 25px 60px -10px rgba(0,0,0,.18); }
+    html.dark .chat-phone { background:#1e293b; border-color:#334155; }
+    /* persona card */
+    .persona-card { background:linear-gradient(135deg,#e6f2ef 0%,#e6f2ef80 100%); }
+    html.dark .persona-card { background:linear-gradient(135deg,rgba(77,143,127,.18) 0%,rgba(77,143,127,.06) 100%); border-color:rgba(77,143,127,.35); }
+  </style>
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased transition-colors duration-200">
+
+  <!-- ── Nav ── -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+      <!-- ロゴ -->
+      <a href="../../zh-hans/" class="flex items-center gap-2 font-bold text-gray-900 dark:text-white text-base shrink-0 hover:opacity-80 transition-opacity">
+        <span class="w-7 h-7 rounded-lg flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+        NeNe Corpus
+      </a>
+      <!-- 戻るリンク -->
+      <a href="../../zh-hans/" class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        返回指南
+      </a>
+
+      <div class="flex items-center gap-1.5 sm:gap-2 ml-auto">
+        <!-- 言語プルダウン -->
+        <div class="relative" id="lang-dropdown">
+          <button onclick="toggleLangMenu(event)"
+                  class="flex items-center gap-1 px-2.5 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+            <span class="hidden sm:inline font-medium">中文</span>
+            <svg class="w-3 h-3 shrink-0 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+          </button>
+          <div id="lang-menu"
+               class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-36 z-50">
+            <a href="../ja/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>日本語
+         </a><a href="../en/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>English
+         </a><a href="../de/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Deutsch
+         </a><a href="../fr/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Français
+         </a><span class="flex items-center gap-2 px-4 py-2 text-sm font-semibold" style="color:#4d8f7f">
+           <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>中文
+         </span><a href="../pt-br/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>Português
+         </a>
+          </div>
+        </div>
+
+        <!-- ダークモードトグル -->
+        <button onclick="toggleTheme()"
+                class="p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode">
+          <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          <svg id="icon-sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        </button>
+
+        <!-- GitHub -->
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ── Hero ── -->
+    <section class="pt-14 pb-12 sm:pt-20 sm:pb-16 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- テキスト -->
+          <div>
+            <span class="inline-flex items-center gap-2 mb-5 px-3.5 py-1.5 rounded-full text-sm font-medium border"
+                  style="color:#4d8f7f;border-color:#e6f2ef;background:#e6f2ef">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+              安装指南 · 约 15 分钟
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-gray-950 dark:text-white leading-[1.15] tracking-tight mb-5">
+              跟 Persona 一起<br>配置 NeNe Corpus
+            </h1>
+            <p class="text-lg text-gray-500 dark:text-gray-400 leading-relaxed mb-8">
+              跟随咖啡馆老板 Sakura，4 个简单步骤为你的网站添加 AI 聊天功能。
+            </p>
+            <a href="#steps"
+               class="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl text-white text-base font-semibold shadow-lg transition-all hover:opacity-90 hover:shadow-xl hover:-translate-y-0.5"
+               style="background:#4d8f7f">
+              开始配置
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            </a>
+          </div>
+
+          <!-- ペルソナカード -->
+          <div class="flex justify-center lg:justify-end">
+            <div class="persona-card border rounded-3xl p-8 max-w-xs w-full shadow-xl">
+              <!-- アバター + 名前 -->
+              <div class="flex items-center gap-4 mb-5">
+                <div class="w-16 h-16 rounded-2xl text-white text-2xl font-black flex items-center justify-center shadow-lg" style="background:#4d8f7f">
+                  S
+                </div>
+                <div>
+                  <p class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakura</p>
+                  <span class="inline-block mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold text-white" style="background:#4d8f7f">咖啡馆老板</span>
+                </div>
+              </div>
+              <!-- 店名 -->
+              <p class="text-sm font-medium mb-4" style="color:#4d8f7f">📍 Sakura 咖啡馆</p>
+              <!-- 吹き出しイントロ -->
+              <div class="relative rounded-2xl rounded-tl-none bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 px-4 py-3 shadow-sm">
+                <span class="absolute -top-2.5 left-4 text-white text-base leading-none" style="text-shadow:0 1px 2px rgba(0,0,0,.1)">▾</span>
+                <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">大家好！我是 Sakura，经营着 Sakura 咖啡馆。我想在网站上添加 AI 聊天功能，让访客随时都能提问。我们一起来完成吧！</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── セットアップステップ ── -->
+    <section id="steps" class="py-16 sm:py-24 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-14">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">4 步完成</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg">跟随 Sakura 从安装到发布小部件，全程陪伴。</p>
+        </div>
+        <!-- タイムライン -->
+        <div>
+          
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">1</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">安装</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              首先只需将文件上传到服务器。听起来很技术，但用 FTP 就能搞定——不需要写代码！😊
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">从 GitHub Releases 下载最新版 ZIP</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">解压 ZIP，将内容上传到 <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">public_html</code></span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">在浏览器中打开 <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">https://你的域名/install</code></span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">输入数据库信息，点击「运行安装」</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">2</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">配置 API 密钥</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              创建 Anthropic 账号并获取 API 密钥。设置好之后 AI 就能运行了！✨
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">在 Anthropic (console.anthropic.com) 创建账号</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">生成新的 API 密钥并复制</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">打开管理后台 → 设置 → LLM 选项卡</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">粘贴密钥，点击「测试连接」→「保存」</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        <span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">3</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">上传内容</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              只需上传菜单 PDF 或 FAQ 文件，这就成了 AI 的知识库！📄
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">在管理后台点击「添加内容」</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">选择 PDF、CSV 或文本文件并上传</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">等待状态显示「完成」（几秒到几分钟）</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">菜单、FAQ、门店信息——可以上传任意多个文件</span>
+      </li>
+            </ul>
+            
+          </div>
+        </div>
+      </div>
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:#4d8f7f">4</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">嵌入小部件</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:#4d8f7f">S</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:#4d8f7f">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:#4d8f7f"></span>
+              只需复制一行代码粘贴到网站！聊天功能就上线了。🎉
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">1</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">打开管理后台 → 设置 → 设计选项卡</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">2</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">复制「嵌入代码」部分的代码</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">3</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">粘贴到网站 HTML 的 <code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">&lt;/body&gt;</code> 标签之前</span>
+      </li>
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:#4d8f7f;opacity:.8">4</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">刷新页面——右下角出现聊天图标即表示完成！</span>
+      </li>
+            </ul>
+            
+      <div class="mt-5">
+        <pre class="rounded-2xl bg-gray-900 text-green-300 text-xs p-5 overflow-x-auto leading-relaxed font-mono shadow-inner border border-gray-800"><code>&lt;script
+  src="https://your-domain.com/widget.js"
+  data-nene-corpus
+&gt;&lt;/script&gt;</code></pre>
+      </div>
+          </div>
+        </div>
+      </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── デモチャット ── -->
+    <section class="py-16 sm:py-24 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-12">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">效果展示</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg max-w-xl mx-auto">Sakura 咖啡馆访客的实际体验。问题即时得到附带引用的回答。</p>
+        </div>
+
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- 説明テキスト -->
+          <div class="space-y-5 order-2 lg:order-1">
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">📄</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">回答来自您上传的文件</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">菜单、FAQ、门店信息——上传的任何内容都成为 AI 的知识库。</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">🔖</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">每个回答都附带引用</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">引用徽章显示答案来自哪个文档和页面。</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">⚡</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">全天候自动回复</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">无论访客何时到来，都能从您的内容中自动获得即时回答。</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- デモチャット画面 -->
+          <div class="order-1 lg:order-2 flex justify-center">
+            <div class="chat-phone w-full max-w-sm">
+              <!-- チャットヘッダー -->
+              <div class="px-5 py-4 flex items-center gap-3" style="background:#4d8f7f">
+                <div class="w-9 h-9 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-black">N</div>
+                <div>
+                  <p class="text-white font-bold text-sm">NeNe Corpus</p>
+                  <p class="text-white/75 text-xs">Sakura 咖啡馆</p>
+                </div>
+              </div>
+              <!-- チャットボディ -->
+              <div class="px-4 py-5 space-y-5 bg-white dark:bg-gray-900 min-h-64">
+                
+    <!-- Q1 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          抹茶拿铁多少钱？
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            抹茶拿铁含税售价 38 元。
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [1] 菜单 p.2
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q2 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          可以预订露台座位吗？
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            露台座位最多可供 4 人预订，可通过电话或网络表单预约。
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [2] 门店信息 p.1
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Q3 -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:#4d8f7f">
+          有免费 Wi-Fi 吗？
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:#3a6e62">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            有的！提供免费 Wi-Fi，到店后请询问工作人员获取密码。
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:#e6f2ef;border-color:#4d8f7f40;color:#4d8f7f">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [3] FAQ p.3
+          </div>
+        </div>
+      </div>
+    </div>
+              </div>
+              <!-- 入力欄 -->
+              <div class="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex gap-2">
+                <div class="flex-1 rounded-xl bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm text-gray-400">…</div>
+                <div class="w-9 h-9 rounded-xl flex items-center justify-center text-white shrink-0" style="background:#4d8f7f">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CTA ── -->
+    <section class="py-20 sm:py-28 text-white" style="background:#4d8f7f">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">在你的网站上部署</h2>
+        <p class="text-lg mb-8 opacity-85">与 Sakura 相同的步骤。免费开源。</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="#steps"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-white font-semibold text-base transition-all hover:bg-gray-50 hover:-translate-y-0.5 shadow-xl"
+             style="color:#4d8f7f">
+            立即开始
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+          </a>
+          <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl font-semibold text-base border border-white/30 hover:bg-white/10 transition-all">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ── Footer ── -->
+  <footer class="bg-gray-950 text-gray-400 py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 text-sm">
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs font-black" style="background:#4d8f7f">N</span>
+          <span class="text-white font-bold">NeNe Corpus</span>
+        </div>
+        <p class="text-gray-500">Powered by <a href="https://nene2.dev" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">NENE2</a> · © <a href="https://ayane.co.jp" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">AYANE</a> All rights reserved.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href="https://github.com/hideyukiMORI/nene-corpus" target="_blank" rel="noopener" class="flex items-center gap-1.5 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+        <span class="text-gray-700">·</span>
+        <span>MIT 许可证</span>
+        <span class="text-gray-700">·</span>
+        <a href="#" class="hover:text-white transition-colors">返回顶部 ↑</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // ── ダークモードトグル ──────────────────────────────────
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('guide-theme', isDark ? 'dark' : 'light');
+      document.getElementById('icon-moon').classList.toggle('hidden', isDark);
+      document.getElementById('icon-sun').classList.toggle('hidden', !isDark);
+    }
+    (function(){
+      if (document.documentElement.classList.contains('dark')) {
+        document.getElementById('icon-moon').classList.add('hidden');
+        document.getElementById('icon-sun').classList.remove('hidden');
+      }
+    })();
+
+    // ── 言語プルダウン ──────────────────────────────────────
+    function toggleLangMenu(e) {
+      e.stopPropagation();
+      document.getElementById('lang-menu').classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      var dd = document.getElementById('lang-dropdown');
+      if (dd && !dd.contains(e.target)) {
+        document.getElementById('lang-menu').classList.remove('open');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/scripts/build-howto.mjs
+++ b/scripts/build-howto.mjs
@@ -1,0 +1,520 @@
+#!/usr/bin/env node
+/**
+ * build-howto.mjs
+ * ペルソナ駆動型セットアップ HOWTO を 6 か国語で生成して public_html/guide/howto/ に出力する。
+ * ペルソナ: さくら（カフェオーナー）— 吹き出し + チャットデモでセットアップ 4 ステップを体験。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT      = path.resolve(__dirname, '..');
+const OUT       = path.join(ROOT, 'public_html', 'guide', 'howto');
+const GH_URL    = 'https://github.com/hideyukiMORI/nene-corpus';
+
+// ブランドカラー（Admin / LP と合わせる）
+const BRAND      = '#4d8f7f';
+const BRAND_DARK = '#3a6e62';
+const BRAND_LIGHT= '#e6f2ef';
+
+const LOCALES = [
+  { id: 'ja',      lang: 'ja',      label: '日本語',    googleFont: 'Noto+Sans+JP:wght@400;500;700;900',     fontFamily: '"Noto Sans JP", system-ui, sans-serif' },
+  { id: 'en',      lang: 'en',      label: 'English',   googleFont: 'Inter:wght@400;500;600;700;800;900',    fontFamily: '"Inter", system-ui, sans-serif' },
+  { id: 'de',      lang: 'de',      label: 'Deutsch',   googleFont: 'Inter:wght@400;500;600;700;800;900',    fontFamily: '"Inter", system-ui, sans-serif' },
+  { id: 'fr',      lang: 'fr',      label: 'Français',  googleFont: 'Inter:wght@400;500;600;700;800;900',    fontFamily: '"Inter", system-ui, sans-serif' },
+  { id: 'zh-hans', lang: 'zh-Hans', label: '中文',      googleFont: 'Noto+Sans+SC:wght@400;500;700;900',    fontFamily: '"Noto Sans SC", system-ui, sans-serif' },
+  { id: 'pt-br',   lang: 'pt-BR',   label: 'Português', googleFont: 'Inter:wght@400;500;600;700;800;900',    fontFamily: '"Inter", system-ui, sans-serif' },
+];
+
+// ── ユーティリティ ─────────────────────────────────────────────────────────────
+
+/**
+ * バッククォート `...` → <code> タグ（中身をHTMLエスケープ）
+ */
+function renderText(str) {
+  return String(str).replace(/`([^`]*)`/g, (_, code) => {
+    const escaped = code.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    return `<code class="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-1.5 py-0.5 rounded text-[0.85em] font-mono">${escaped}</code>`;
+  });
+}
+
+// ── ページ生成 ────────────────────────────────────────────────────────────────
+
+function buildPage(locale, msgs, allLocales) {
+  const t = (key) => renderText(msgs[key] ?? key);
+  const raw = (key) => msgs[key] ?? key; // HTML エスケープなし（attributeで使う）
+
+  // 言語プルダウンのメニューアイテム
+  const langMenuItems = allLocales.map(({ id, label }) =>
+    id === locale.id
+      ? `<span class="flex items-center gap-2 px-4 py-2 text-sm font-semibold" style="color:${BRAND}">
+           <svg class="w-3.5 h-3.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>${label}
+         </span>`
+      : `<a href="../${id}/" class="flex items-center gap-2 px-4 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+           <span class="w-3.5 h-3.5 shrink-0"></span>${label}
+         </a>`
+  ).join('');
+
+  // ── セットアップステップ ──
+  const steps = [1,2,3,4].map(n => {
+    const items = [1,2,3,4].map(i => `
+      <li class="flex items-start gap-2.5">
+        <span class="flex-none w-5 h-5 rounded-full text-white text-xs font-bold flex items-center justify-center mt-0.5 shrink-0" style="background:${BRAND};opacity:.8">${i}</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">${t(`step${n}.item${i}`)}</span>
+      </li>`).join('');
+
+    const embedCode = n === 4 ? `
+      <div class="mt-5">
+        <pre class="rounded-2xl bg-gray-900 text-green-300 text-xs p-5 overflow-x-auto leading-relaxed font-mono shadow-inner border border-gray-800"><code>&lt;script
+  src="https://your-domain.com/widget.js"
+  data-nene-corpus
+&gt;&lt;/script&gt;</code></pre>
+      </div>` : '';
+
+    return `
+      <div class="relative flex gap-6 pb-12 last:pb-0">
+        <!-- 縦線（最後のステップ以外）-->
+        ${n < 4 ? `<span class="absolute left-6 top-14 bottom-0 w-0.5 bg-gradient-to-b from-gray-200 to-transparent dark:from-gray-700" aria-hidden="true"></span>` : ''}
+
+        <!-- ステップ番号バッジ -->
+        <div class="flex-none w-12 h-12 rounded-2xl text-white text-lg font-extrabold flex items-center justify-center shadow-lg shrink-0" style="background:${BRAND}">${n}</div>
+
+        <!-- コンテンツ -->
+        <div class="flex-1 min-w-0 pt-1">
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">${t(`step${n}.title`)}</h3>
+
+          <!-- ペルソナ吹き出し -->
+          <div class="relative mb-5 flex items-start gap-3">
+            <div class="flex-none w-9 h-9 rounded-full text-white text-sm font-black flex items-center justify-center shadow-md shrink-0" style="background:${BRAND}">${raw('persona.avatar')}</div>
+            <div class="relative flex-1 rounded-2xl rounded-tl-none px-4 py-3 text-sm leading-relaxed text-white shadow-md" style="background:${BRAND}">
+              <span class="absolute -left-2 top-3 w-3 h-3 rotate-45" style="background:${BRAND}"></span>
+              ${t(`step${n}.persona.speech`)}
+            </div>
+          </div>
+
+          <!-- 手順リスト -->
+          <div class="rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700 px-5 py-4">
+            <ul class="space-y-3">
+              ${items}
+            </ul>
+            ${embedCode}
+          </div>
+        </div>
+      </div>`;
+  }).join('');
+
+  // ── デモチャット ──
+  const demoChats = [1,2,3].map(n => `
+    <!-- Q${n} -->
+    <div class="flex flex-col gap-2">
+      <!-- ユーザーバブル（右） -->
+      <div class="flex justify-end">
+        <div class="max-w-[75%] rounded-2xl rounded-br-sm px-4 py-2.5 text-sm text-white shadow-sm" style="background:${BRAND}">
+          ${t(`demo.${n}.question`)}
+        </div>
+      </div>
+      <!-- AI バブル（左）+ 引用バッジ -->
+      <div class="flex items-end gap-2">
+        <div class="flex-none w-7 h-7 rounded-full text-white text-xs font-black flex items-center justify-center shrink-0 mb-0.5 shadow" style="background:${BRAND_DARK}">N</div>
+        <div class="flex-1 min-w-0">
+          <div class="inline-block rounded-2xl rounded-bl-sm bg-gray-100 dark:bg-gray-800 px-4 py-2.5 text-sm text-gray-700 dark:text-gray-300 shadow-sm">
+            ${t(`demo.${n}.answer`)}
+          </div>
+          <div class="mt-1.5 ml-1 inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border" style="background:${BRAND_LIGHT};border-color:${BRAND}40;color:${BRAND}">
+            <svg class="w-3 h-3 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
+            [${n}] ${t(`demo.${n}.citation`)}
+          </div>
+        </div>
+      </div>
+    </div>`).join('');
+
+  // 改行を <br> に（hero title など）
+  const heroTitle = t('hero.title').replace(/\n/g, '<br>');
+
+  return `<!doctype html>
+<html lang="${locale.lang}">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>${raw('meta.title')}</title>
+  <meta name="description" content="${raw('meta.description')}"/>
+  <meta property="og:title" content="${raw('meta.title')}"/>
+  <meta property="og:description" content="${raw('meta.description')}"/>
+  <meta property="og:type" content="website"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=${locale.googleFont}&display=swap" rel="stylesheet"/>
+  <!-- ダークモード初期化: flash を防ぐため CDN より先に実行 -->
+  <script>
+    (function(){
+      var s = localStorage.getItem('guide-theme');
+      if (s === 'dark' || (!s && window.matchMedia('(prefers-color-scheme:dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <!-- Tailwind Play CDN v3: CDN を先に読み込み、その後 tailwind.config を設定する -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    /* Tailwind Play CDN v3: tailwind.config は CDN 読み込み後に設定する */
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          colors: {
+            brand: { DEFAULT:'${BRAND}', dark:'${BRAND_DARK}', light:'${BRAND_LIGHT}' },
+          },
+          fontFamily: {
+            sans: [${locale.fontFamily.split(',').map(f => `'${f.trim().replace(/"/g,'')}'`).join(',')}],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    html { scroll-behavior:smooth; }
+    body { font-family: ${locale.fontFamily}, sans-serif; }
+    details summary::-webkit-details-marker { display:none; }
+    pre code { font-family:'Menlo','Monaco','Consolas',monospace; }
+    /* lang dropdown */
+    #lang-menu { display:none; }
+    #lang-menu.open { display:block; }
+    /* デモチャット吹き出し装飾 */
+    .chat-phone { background:white; border-radius:2rem; overflow:hidden; border:2px solid #e2e8f0; box-shadow:0 25px 60px -10px rgba(0,0,0,.18); }
+    html.dark .chat-phone { background:#1e293b; border-color:#334155; }
+    /* persona card */
+    .persona-card { background:linear-gradient(135deg,${BRAND_LIGHT} 0%,${BRAND_LIGHT}80 100%); }
+    html.dark .persona-card { background:linear-gradient(135deg,rgba(77,143,127,.18) 0%,rgba(77,143,127,.06) 100%); border-color:rgba(77,143,127,.35); }
+  </style>
+</head>
+<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 antialiased transition-colors duration-200">
+
+  <!-- ── Nav ── -->
+  <header class="sticky top-0 z-50 bg-white/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 h-16 flex items-center gap-4">
+      <!-- ロゴ -->
+      <a href="../../${locale.id}/" class="flex items-center gap-2 font-bold text-gray-900 dark:text-white text-base shrink-0 hover:opacity-80 transition-opacity">
+        <span class="w-7 h-7 rounded-lg flex items-center justify-center text-white text-xs font-black" style="background:${BRAND}">N</span>
+        NeNe Corpus
+      </a>
+      <!-- 戻るリンク -->
+      <a href="../../${locale.id}/" class="hidden sm:inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        ${t('nav.backToGuide')}
+      </a>
+
+      <div class="flex items-center gap-1.5 sm:gap-2 ml-auto">
+        <!-- 言語プルダウン -->
+        <div class="relative" id="lang-dropdown">
+          <button onclick="toggleLangMenu(event)"
+                  class="flex items-center gap-1 px-2.5 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+            <svg class="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/></svg>
+            <span class="hidden sm:inline font-medium">${allLocales.find(l=>l.id===locale.id).label}</span>
+            <svg class="w-3 h-3 shrink-0 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M19 9l-7 7-7-7"/></svg>
+          </button>
+          <div id="lang-menu"
+               class="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg py-1 min-w-36 z-50">
+            ${langMenuItems}
+          </div>
+        </div>
+
+        <!-- ダークモードトグル -->
+        <button onclick="toggleTheme()"
+                class="p-2 rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label="Toggle dark mode">
+          <svg id="icon-moon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+          <svg id="icon-sun" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+        </button>
+
+        <!-- GitHub -->
+        <a href="${GH_URL}" target="_blank" rel="noopener"
+           class="hidden sm:inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors font-medium">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          GitHub
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+
+    <!-- ── Hero ── -->
+    <section class="pt-14 pb-12 sm:pt-20 sm:pb-16 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- テキスト -->
+          <div>
+            <span class="inline-flex items-center gap-2 mb-5 px-3.5 py-1.5 rounded-full text-sm font-medium border"
+                  style="color:${BRAND};border-color:${BRAND_LIGHT};background:${BRAND_LIGHT}">
+              <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+              ${t('hero.badge')}
+            </span>
+            <h1 class="text-3xl sm:text-4xl lg:text-5xl font-extrabold text-gray-950 dark:text-white leading-[1.15] tracking-tight mb-5">
+              ${heroTitle}
+            </h1>
+            <p class="text-lg text-gray-500 dark:text-gray-400 leading-relaxed mb-8">
+              ${t('hero.subtitle')}
+            </p>
+            <a href="#steps"
+               class="inline-flex items-center justify-center gap-2 px-7 py-4 rounded-2xl text-white text-base font-semibold shadow-lg transition-all hover:opacity-90 hover:shadow-xl hover:-translate-y-0.5"
+               style="background:${BRAND}">
+              ${t('hero.cta')}
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+            </a>
+          </div>
+
+          <!-- ペルソナカード -->
+          <div class="flex justify-center lg:justify-end">
+            <div class="persona-card border rounded-3xl p-8 max-w-xs w-full shadow-xl">
+              <!-- アバター + 名前 -->
+              <div class="flex items-center gap-4 mb-5">
+                <div class="w-16 h-16 rounded-2xl text-white text-2xl font-black flex items-center justify-center shadow-lg" style="background:${BRAND}">
+                  ${raw('persona.avatar')}
+                </div>
+                <div>
+                  <p class="text-xl font-bold text-gray-900 dark:text-gray-100">${t('persona.name')}</p>
+                  <span class="inline-block mt-1 px-2.5 py-0.5 rounded-full text-xs font-semibold text-white" style="background:${BRAND}">${t('persona.role')}</span>
+                </div>
+              </div>
+              <!-- 店名 -->
+              <p class="text-sm font-medium mb-4" style="color:${BRAND}">📍 ${t('persona.shopName')}</p>
+              <!-- 吹き出しイントロ -->
+              <div class="relative rounded-2xl rounded-tl-none bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 px-4 py-3 shadow-sm">
+                <span class="absolute -top-2.5 left-4 text-white text-base leading-none" style="text-shadow:0 1px 2px rgba(0,0,0,.1)">▾</span>
+                <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">${t('hero.persona.intro')}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── セットアップステップ ── -->
+    <section id="steps" class="py-16 sm:py-24 bg-gray-50 dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-14">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">${t('steps.title')}</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg">${t('steps.subtitle')}</p>
+        </div>
+        <!-- タイムライン -->
+        <div>
+          ${steps}
+        </div>
+      </div>
+    </section>
+
+    <!-- ── デモチャット ── -->
+    <section class="py-16 sm:py-24 bg-white dark:bg-gray-950">
+      <div class="max-w-5xl mx-auto px-4 sm:px-6">
+        <div class="text-center mb-12">
+          <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-3">${t('demo.title')}</h2>
+          <p class="text-gray-400 dark:text-gray-500 text-lg max-w-xl mx-auto">${t('demo.subtitle')}</p>
+        </div>
+
+        <div class="grid lg:grid-cols-2 gap-10 lg:gap-16 items-center">
+          <!-- 説明テキスト -->
+          <div class="space-y-5 order-2 lg:order-1">
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">📄</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">${{
+                  ja:'アップロードしたファイルから答えます',
+                  en:'Answers come from your uploaded files',
+                  de:'Antworten stammen aus Ihren hochgeladenen Dateien',
+                  fr:'Les réponses viennent de vos fichiers chargés',
+                  'zh-hans':'回答来自您上传的文件',
+                  'pt-br':'Respostas vêm dos seus arquivos carregados',
+                }[locale.id]}</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">${{
+                  ja:'メニュー・FAQ・店舗情報など、アップロードしたドキュメントの内容をもとに回答します。',
+                  en:'Menu, FAQ, store info — whatever you upload becomes the AI\'s knowledge base.',
+                  de:'Menü, FAQ, Storeinformationen — alles Hochgeladene wird zur Wissensbasis der KI.',
+                  fr:'Menu, FAQ, infos boutique — tout ce que vous chargez devient la base de connaissances.',
+                  'zh-hans':'菜单、FAQ、门店信息——上传的任何内容都成为 AI 的知识库。',
+                  'pt-br':'Menu, FAQ, infos da loja — tudo que você envia vira a base de conhecimento da IA.',
+                }[locale.id]}</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">🔖</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">${{
+                  ja:'出典が必ず付きます',
+                  en:'Every answer includes citations',
+                  de:'Jede Antwort enthält Quellen',
+                  fr:'Chaque réponse inclut des citations',
+                  'zh-hans':'每个回答都附带引用',
+                  'pt-br':'Cada resposta inclui citações',
+                }[locale.id]}</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">${{
+                  ja:'どのドキュメントの何ページに書いてあるかを引用バッジで表示。信頼性を担保します。',
+                  en:'Citation badges show exactly which document and page the answer comes from.',
+                  de:'Zitatbadges zeigen genau, aus welchem Dokument und welcher Seite die Antwort stammt.',
+                  fr:'Les badges de citation indiquent exactement de quel document et quelle page provient la réponse.',
+                  'zh-hans':'引用徽章显示答案来自哪个文档和页面。',
+                  'pt-br':'Badges de citação mostram exatamente de qual documento e página vem a resposta.',
+                }[locale.id]}</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3 p-4 rounded-2xl bg-gray-50 dark:bg-gray-800/60 border border-gray-100 dark:border-gray-700">
+              <span class="text-2xl shrink-0">⚡</span>
+              <div>
+                <p class="font-semibold text-sm text-gray-800 dark:text-gray-200 mb-1">${{
+                  ja:'24時間自動応答',
+                  en:'24/7 automatic responses',
+                  de:'24/7 automatische Antworten',
+                  fr:'Réponses automatiques 24h/24',
+                  'zh-hans':'全天候自动回复',
+                  'pt-br':'Respostas automáticas 24h',
+                }[locale.id]}</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">${{
+                  ja:'訪問者がいつ来ても、設置したコンテンツから自動で回答します。',
+                  en:'Visitors get instant answers any time of day, automatically from your content.',
+                  de:'Besucher erhalten jederzeit sofortige Antworten aus Ihren Inhalten.',
+                  fr:"Les visiteurs obtiennent des réponses instantanées à tout moment depuis votre contenu.",
+                  'zh-hans':'无论访客何时到来，都能从您的内容中自动获得即时回答。',
+                  'pt-br':'Visitantes recebem respostas instantâneas a qualquer hora do seu conteúdo.',
+                }[locale.id]}</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- デモチャット画面 -->
+          <div class="order-1 lg:order-2 flex justify-center">
+            <div class="chat-phone w-full max-w-sm">
+              <!-- チャットヘッダー -->
+              <div class="px-5 py-4 flex items-center gap-3" style="background:${BRAND}">
+                <div class="w-9 h-9 rounded-full bg-white/20 flex items-center justify-center text-white text-sm font-black">N</div>
+                <div>
+                  <p class="text-white font-bold text-sm">NeNe Corpus</p>
+                  <p class="text-white/75 text-xs">${t('persona.shopName')}</p>
+                </div>
+              </div>
+              <!-- チャットボディ -->
+              <div class="px-4 py-5 space-y-5 bg-white dark:bg-gray-900 min-h-64">
+                ${demoChats}
+              </div>
+              <!-- 入力欄 -->
+              <div class="px-4 py-3 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 flex gap-2">
+                <div class="flex-1 rounded-xl bg-gray-100 dark:bg-gray-800 px-3 py-2 text-sm text-gray-400">…</div>
+                <div class="w-9 h-9 rounded-xl flex items-center justify-center text-white shrink-0" style="background:${BRAND}">
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── CTA ── -->
+    <section class="py-20 sm:py-28 text-white" style="background:${BRAND}">
+      <div class="max-w-3xl mx-auto px-4 sm:px-6 text-center">
+        <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold mb-4 leading-tight">${t('cta.title')}</h2>
+        <p class="text-lg mb-8 opacity-85">${t('cta.subtitle')}</p>
+        <div class="flex flex-col sm:flex-row gap-3 justify-center">
+          <a href="#steps"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl bg-white font-semibold text-base transition-all hover:bg-gray-50 hover:-translate-y-0.5 shadow-xl"
+             style="color:${BRAND}">
+            ${t('cta.button')}
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+          </a>
+          <a href="${GH_URL}" target="_blank" rel="noopener"
+             class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-2xl font-semibold text-base border border-white/30 hover:bg-white/10 transition-all">
+            <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ── Footer ── -->
+  <footer class="bg-gray-950 text-gray-400 py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6 text-sm">
+      <div>
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs font-black" style="background:${BRAND}">N</span>
+          <span class="text-white font-bold">NeNe Corpus</span>
+        </div>
+        <p class="text-gray-500">Powered by <a href="https://nene2.dev" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">NENE2</a> · © <a href="https://ayane.co.jp" target="_blank" rel="noopener" class="hover:text-gray-300 transition-colors">AYANE</a> All rights reserved.</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href="${GH_URL}" target="_blank" rel="noopener" class="flex items-center gap-1.5 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/></svg>
+          ${t('footer.github')}
+        </a>
+        <span class="text-gray-700">·</span>
+        <span>${t('footer.license')}</span>
+        <span class="text-gray-700">·</span>
+        <a href="#" class="hover:text-white transition-colors">${t('footer.backToTop')} ↑</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    // ── ダークモードトグル ──────────────────────────────────
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.toggle('dark');
+      localStorage.setItem('guide-theme', isDark ? 'dark' : 'light');
+      document.getElementById('icon-moon').classList.toggle('hidden', isDark);
+      document.getElementById('icon-sun').classList.toggle('hidden', !isDark);
+    }
+    (function(){
+      if (document.documentElement.classList.contains('dark')) {
+        document.getElementById('icon-moon').classList.add('hidden');
+        document.getElementById('icon-sun').classList.remove('hidden');
+      }
+    })();
+
+    // ── 言語プルダウン ──────────────────────────────────────
+    function toggleLangMenu(e) {
+      e.stopPropagation();
+      document.getElementById('lang-menu').classList.toggle('open');
+    }
+    document.addEventListener('click', function(e) {
+      var dd = document.getElementById('lang-dropdown');
+      if (dd && !dd.contains(e.target)) {
+        document.getElementById('lang-menu').classList.remove('open');
+      }
+    });
+  </script>
+</body>
+</html>`;
+}
+
+// ── index.html（言語自動検出）────────────────────────────────────────────────
+
+function buildIndex() {
+  return `<!doctype html><html><head><meta charset="UTF-8"/><title>NeNe Corpus — Setup Guide</title>
+<script>(function(){var l=(navigator.language||'en').toLowerCase(),locale='en';
+if(l.startsWith('ja'))locale='ja';else if(l.startsWith('de'))locale='de';
+else if(l.startsWith('fr'))locale='fr';else if(l.startsWith('zh'))locale='zh-hans';
+else if(l.startsWith('pt'))locale='pt-br';
+window.location.replace(locale+'/');})();</script>
+</head><body></body></html>`;
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(path.join(OUT, 'index.html'), buildIndex(), 'utf8');
+  console.log('✓ guide/howto/index.html');
+
+  for (const locale of LOCALES) {
+    const mod  = await import(`./howto-locales/${locale.id}.mjs`);
+    const msgs = mod.default;
+    const dir  = path.join(OUT, locale.id);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'index.html'), buildPage(locale, msgs, LOCALES), 'utf8');
+    console.log(`✓ guide/howto/${locale.id}/index.html`);
+  }
+
+  console.log('\n✅ howto pages generated →', OUT);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/howto-locales/de.mjs
+++ b/scripts/howto-locales/de.mjs
@@ -1,0 +1,71 @@
+export default {
+  'meta.title': 'Einrichtungsanleitung — NeNe Corpus HOWTO',
+  'meta.description': 'Folge Sakura, einer Café-Besitzerin, und richte NeNe Corpus in 4 Schritten ein — von der Installation bis zum Live-Chat.',
+
+  'nav.backToGuide': 'Zurück zum Guide',
+
+  'persona.name': 'Sakura',
+  'persona.role': 'Café-Besitzerin',
+  'persona.shopName': 'Sakura Café',
+  'persona.avatar': 'S',
+
+  'hero.badge': 'Einrichtungsanleitung · ca. 15 Minuten',
+  'hero.title': 'NeNe Corpus Einrichten\nMit Persona',
+  'hero.subtitle': 'Begleite Sakura, eine Café-Besitzerin, und richte den KI-Chat in 4 einfachen Schritten ein.',
+  'hero.persona.intro': 'Hallo! Ich bin Sakura und führe das Sakura Café. Ich wollte einen KI-Chat auf meiner Website einrichten, damit Besucher jederzeit Fragen stellen können. Lass uns das zusammen angehen!',
+  'hero.cta': 'Einrichtung starten',
+
+  'steps.title': 'In 4 Schritten fertig',
+  'steps.subtitle': 'Folge Sakura von der Installation bis zur Veröffentlichung des Widgets.',
+
+  'step1.title': 'Installieren',
+  'step1.persona.speech': 'Zuerst lädst du die Dateien einfach auf deinen Server hoch. Klingt technisch, geht aber per FTP — kein Programmieren nötig! 😊',
+  'step1.item1': 'Lade das neueste Release-ZIP von GitHub Releases herunter',
+  'step1.item2': 'Entpacke das ZIP und lade den Inhalt in `public_html` hoch',
+  'step1.item3': 'Öffne `https://deine-domain.de/install` im Browser',
+  'step1.item4': 'Gib deine Datenbankdaten ein und klicke auf „Installation ausführen"',
+
+  'step2.title': 'API-Schlüssel konfigurieren',
+  'step2.persona.speech': 'Erstelle ein Anthropic-Konto und hole dir einen API-Schlüssel. Danach ist die KI einsatzbereit! ✨',
+  'step2.item1': 'Erstelle ein Konto bei Anthropic (console.anthropic.com)',
+  'step2.item2': 'Erstelle einen neuen API-Schlüssel und kopiere ihn',
+  'step2.item3': 'Öffne Admin → Einstellungen → LLM-Tab',
+  'step2.item4': 'Füge den Schlüssel ein, klicke „Verbindung testen" → „Speichern"',
+
+  'step3.title': 'Inhalte hochladen',
+  'step3.persona.speech': 'Lade einfach deine Menü-PDF oder FAQ-Datei hoch. Das wird zur Wissensbasis deiner KI! 📄',
+  'step3.item1': 'Klicke im Admin-Bereich auf „Inhalt hinzufügen"',
+  'step3.item2': 'Wähle deine PDF-, CSV- oder Textdateien aus und lade sie hoch',
+  'step3.item3': 'Warte, bis der Status „Fertig" anzeigt (Sekunden bis Minuten)',
+  'step3.item4': 'Du kannst Menüs, FAQs, Storeinfos hochladen — so viele Dateien du willst',
+
+  'step4.title': 'Widget einbetten',
+  'step4.persona.speech': 'Kopiere eine Zeile Code und füge sie in deine Website ein! Das war\'s — der Chat ist live! 🎉',
+  'step4.item1': 'Öffne Admin → Einstellungen → Design-Tab',
+  'step4.item2': 'Kopiere den Code aus dem Abschnitt „Einbettungscode"',
+  'step4.item3': 'Füge ihn direkt vor `</body>` in dein Website-HTML ein',
+  'step4.item4': 'Lade die Seite neu — unten rechts sollte ein Chat-Symbol erscheinen!',
+
+  'demo.title': 'So sieht es in Aktion aus',
+  'demo.subtitle': 'So erleben Besucher das Sakura Café. Fragen werden sofort mit Quellenangabe beantwortet.',
+
+  'demo.1.question': 'Was kostet der Matcha Latte?',
+  'demo.1.answer': 'Der Matcha Latte kostet 5,80 € inkl. MwSt.',
+  'demo.1.citation': 'Menü S.2',
+
+  'demo.2.question': 'Kann ich einen Terrassenplatz reservieren?',
+  'demo.2.answer': 'Terrassenplätze können für bis zu 4 Personen reserviert werden. Per Telefon oder Web-Formular.',
+  'demo.2.citation': 'Storeinfo S.1',
+
+  'demo.3.question': 'Gibt es kostenloses WLAN?',
+  'demo.3.answer': 'Ja! Kostenloses WLAN ist verfügbar. Das Passwort erhalten Sie beim Personal.',
+  'demo.3.citation': 'FAQ S.3',
+
+  'cta.title': 'Richte es auf deiner Website ein',
+  'cta.subtitle': 'Dieselben Schritte wie Sakura. Kostenlos und Open Source.',
+  'cta.button': 'Loslegen',
+
+  'footer.github': 'GitHub',
+  'footer.license': 'MIT-Lizenz',
+  'footer.backToTop': 'Nach oben',
+};

--- a/scripts/howto-locales/en.mjs
+++ b/scripts/howto-locales/en.mjs
@@ -1,0 +1,71 @@
+export default {
+  'meta.title': 'Setup Guide — NeNe Corpus HOWTO',
+  'meta.description': 'Follow along with Sakura, a café owner, and set up NeNe Corpus in 4 steps — from install to AI chat going live.',
+
+  'nav.backToGuide': 'Back to Guide',
+
+  'persona.name': 'Sakura',
+  'persona.role': 'Café Owner',
+  'persona.shopName': 'Sakura Café',
+  'persona.avatar': 'S',
+
+  'hero.badge': 'Setup Guide · ~15 minutes',
+  'hero.title': 'NeNe Corpus Setup\nWith Persona',
+  'hero.subtitle': 'Join Sakura, a café owner, and set up AI chat on your website in 4 easy steps.',
+  'hero.persona.intro': 'Hi there! I\'m Sakura and I run Sakura Café. I wanted to add an AI chat to my website so visitors can ask questions anytime. Let\'s set it up together!',
+  'hero.cta': 'Start Setup',
+
+  'steps.title': 'Done in 4 Steps',
+  'steps.subtitle': 'Follow along with Sakura from installation to publishing your widget.',
+
+  'step1.title': 'Install',
+  'step1.persona.speech': 'First you just upload the files to your server. It sounds technical but you can do it all with FTP — no coding required! 😊',
+  'step1.item1': 'Download the latest release ZIP from GitHub Releases',
+  'step1.item2': 'Extract the ZIP and upload the contents to `public_html`',
+  'step1.item3': 'Open `https://your-domain.com/install` in your browser',
+  'step1.item4': 'Enter your database credentials and click "Run Install"',
+
+  'step2.title': 'Configure API Key',
+  'step2.persona.speech': 'Create an Anthropic account and get an API key. Once that\'s set, the AI powers up! ✨',
+  'step2.item1': 'Create an account at Anthropic (console.anthropic.com)',
+  'step2.item2': 'Generate a new API key and copy it',
+  'step2.item3': 'Open Admin → Settings → LLM tab',
+  'step2.item4': 'Paste the key, click "Test Connection" → "Save"',
+
+  'step3.title': 'Upload Content',
+  'step3.persona.speech': 'Just upload your menu PDF or FAQ file. That becomes the knowledge your AI answers from! 📄',
+  'step3.item1': 'In the Admin panel, click "Add Content"',
+  'step3.item2': 'Select your PDF, CSV, or text files and upload them',
+  'step3.item3': 'Wait for the status to show "Done" (takes a few seconds to minutes)',
+  'step3.item4': 'You can upload menus, FAQs, store info — as many files as you like',
+
+  'step4.title': 'Embed the Widget',
+  'step4.persona.speech': 'Just copy one line of code and paste it into your site! That\'s all it takes to go live. 🎉',
+  'step4.item1': 'Open Admin → Settings → Design tab',
+  'step4.item2': 'Copy the code from the "Embed Code" section',
+  'step4.item3': 'Paste it just before `</body>` in your website HTML',
+  'step4.item4': 'Reload your page — a chat icon should appear in the bottom-right!',
+
+  'demo.title': 'See It in Action',
+  'demo.subtitle': 'Here\'s what Sakura Café visitors experience. Questions answered with citations instantly.',
+
+  'demo.1.question': 'How much is the matcha latte?',
+  'demo.1.answer': 'The matcha latte is $5.80 including tax.',
+  'demo.1.citation': 'Menu p.2',
+
+  'demo.2.question': 'Can I reserve a terrace seat?',
+  'demo.2.answer': 'Terrace seats can be reserved for up to 4 guests. You can book by phone or via the web form.',
+  'demo.2.citation': 'Store Info p.1',
+
+  'demo.3.question': 'Is there free Wi-Fi?',
+  'demo.3.answer': 'Yes! Free Wi-Fi is available. Just ask a staff member for the password when you arrive.',
+  'demo.3.citation': 'FAQ p.3',
+
+  'cta.title': 'Set It Up on Your Site',
+  'cta.subtitle': 'Same steps as Sakura used. Free and open source.',
+  'cta.button': 'Get Started',
+
+  'footer.github': 'GitHub',
+  'footer.license': 'MIT License',
+  'footer.backToTop': 'Back to top',
+};

--- a/scripts/howto-locales/fr.mjs
+++ b/scripts/howto-locales/fr.mjs
@@ -1,0 +1,71 @@
+export default {
+  'meta.title': "Guide d'installation — NeNe Corpus HOWTO",
+  'meta.description': "Suivez Sakura, propriétaire d'un café, et configurez NeNe Corpus en 4 étapes — de l'installation à la mise en ligne du chat IA.",
+
+  'nav.backToGuide': 'Retour au Guide',
+
+  'persona.name': 'Sakura',
+  'persona.role': "Propriétaire du café",
+  'persona.shopName': 'Café Sakura',
+  'persona.avatar': 'S',
+
+  'hero.badge': "Guide d'installation · ~15 minutes",
+  'hero.title': 'Configurer NeNe Corpus\nAvec un Persona',
+  'hero.subtitle': "Accompagnez Sakura, propriétaire d'un café, et ajoutez un chat IA à votre site en 4 étapes simples.",
+  'hero.persona.intro': "Bonjour ! Je suis Sakura et je gère le Café Sakura. Je voulais ajouter un chat IA sur mon site pour que les visiteurs puissent poser des questions à tout moment. Faisons-le ensemble !",
+  'hero.cta': "Commencer l'installation",
+
+  'steps.title': 'Terminé en 4 étapes',
+  'steps.subtitle': "Suivez Sakura de l'installation à la publication du widget.",
+
+  'step1.title': 'Installer',
+  'step1.persona.speech': "D'abord, il faut juste déposer les fichiers sur le serveur. Ça semble technique, mais on peut tout faire avec FTP — sans coder ! 😊",
+  'step1.item1': 'Téléchargez le dernier ZIP depuis GitHub Releases',
+  'step1.item2': "Décompressez le ZIP et déposez le contenu dans `public_html`",
+  'step1.item3': "Ouvrez `https://votre-domaine.fr/install` dans le navigateur",
+  'step1.item4': "Saisissez vos informations de base de données et cliquez sur « Installer »",
+
+  'step2.title': "Configurer la clé API",
+  'step2.persona.speech': "Créez un compte Anthropic et obtenez une clé API. Une fois configurée, l'IA est opérationnelle ! ✨",
+  'step2.item1': "Créez un compte sur Anthropic (console.anthropic.com)",
+  'step2.item2': "Générez une nouvelle clé API et copiez-la",
+  'step2.item3': "Ouvrez Admin → Paramètres → onglet LLM",
+  'step2.item4': "Collez la clé, cliquez « Tester la connexion » → « Enregistrer »",
+
+  'step3.title': 'Ajouter du contenu',
+  'step3.persona.speech': "Déposez simplement votre menu PDF ou votre FAQ. C'est ça qui devient la base de connaissance de l'IA ! 📄",
+  'step3.item1': "Dans l'interface Admin, cliquez sur « Ajouter du contenu »",
+  'step3.item2': "Sélectionnez vos fichiers PDF, CSV ou texte et envoyez-les",
+  'step3.item3': "Attendez que le statut affiche « Terminé » (quelques secondes à minutes)",
+  'step3.item4': "Menus, FAQ, infos boutique — ajoutez autant de fichiers que nécessaire",
+
+  'step4.title': 'Intégrer le widget',
+  'step4.persona.speech': "Copiez une seule ligne de code et collez-la sur votre site ! Le chat est en ligne. 🎉",
+  'step4.item1': "Ouvrez Admin → Paramètres → onglet Design",
+  'step4.item2': "Copiez le code dans la section « Code d'intégration »",
+  'step4.item3': "Collez-le juste avant `</body>` dans votre HTML",
+  'step4.item4': "Rechargez la page — une icône de chat apparaît en bas à droite !",
+
+  'demo.title': "Voyez-le en action",
+  'demo.subtitle': "Voici ce que vivent les visiteurs du Café Sakura. Questions répondues avec citations instantanément.",
+
+  'demo.1.question': "Combien coûte le latte matcha ?",
+  'demo.1.answer': "Le latte matcha est à 5,80 € TTC.",
+  'demo.1.citation': 'Menu p.2',
+
+  'demo.2.question': "Peut-on réserver une table en terrasse ?",
+  'demo.2.answer': "Les tables en terrasse peuvent être réservées pour 4 personnes maximum, par téléphone ou formulaire web.",
+  'demo.2.citation': 'Infos p.1',
+
+  'demo.3.question': "Y a-t-il le Wi-Fi gratuit ?",
+  'demo.3.answer': "Oui ! Le Wi-Fi gratuit est disponible. Demandez le mot de passe à notre personnel à l'accueil.",
+  'demo.3.citation': 'FAQ p.3',
+
+  'cta.title': 'Installez-le sur votre site',
+  'cta.subtitle': "Mêmes étapes que Sakura. Gratuit et open source.",
+  'cta.button': 'Commencer',
+
+  'footer.github': 'GitHub',
+  'footer.license': 'Licence MIT',
+  'footer.backToTop': 'Haut de page',
+};

--- a/scripts/howto-locales/ja.mjs
+++ b/scripts/howto-locales/ja.mjs
@@ -1,0 +1,71 @@
+export default {
+  'meta.title': 'セットアップガイド — NeNe Corpus HOWTO',
+  'meta.description': 'カフェオーナーのさくらさんといっしょに NeNe Corpus のセットアップを体験。インストールから AI チャット公開まで 4 ステップで完了。',
+
+  'nav.backToGuide': 'ガイドに戻る',
+
+  'persona.name': 'さくら',
+  'persona.role': 'カフェオーナー',
+  'persona.shopName': 'さくらカフェ',
+  'persona.avatar': 'S',
+
+  'hero.badge': 'セットアップガイド · 所要時間 約15分',
+  'hero.title': 'ペルソナで学ぶ\nNeNe Corpus セットアップ',
+  'hero.subtitle': 'カフェオーナーのさくらさんといっしょに、4 つのステップでウェブサイトに AI チャットを設置してみましょう。',
+  'hero.persona.intro': 'はじめまして！さくらカフェを経営しているさくらです。ホームページに AI チャットを設置してみたくて、NeNe Corpus を使ってみることにしました。いっしょにやってみましょう！',
+  'hero.cta': 'セットアップをはじめる',
+
+  'steps.title': '4 ステップで完了',
+  'steps.subtitle': 'インストールからウィジェット公開まで、さくらさんに付き合いながら進めましょう。',
+
+  'step1.title': 'インストールしよう',
+  'step1.persona.speech': 'まずはファイルをサーバーにアップロードするだけ！難しそうに聞こえるけど、FTP でできるから大丈夫よ 😊',
+  'step1.item1': 'GitHub の Releases から最新の ZIP をダウンロードします',
+  'step1.item2': 'ZIP を展開して、中身を `public_html` にアップロードします',
+  'step1.item3': 'ブラウザで `https://あなたのドメイン/install` を開きます',
+  'step1.item4': 'データベース接続情報を入力して「インストール実行」をクリックします',
+
+  'step2.title': 'API キーを設定しよう',
+  'step2.persona.speech': 'Anthropic のアカウントを作って API キーを取得するだけ。これを設定すれば AI が動くようになるよ ✨',
+  'step2.item1': 'Anthropic (console.anthropic.com) でアカウントを作成・ログインします',
+  'step2.item2': 'API Keys ページで新しいキーを発行してコピーします',
+  'step2.item3': '管理画面 → 設定アイコン → LLM タブを開きます',
+  'step2.item4': 'API キーを貼り付けて「接続テスト」→「保存」をクリックします',
+
+  'step3.title': 'コンテンツをアップロードしよう',
+  'step3.persona.speech': 'メニュー PDF や FAQ テキストをアップロードするだけ！これが AI が答えてくれるコンテンツになるの 📄',
+  'step3.item1': '管理画面 → 「コンテンツ追加」ボタンをクリックします',
+  'step3.item2': 'PDF・CSV・テキストファイルを選択してアップロードします',
+  'step3.item3': 'ステータスが「完了」になるまで待ちます（数秒〜数分）',
+  'step3.item4': 'メニュー・FAQ・店舗情報などを複数まとめて追加できます',
+
+  'step4.title': 'ウィジェットを埋め込もう',
+  'step4.persona.speech': 'たった 1 行のコードをコピペするだけ！これでホームページにチャットが現れるよ 🎉',
+  'step4.item1': '管理画面 → 設定 → デザインタブを開きます',
+  'step4.item2': '「埋め込みコード」セクションのコードをコピーします',
+  'step4.item3': 'ホームページの HTML の `</body>` 直前に貼り付けます',
+  'step4.item4': 'ページをリロード → 右下にチャットアイコンが現れたら完了です！',
+
+  'demo.title': 'こんな会話ができます',
+  'demo.subtitle': 'さくらカフェに設置したらこんな感じ。訪問者の質問に出典付きで即答します。',
+
+  'demo.1.question': '抹茶ラテって何円ですか？',
+  'demo.1.answer': '抹茶ラテは税込 580 円でご提供しています。',
+  'demo.1.citation': 'メニュー p.2',
+
+  'demo.2.question': 'テラス席の予約はできますか？',
+  'demo.2.answer': 'テラス席は4名様まで事前予約を承っています。お電話またはウェブフォームからどうぞ。',
+  'demo.2.citation': '店舗情報 p.1',
+
+  'demo.3.question': 'Wi-Fi はありますか？',
+  'demo.3.answer': 'フリー Wi-Fi をご利用いただけます。パスワードはご来店時にスタッフまでお声がけください。',
+  'demo.3.citation': 'FAQ p.3',
+
+  'cta.title': 'あなたのサイトにも設置してみよう',
+  'cta.subtitle': 'さくらさんと同じ手順で、今すぐはじめられます。無料の OSS です。',
+  'cta.button': 'はじめる',
+
+  'footer.github': 'GitHub',
+  'footer.license': 'MIT ライセンス',
+  'footer.backToTop': 'ページ上部へ',
+};

--- a/scripts/howto-locales/pt-br.mjs
+++ b/scripts/howto-locales/pt-br.mjs
@@ -1,0 +1,71 @@
+export default {
+  'meta.title': 'Guia de Instalação — NeNe Corpus HOWTO',
+  'meta.description': 'Siga a Sakura, dona de um café, e configure o NeNe Corpus em 4 passos — da instalação ao chat de IA no ar.',
+
+  'nav.backToGuide': 'Voltar ao Guia',
+
+  'persona.name': 'Sakura',
+  'persona.role': 'Dona do Café',
+  'persona.shopName': 'Café Sakura',
+  'persona.avatar': 'S',
+
+  'hero.badge': 'Guia de Instalação · ~15 minutos',
+  'hero.title': 'Configure o NeNe Corpus\nCom Persona',
+  'hero.subtitle': 'Acompanhe a Sakura, dona de um café, e adicione o chat de IA ao seu site em 4 passos simples.',
+  'hero.persona.intro': 'Olá! Eu sou a Sakura e administro o Café Sakura. Queria adicionar um chat de IA ao meu site para que os visitantes possam tirar dúvidas a qualquer hora. Vamos fazer isso juntos!',
+  'hero.cta': 'Iniciar Configuração',
+
+  'steps.title': 'Pronto em 4 Passos',
+  'steps.subtitle': 'Siga a Sakura da instalação até a publicação do widget.',
+
+  'step1.title': 'Instalar',
+  'step1.persona.speech': 'Primeiro você só faz o upload dos arquivos para o servidor. Parece técnico, mas dá para fazer pelo FTP — sem programar! 😊',
+  'step1.item1': 'Baixe o ZIP mais recente do GitHub Releases',
+  'step1.item2': 'Extraia o ZIP e envie o conteúdo para `public_html`',
+  'step1.item3': 'Abra `https://seu-dominio.com.br/install` no navegador',
+  'step1.item4': 'Informe os dados do banco de dados e clique em "Executar Instalação"',
+
+  'step2.title': 'Configurar Chave de API',
+  'step2.persona.speech': 'Crie uma conta na Anthropic e obtenha uma chave de API. Com ela configurada, a IA entra em ação! ✨',
+  'step2.item1': 'Crie uma conta na Anthropic (console.anthropic.com)',
+  'step2.item2': 'Gere uma nova chave de API e copie-a',
+  'step2.item3': 'Abra o Admin → Configurações → aba LLM',
+  'step2.item4': 'Cole a chave, clique em "Testar Conexão" → "Salvar"',
+
+  'step3.title': 'Adicionar Conteúdo',
+  'step3.persona.speech': 'Só fazer upload do seu cardápio em PDF ou arquivo de FAQ. Isso vira a base de conhecimento da IA! 📄',
+  'step3.item1': 'No painel Admin, clique em "Adicionar Conteúdo"',
+  'step3.item2': 'Selecione seus arquivos PDF, CSV ou de texto e envie',
+  'step3.item3': 'Aguarde o status mostrar "Concluído" (leva segundos a minutos)',
+  'step3.item4': 'Cardápios, FAQs, info da loja — envie quantos arquivos quiser',
+
+  'step4.title': 'Incorporar o Widget',
+  'step4.persona.speech': 'Copie uma linha de código e cole no seu site! O chat vai ao ar na hora. 🎉',
+  'step4.item1': 'Abra o Admin → Configurações → aba Design',
+  'step4.item2': 'Copie o código da seção "Código de Incorporação"',
+  'step4.item3': 'Cole-o logo antes do `</body>` no HTML do seu site',
+  'step4.item4': 'Recarregue a página — um ícone de chat deve aparecer no canto inferior direito!',
+
+  'demo.title': 'Veja em Ação',
+  'demo.subtitle': 'É assim que os visitantes do Café Sakura experienciam. Perguntas respondidas com citações instantaneamente.',
+
+  'demo.1.question': 'Quanto custa o latte de matcha?',
+  'demo.1.answer': 'O latte de matcha custa R$ 18,90 com impostos.',
+  'demo.1.citation': 'Cardápio p.2',
+
+  'demo.2.question': 'Posso reservar uma mesa na varanda?',
+  'demo.2.answer': 'As mesas na varanda comportam até 4 pessoas e podem ser reservadas por telefone ou formulário online.',
+  'demo.2.citation': 'Info da Loja p.1',
+
+  'demo.3.question': 'Tem Wi-Fi gratuito?',
+  'demo.3.answer': 'Sim! Wi-Fi gratuito disponível. Solicite a senha ao chegar — nossos atendentes terão o prazer em informar.',
+  'demo.3.citation': 'FAQ p.3',
+
+  'cta.title': 'Instale no Seu Site',
+  'cta.subtitle': 'Os mesmos passos que a Sakura usou. Gratuito e open source.',
+  'cta.button': 'Começar',
+
+  'footer.github': 'GitHub',
+  'footer.license': 'Licença MIT',
+  'footer.backToTop': 'Voltar ao topo',
+};

--- a/scripts/howto-locales/zh-hans.mjs
+++ b/scripts/howto-locales/zh-hans.mjs
@@ -1,0 +1,71 @@
+export default {
+  'meta.title': '安装指南 — NeNe Corpus HOWTO',
+  'meta.description': '跟随咖啡馆老板 Sakura，4 步完成 NeNe Corpus 的安装与配置，从安装到 AI 聊天上线。',
+
+  'nav.backToGuide': '返回指南',
+
+  'persona.name': 'Sakura',
+  'persona.role': '咖啡馆老板',
+  'persona.shopName': 'Sakura 咖啡馆',
+  'persona.avatar': 'S',
+
+  'hero.badge': '安装指南 · 约 15 分钟',
+  'hero.title': '跟 Persona 一起\n配置 NeNe Corpus',
+  'hero.subtitle': '跟随咖啡馆老板 Sakura，4 个简单步骤为你的网站添加 AI 聊天功能。',
+  'hero.persona.intro': '大家好！我是 Sakura，经营着 Sakura 咖啡馆。我想在网站上添加 AI 聊天功能，让访客随时都能提问。我们一起来完成吧！',
+  'hero.cta': '开始配置',
+
+  'steps.title': '4 步完成',
+  'steps.subtitle': '跟随 Sakura 从安装到发布小部件，全程陪伴。',
+
+  'step1.title': '安装',
+  'step1.persona.speech': '首先只需将文件上传到服务器。听起来很技术，但用 FTP 就能搞定——不需要写代码！😊',
+  'step1.item1': '从 GitHub Releases 下载最新版 ZIP',
+  'step1.item2': '解压 ZIP，将内容上传到 `public_html`',
+  'step1.item3': '在浏览器中打开 `https://你的域名/install`',
+  'step1.item4': '输入数据库信息，点击「运行安装」',
+
+  'step2.title': '配置 API 密钥',
+  'step2.persona.speech': '创建 Anthropic 账号并获取 API 密钥。设置好之后 AI 就能运行了！✨',
+  'step2.item1': '在 Anthropic (console.anthropic.com) 创建账号',
+  'step2.item2': '生成新的 API 密钥并复制',
+  'step2.item3': '打开管理后台 → 设置 → LLM 选项卡',
+  'step2.item4': '粘贴密钥，点击「测试连接」→「保存」',
+
+  'step3.title': '上传内容',
+  'step3.persona.speech': '只需上传菜单 PDF 或 FAQ 文件，这就成了 AI 的知识库！📄',
+  'step3.item1': '在管理后台点击「添加内容」',
+  'step3.item2': '选择 PDF、CSV 或文本文件并上传',
+  'step3.item3': '等待状态显示「完成」（几秒到几分钟）',
+  'step3.item4': '菜单、FAQ、门店信息——可以上传任意多个文件',
+
+  'step4.title': '嵌入小部件',
+  'step4.persona.speech': '只需复制一行代码粘贴到网站！聊天功能就上线了。🎉',
+  'step4.item1': '打开管理后台 → 设置 → 设计选项卡',
+  'step4.item2': '复制「嵌入代码」部分的代码',
+  'step4.item3': '粘贴到网站 HTML 的 `</body>` 标签之前',
+  'step4.item4': '刷新页面——右下角出现聊天图标即表示完成！',
+
+  'demo.title': '效果展示',
+  'demo.subtitle': 'Sakura 咖啡馆访客的实际体验。问题即时得到附带引用的回答。',
+
+  'demo.1.question': '抹茶拿铁多少钱？',
+  'demo.1.answer': '抹茶拿铁含税售价 38 元。',
+  'demo.1.citation': '菜单 p.2',
+
+  'demo.2.question': '可以预订露台座位吗？',
+  'demo.2.answer': '露台座位最多可供 4 人预订，可通过电话或网络表单预约。',
+  'demo.2.citation': '门店信息 p.1',
+
+  'demo.3.question': '有免费 Wi-Fi 吗？',
+  'demo.3.answer': '有的！提供免费 Wi-Fi，到店后请询问工作人员获取密码。',
+  'demo.3.citation': 'FAQ p.3',
+
+  'cta.title': '在你的网站上部署',
+  'cta.subtitle': '与 Sakura 相同的步骤。免费开源。',
+  'cta.button': '立即开始',
+
+  'footer.github': 'GitHub',
+  'footer.license': 'MIT 许可证',
+  'footer.backToTop': '返回顶部',
+};


### PR DESCRIPTION
## 概要

Issue #222 対応。ペルソナ（さくら：カフェオーナー）が吹き出し形式でセットアップを案内する HOWTO チュートリアルページを実装。

## 変更内容

### 新規ファイル
- **`scripts/build-howto.mjs`** — 6か国語 HOWTO ページ生成スクリプト
- **`scripts/howto-locales/{ja,en,de,fr,zh-hans,pt-br}.mjs`** — ロケール別メッセージカタログ
- **`public_html/guide/howto/{index,ja,en,de,fr,zh-hans,pt-br}/index.html`** — 生成済み HTML（7ファイル）

### 更新ファイル
- **`frontend/package.json`** — `build:release` に `&& node ../scripts/build-howto.mjs` を追加
- **`frontend/apps/admin/src/HelpPanel.tsx`** — `GUIDE_URL_MAP` を `/guide/howto/{locale}/` に更新

## ページ構成

| セクション | 内容 |
|---|---|
| Hero | ペルソナカード（さくら／カフェオーナー）+ 吹き出しイントロ |
| 4ステップ | 各ステップにペルソナ吹き出し（teal 背景）+ 番号付き手順リスト、Step 4 に埋め込みコードスニペット |
| デモチャット | 電話モックアップ — 抹茶ラテ・テラス席・Wi-Fi の Q&A ×3 + 引用バッジ |
| CTA | teal 背景 |
| フッター | NENE2/AYANE リンク |

## テクニカルノート
- ダークモード対応（CDN-first Tailwind config、LP と同じ構造）
- 言語プルダウン（../${id}/）・ダークモードトグル・GitHub リンク — LP と同じ Nav
- `build:release` が `build-howto.mjs` を呼ぶのでデグレなし

## セルフレビュー
- [x] TypeScript check 通過
- [x] 6言語すべてで HTML 生成確認
- [x] HelpPanel の「セットアップガイドを見る」リンク先が HOWTO に更新済み
- [x] build:release に追加済み

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)