### PR TITLE
feat(guide): ガイド LP から HOWTO へのクロスリンクを追加 (#230)

### DIFF
--- a/public_html/guide/de/index.html
+++ b/public_html/guide/de/index.html
@@ -496,7 +496,12 @@
           <div>
             <span class="text-xs font-bold uppercase tracking-widest mb-3 block" style="color:#4d8f7f">For Operators</span>
             <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-4">Erste Schritte (Betreiber)</h2>
-            <p class="text-gray-400 dark:text-gray-500 mb-10 text-lg">Von der Installation bis zum Live-Widget in 4 Schritten — funktioniert auf Shared Hosting und Docker.</p>
+            <p class="text-gray-400 dark:text-gray-500 mb-6 text-lg">Von der Installation bis zum Live-Widget in 4 Schritten — funktioniert auf Shared Hosting und Docker.</p>
+            <a href="../howto/de/"
+               class="inline-flex items-center gap-2 mb-8 rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-md transition-opacity hover:opacity-90"
+               style="background:#4d8f7f">
+              Schritt-für-Schritt-Tutorial →
+            </a>
             
         <div class="relative flex gap-5 pb-10">
           <span class="absolute left-5 top-11 bottom-0 border-l-2 border-dashed border-gray-200" aria-hidden="true"></span>

--- a/public_html/guide/en/index.html
+++ b/public_html/guide/en/index.html
@@ -496,7 +496,12 @@
           <div>
             <span class="text-xs font-bold uppercase tracking-widest mb-3 block" style="color:#4d8f7f">For Operators</span>
             <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-4">Getting Started (Operators)</h2>
-            <p class="text-gray-400 dark:text-gray-500 mb-10 text-lg">From install to live widget in 4 steps — works on shared hosting and Docker alike.</p>
+            <p class="text-gray-400 dark:text-gray-500 mb-6 text-lg">From install to live widget in 4 steps — works on shared hosting and Docker alike.</p>
+            <a href="../howto/en/"
+               class="inline-flex items-center gap-2 mb-8 rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-md transition-opacity hover:opacity-90"
+               style="background:#4d8f7f">
+              Step-by-step tutorial →
+            </a>
             
         <div class="relative flex gap-5 pb-10">
           <span class="absolute left-5 top-11 bottom-0 border-l-2 border-dashed border-gray-200" aria-hidden="true"></span>

--- a/public_html/guide/fr/index.html
+++ b/public_html/guide/fr/index.html
@@ -496,7 +496,12 @@
           <div>
             <span class="text-xs font-bold uppercase tracking-widest mb-3 block" style="color:#4d8f7f">For Operators</span>
             <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-4">Démarrage (opérateurs)</h2>
-            <p class="text-gray-400 dark:text-gray-500 mb-10 text-lg">De l'installation au widget en direct en 4 étapes — fonctionne sur hébergement mutualisé et Docker.</p>
+            <p class="text-gray-400 dark:text-gray-500 mb-6 text-lg">De l'installation au widget en direct en 4 étapes — fonctionne sur hébergement mutualisé et Docker.</p>
+            <a href="../howto/fr/"
+               class="inline-flex items-center gap-2 mb-8 rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-md transition-opacity hover:opacity-90"
+               style="background:#4d8f7f">
+              Tutoriel étape par étape →
+            </a>
             
         <div class="relative flex gap-5 pb-10">
           <span class="absolute left-5 top-11 bottom-0 border-l-2 border-dashed border-gray-200" aria-hidden="true"></span>

--- a/public_html/guide/ja/index.html
+++ b/public_html/guide/ja/index.html
@@ -496,7 +496,12 @@
           <div>
             <span class="text-xs font-bold uppercase tracking-widest mb-3 block" style="color:#4d8f7f">For Operators</span>
             <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-4">はじめかた（管理者向け）</h2>
-            <p class="text-gray-400 dark:text-gray-500 mb-10 text-lg">インストールからウィジェット公開まで 4 ステップ。共用ホスティングでも Docker でも同じ手順です。</p>
+            <p class="text-gray-400 dark:text-gray-500 mb-6 text-lg">インストールからウィジェット公開まで 4 ステップ。共用ホスティングでも Docker でも同じ手順です。</p>
+            <a href="../howto/ja/"
+               class="inline-flex items-center gap-2 mb-8 rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-md transition-opacity hover:opacity-90"
+               style="background:#4d8f7f">
+              ステップごとのチュートリアルはこちら →
+            </a>
             
         <div class="relative flex gap-5 pb-10">
           <span class="absolute left-5 top-11 bottom-0 border-l-2 border-dashed border-gray-200" aria-hidden="true"></span>

--- a/public_html/guide/pt-br/index.html
+++ b/public_html/guide/pt-br/index.html
@@ -496,7 +496,12 @@
           <div>
             <span class="text-xs font-bold uppercase tracking-widest mb-3 block" style="color:#4d8f7f">For Operators</span>
             <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-4">Primeiros Passos (Operadores)</h2>
-            <p class="text-gray-400 dark:text-gray-500 mb-10 text-lg">Da instalação ao widget ao vivo em 4 passos — funciona em hospedagem compartilhada e Docker.</p>
+            <p class="text-gray-400 dark:text-gray-500 mb-6 text-lg">Da instalação ao widget ao vivo em 4 passos — funciona em hospedagem compartilhada e Docker.</p>
+            <a href="../howto/pt-br/"
+               class="inline-flex items-center gap-2 mb-8 rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-md transition-opacity hover:opacity-90"
+               style="background:#4d8f7f">
+              Tutorial passo a passo →
+            </a>
             
         <div class="relative flex gap-5 pb-10">
           <span class="absolute left-5 top-11 bottom-0 border-l-2 border-dashed border-gray-200" aria-hidden="true"></span>

--- a/public_html/guide/zh-hans/index.html
+++ b/public_html/guide/zh-hans/index.html
@@ -496,7 +496,12 @@
           <div>
             <span class="text-xs font-bold uppercase tracking-widest mb-3 block" style="color:#4d8f7f">For Operators</span>
             <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-4">快速开始（管理员）</h2>
-            <p class="text-gray-400 dark:text-gray-500 mb-10 text-lg">从安装到上线 Widget，只需 4 步——适用于共享主机和 Docker。</p>
+            <p class="text-gray-400 dark:text-gray-500 mb-6 text-lg">从安装到上线 Widget，只需 4 步——适用于共享主机和 Docker。</p>
+            <a href="../howto/zh-hans/"
+               class="inline-flex items-center gap-2 mb-8 rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-md transition-opacity hover:opacity-90"
+               style="background:#4d8f7f">
+              逐步教程 →
+            </a>
             
         <div class="relative flex gap-5 pb-10">
           <span class="absolute left-5 top-11 bottom-0 border-l-2 border-dashed border-gray-200" aria-hidden="true"></span>

--- a/scripts/build-guide.mjs
+++ b/scripts/build-guide.mjs
@@ -623,7 +623,12 @@ function buildPage(locale, msgs, allLocales) {
           <div>
             <span class="text-xs font-bold uppercase tracking-widest mb-3 block" style="color:${BRAND}">For Operators</span>
             <h2 class="text-2xl sm:text-3xl lg:text-4xl font-extrabold text-gray-950 dark:text-white mb-4">${t('forAdmin.title')}</h2>
-            <p class="text-gray-400 dark:text-gray-500 mb-10 text-lg">${t('forAdmin.subtitle')}</p>
+            <p class="text-gray-400 dark:text-gray-500 mb-6 text-lg">${t('forAdmin.subtitle')}</p>
+            <a href="../howto/${locale.id}/"
+               class="inline-flex items-center gap-2 mb-8 rounded-xl px-5 py-2.5 text-sm font-semibold text-white shadow-md transition-opacity hover:opacity-90"
+               style="background:${BRAND}">
+              ${t('forAdmin.howtoLink')}
+            </a>
             ${stepTimeline('forAdmin', 4)}
           </div>
           <div class="hidden lg:block sticky top-24">

--- a/scripts/guide-locales/de.mjs
+++ b/scripts/guide-locales/de.mjs
@@ -53,6 +53,7 @@ export default {
   'forAdmin.step4.title': 'Widget einbetten',
   'forAdmin.step4.desc': 'Einbettungscode aus Einstellungen → Design kopieren und direkt vor &lt;/body&gt; einfügen. Fertig.',
   'forAdmin.embedCaption': 'Einbettungscode (aus Einstellungen → Design kopieren)',
+  'forAdmin.howtoLink': 'Schritt-für-Schritt-Tutorial →',
 
   'forUser.title': 'Chat-Widget verwenden',
   'forUser.subtitle': 'Das Widget ist intuitiv. So funktioniert es in 3 Schritten.',

--- a/scripts/guide-locales/en.mjs
+++ b/scripts/guide-locales/en.mjs
@@ -53,6 +53,7 @@ export default {
   'forAdmin.step4.title': 'Embed the Widget',
   'forAdmin.step4.desc': 'Copy the embed code from Settings → Design and paste it just before &lt;/body&gt;. That\'s all it takes to go live.',
   'forAdmin.embedCaption': 'Embed code (copy from Settings → Design)',
+  'forAdmin.howtoLink': 'Step-by-step tutorial →',
 
   'forUser.title': 'Using the Chat Widget',
   'forUser.subtitle': 'The widget is intuitive. Here\'s how it works in 3 steps.',

--- a/scripts/guide-locales/fr.mjs
+++ b/scripts/guide-locales/fr.mjs
@@ -53,6 +53,7 @@ export default {
   'forAdmin.step4.title': "Intégrer le widget",
   'forAdmin.step4.desc': "Copiez le code d'intégration depuis Paramètres → Design et collez-le juste avant &lt;/body&gt;. C'est tout.",
   'forAdmin.embedCaption': "Code d'intégration (copier depuis Paramètres → Design)",
+  'forAdmin.howtoLink': 'Tutoriel étape par étape →',
 
   'forUser.title': 'Utiliser le widget de chat',
   'forUser.subtitle': "Le widget est intuitif. Voici comment il fonctionne en 3 étapes.",

--- a/scripts/guide-locales/ja.mjs
+++ b/scripts/guide-locales/ja.mjs
@@ -53,6 +53,7 @@ export default {
   'forAdmin.step4.title': 'ウィジェットを埋め込む',
   'forAdmin.step4.desc': '設定 → デザインタブの埋め込みコードをコピーして、既存ページの &lt;/body&gt; 直前に貼り付けてください。それだけで公開完了です。',
   'forAdmin.embedCaption': '埋め込みコード（設定 → デザインタブからコピーできます）',
+  'forAdmin.howtoLink': 'ステップごとのチュートリアルはこちら →',
 
   'forUser.title': 'はじめかた（利用者向け）',
   'forUser.subtitle': 'ウィジェットは直感的に使えます。3 ステップで使い方がわかります。',

--- a/scripts/guide-locales/pt-br.mjs
+++ b/scripts/guide-locales/pt-br.mjs
@@ -53,6 +53,7 @@ export default {
   'forAdmin.step4.title': 'Incorporar o Widget',
   'forAdmin.step4.desc': 'Copie o código de incorporação de Configurações → Design e cole logo antes de &lt;/body&gt;. Pronto.',
   'forAdmin.embedCaption': 'Código de incorporação (copiar de Configurações → Design)',
+  'forAdmin.howtoLink': 'Tutorial passo a passo →',
 
   'forUser.title': 'Usando o Widget de Chat',
   'forUser.subtitle': 'O widget é intuitivo. Veja como funciona em 3 passos.',

--- a/scripts/guide-locales/zh-hans.mjs
+++ b/scripts/guide-locales/zh-hans.mjs
@@ -53,6 +53,7 @@ export default {
   'forAdmin.step4.title': '嵌入组件',
   'forAdmin.step4.desc': '从设置 → 设计选项卡复制嵌入代码，粘贴到页面 &lt;/body&gt; 之前。完成。',
   'forAdmin.embedCaption': '嵌入代码（从设置 → 设计选项卡复制）',
+  'forAdmin.howtoLink': '逐步教程 →',
 
   'forUser.title': '使用聊天组件',
   'forUser.subtitle': '聊天组件操作直观，3 步即可上手。',


### PR DESCRIPTION
## 概要

Closes #230

ガイド LP（/guide/{locale}/）の「管理者ガイド」セクションに、HOWTO ページ（/guide/howto/{locale}/）へのリンクボタンを追加。

## 変更内容

- `scripts/build-guide.mjs` — for-admin セクションにブランドカラーのリンクボタンを追加
- `scripts/guide-locales/{ja,en,de,fr,zh-hans,pt-br}.mjs` — `forAdmin.howtoLink` キー追加
- `public_html/guide/*/index.html` — 再ビルド済み

## セルフレビューチェックリスト

- [x] [docs-policy.md](docs/review/docs-policy.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)