### PR TITLE
security(admin-auth): ログインブルートフォース対策を追加 (#224)

### DIFF
--- a/src/AdminAuth/AdminAuthServiceProvider.php
+++ b/src/AdminAuth/AdminAuthServiceProvider.php
@@ -14,6 +14,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Middleware\RateLimitStorageInterface;
 use Psr\Container\ContainerInterface;
 
 final readonly class AdminAuthServiceProvider implements ServiceProviderInterface
@@ -21,6 +22,8 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
     public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.admin_auth';
 
     public const AUTH_MIDDLEWARE = 'nene-corpus.middleware.admin_auth';
+
+    public const LOGIN_RATE_LIMIT_MIDDLEWARE = 'nene-corpus.middleware.admin_login_rate_limit';
 
     public const TOKEN_ISSUER = 'nene-corpus.admin_auth.token_issuer';
 
@@ -184,6 +187,23 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                     }
 
                     return new ChangeAdminEmailHandler($useCase, $response);
+                },
+            )
+            ->set(
+                self::LOGIN_RATE_LIMIT_MIDDLEWARE,
+                static function (ContainerInterface $container): AdminLoginRateLimitMiddleware {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+                    $storage        = $container->get(RateLimitStorageInterface::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    if (!$storage instanceof RateLimitStorageInterface) {
+                        throw new LogicException('Rate limit storage service is invalid.');
+                    }
+
+                    return new AdminLoginRateLimitMiddleware($problemDetails, $storage);
                 },
             )
             ->set(

--- a/src/AdminAuth/AdminLoginRateLimitMiddleware.php
+++ b/src/AdminAuth/AdminLoginRateLimitMiddleware.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Middleware\RateLimitStorageInterface;
+use NeneCorpus\Http\RequestMetadataExtractor;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Protects POST /admin/auth/login against brute-force attacks.
+ *
+ * Limits login attempts to MAX_ATTEMPTS per IP per WINDOW_SECONDS.
+ * Uses the shared PdoRateLimitStorage (rate_limit_buckets table).
+ */
+final readonly class AdminLoginRateLimitMiddleware implements MiddlewareInterface
+{
+    private const LOGIN_PATH = '/admin/auth/login';
+
+    /** Maximum login attempts allowed within the window. */
+    private const MAX_ATTEMPTS = 10;
+
+    /** Rate-limit window in seconds (15 minutes). */
+    private const WINDOW_SECONDS = 900;
+
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+        private RateLimitStorageInterface $storage,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (
+            strtoupper($request->getMethod()) !== 'POST'
+            || $request->getUri()->getPath() !== self::LOGIN_PATH
+        ) {
+            return $handler->handle($request);
+        }
+
+        $ip  = RequestMetadataExtractor::clientIp($request) ?? 'unknown';
+        $key = 'admin:login:ip:' . $ip;
+
+        $result = $this->storage->hit($key, self::WINDOW_SECONDS);
+
+        if ($result['count'] > self::MAX_ATTEMPTS) {
+            $retryAfter = max(0, $result['reset_at'] - time());
+            $response   = $this->problemDetails->create(
+                $request,
+                'too_many_requests',
+                'Too many login attempts. Please try again later.',
+                429,
+                'Rate limit exceeded: ' . self::MAX_ATTEMPTS . ' attempts per ' . (self::WINDOW_SECONDS / 60) . ' minutes.',
+            );
+
+            return $response->withHeader('Retry-After', (string) $retryAfter);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -23,6 +23,7 @@ use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
 use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
 use NeneCorpus\AdminAuth\AdminBearerTokenMiddleware;
+use NeneCorpus\AdminAuth\AdminLoginRateLimitMiddleware;
 use NeneCorpus\ApplicationServiceProvider;
 use NeneCorpus\Install\InstallServiceProvider;
 use NeneCorpus\RateLimit\ConsumerChatRateLimitMiddleware;
@@ -217,12 +218,17 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('RequestIdHolder service is invalid.');
                     }
 
-                    $authMiddleware = $container->get(AdminAuthServiceProvider::AUTH_MIDDLEWARE);
-                    $chatRateLimit = $container->get(RateLimitServiceProvider::CHAT_RATE_LIMIT_MIDDLEWARE);
-                    $basePathMiddleware = $container->get(InstallServiceProvider::BASE_PATH_MIDDLEWARE);
+                    $authMiddleware      = $container->get(AdminAuthServiceProvider::AUTH_MIDDLEWARE);
+                    $loginRateLimit      = $container->get(AdminAuthServiceProvider::LOGIN_RATE_LIMIT_MIDDLEWARE);
+                    $chatRateLimit       = $container->get(RateLimitServiceProvider::CHAT_RATE_LIMIT_MIDDLEWARE);
+                    $basePathMiddleware  = $container->get(InstallServiceProvider::BASE_PATH_MIDDLEWARE);
 
                     if ($authMiddleware !== null && !$authMiddleware instanceof AdminBearerTokenMiddleware) {
                         throw new LogicException('Admin auth middleware service is invalid.');
+                    }
+
+                    if (!$loginRateLimit instanceof AdminLoginRateLimitMiddleware) {
+                        throw new LogicException('Admin login rate limit middleware service is invalid.');
                     }
 
                     if (!$chatRateLimit instanceof ConsumerChatRateLimitMiddleware) {
@@ -236,6 +242,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     /** @var list<\Psr\Http\Server\MiddlewareInterface> $requestMiddleware */
                     $requestMiddleware = array_values(array_filter([
                         $basePathMiddleware,
+                        $loginRateLimit,
                         $authMiddleware,
                         $chatRateLimit,
                     ]));

--- a/tests/AdminAuth/AdminAuthHttpTest.php
+++ b/tests/AdminAuth/AdminAuthHttpTest.php
@@ -8,7 +8,9 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -35,6 +37,7 @@ final class AdminAuthHttpTest extends TestCase
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
         CorpusSchemaSetup::createAdminUsers($executor);
+        RateLimitSchemaSetup::create($executor);
 
         $hash = password_hash('secret-password', PASSWORD_ARGON2ID);
         $now = gmdate('Y-m-d H:i:s');
@@ -126,6 +129,66 @@ final class AdminAuthHttpTest extends TestCase
         );
 
         self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_login_returns_429_after_exceeding_rate_limit(): void
+    {
+        $app  = $this->application();
+        $body = json_encode(['email' => 'admin@example.com', 'password' => 'wrong-password'], JSON_THROW_ON_ERROR);
+
+        $makeRequest = function () use ($app, $body): ResponseInterface {
+            return $app->handle(
+                new ServerRequest(
+                    'POST',
+                    'https://example.test/admin/auth/login',
+                    ['Content-Type' => ['application/json']],
+                    $this->factory()->createStream($body),
+                    '1.1',
+                    ['REMOTE_ADDR' => '192.0.2.1'],
+                ),
+            );
+        };
+
+        // Exhaust the rate limit (MAX_ATTEMPTS = 10)
+        for ($i = 0; $i < 10; $i++) {
+            $makeRequest();
+        }
+
+        // The 11th attempt must be rejected
+        $response = $makeRequest();
+
+        self::assertSame(429, $response->getStatusCode());
+        self::assertNotEmpty($response->getHeaderLine('Retry-After'));
+    }
+
+    public function test_login_rate_limit_is_per_ip(): void
+    {
+        $app  = $this->application();
+        $body = json_encode(['email' => 'admin@example.com', 'password' => 'wrong-password'], JSON_THROW_ON_ERROR);
+
+        $makeRequest = function (string $ip) use ($app, $body): ResponseInterface {
+            return $app->handle(
+                new ServerRequest(
+                    'POST',
+                    'https://example.test/admin/auth/login',
+                    ['Content-Type' => ['application/json']],
+                    $this->factory()->createStream($body),
+                    '1.1',
+                    ['REMOTE_ADDR' => $ip],
+                ),
+            );
+        };
+
+        // Exhaust the limit for IP A
+        for ($i = 0; $i < 10; $i++) {
+            $makeRequest('10.0.0.1');
+        }
+
+        // IP A is blocked
+        self::assertSame(429, $makeRequest('10.0.0.1')->getStatusCode());
+
+        // IP B is still allowed
+        self::assertSame(401, $makeRequest('10.0.0.2')->getStatusCode());
     }
 
     private function application(): RequestHandlerInterface

--- a/tests/Appearance/AppearanceHttpTest.php
+++ b/tests/Appearance/AppearanceHttpTest.php
@@ -8,6 +8,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use NeneCorpus\Tests\Support\SampleHeroImage;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -36,6 +37,7 @@ final class AppearanceHttpTest extends TestCase
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
         CorpusSchemaSetup::createAdminUsers($executor);
+        RateLimitSchemaSetup::create($executor);
         CorpusSchemaSetup::createAppearanceSettings($executor);
 
         $hash = password_hash('secret-password', PASSWORD_ARGON2ID);

--- a/tests/ChatSettings/ChatSettingsHttpTest.php
+++ b/tests/ChatSettings/ChatSettingsHttpTest.php
@@ -8,6 +8,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -50,6 +51,7 @@ final class ChatSettingsHttpTest extends TestCase
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
         CorpusSchemaSetup::createAdminUsers($executor);
+        RateLimitSchemaSetup::create($executor);
         CorpusSchemaSetup::createChatSettings($executor);
 
         $hash = password_hash('secret-password', PASSWORD_ARGON2ID);

--- a/tests/Settings/LlmSettingsHttpTest.php
+++ b/tests/Settings/LlmSettingsHttpTest.php
@@ -8,6 +8,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -55,6 +56,7 @@ final class LlmSettingsHttpTest extends TestCase
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
         CorpusSchemaSetup::createAdminUsers($executor);
+        RateLimitSchemaSetup::create($executor);
 
         $hash = password_hash('secret-password', PASSWORD_ARGON2ID);
         $now = gmdate('Y-m-d H:i:s');

--- a/tests/Support/AdminHttpTestSupport.php
+++ b/tests/Support/AdminHttpTestSupport.php
@@ -11,6 +11,7 @@ final class AdminHttpTestSupport
     public static function seedCorpusSchema(PdoDatabaseQueryExecutor $executor): void
     {
         CorpusSchemaSetup::create($executor);
+        RateLimitSchemaSetup::create($executor);
         self::seedAdminUser($executor);
     }
 


### PR DESCRIPTION
## 概要

Issue #224 対応。管理画面ログインに IP ベースのレートリミットを実装。

## 変更内容

### 新規
- **`src/AdminAuth/AdminLoginRateLimitMiddleware.php`**
  - `POST /admin/auth/login` を IP 単位でレートリミット
  - 15分間10回超 → HTTP 429 + `Retry-After` ヘッダー
  - 既存 `PdoRateLimitStorage`（`rate_limit_buckets` テーブル）を使用

### 更新
- **`AdminAuthServiceProvider`** — `LOGIN_RATE_LIMIT_MIDDLEWARE` を DI 登録
- **`RuntimeServiceProvider`** — ミドルウェアスタックに追加
  `basePathMiddleware → loginRateLimit → authMiddleware → chatRateLimit`
- **`AdminAuthHttpTest`** — 429 テスト・IP分離テスト追加
- **`AdminHttpTestSupport.seedCorpusSchema`** — `rate_limit_buckets` を全 HTTP テストに追加

## テクニカルノート
- `ConsumerChatRateLimitMiddleware` と同パターン（path filter + `storage->hit()`）
- 成功・失敗関係なく全ログイン試行をカウント（timing attack 対策）
- bucket key: `admin:login:ip:{ip}`

## セルフレビュー
- [x] `docs/review/middleware-security.md` チェック
- [x] `composer check` (PHPUnit 122 tests + PHPStan level8 + CS-Fixer + OpenAPI + MCP) 通過

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)