### PR TITLE
feat(guide): ガイド・HOWTO 全ページに OG / Twitter Card メタタグを追加 (#232)

### DIFF
--- a/public_html/guide/de/index.html
+++ b/public_html/guide/de/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="NeNe Corpus — Wissens-Chat für Ihre Website"/>
   <meta property="og:description" content="Laden Sie PDFs und CSVs hoch, um ein Corpus aufzubauen, und betten Sie einen zitierbasierten KI-Chat auf Ihrer Website ein. Open Source, selbst gehostet, MIT-Lizenz."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="NeNe Corpus — Wissens-Chat für Ihre Website"/>
+  <meta name="twitter:description" content="Laden Sie PDFs und CSVs hoch, um ein Corpus aufzubauen, und betten Sie einen zitierbasierten KI-Chat auf Ihrer Website ein. Open Source, selbst gehostet, MIT-Lizenz."/>
+  <meta name="twitter:image" content="../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/en/index.html
+++ b/public_html/guide/en/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="NeNe Corpus — Knowledge Chat for Your Website"/>
   <meta property="og:description" content="Upload PDFs and CSVs to build a corpus, then embed a citation-based AI chat widget on your website. Open source, self-hosted, MIT license."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="NeNe Corpus — Knowledge Chat for Your Website"/>
+  <meta name="twitter:description" content="Upload PDFs and CSVs to build a corpus, then embed a citation-based AI chat widget on your website. Open source, self-hosted, MIT license."/>
+  <meta name="twitter:image" content="../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/fr/index.html
+++ b/public_html/guide/fr/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="NeNe Corpus — Chat de connaissances pour votre site web"/>
   <meta property="og:description" content="Téléchargez des PDF et CSV pour construire un corpus, puis intégrez un widget de chat IA avec citations. Open source, auto-hébergé, licence MIT."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="NeNe Corpus — Chat de connaissances pour votre site web"/>
+  <meta name="twitter:description" content="Téléchargez des PDF et CSV pour construire un corpus, puis intégrez un widget de chat IA avec citations. Open source, auto-hébergé, licence MIT."/>
+  <meta name="twitter:image" content="../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/howto/de/index.html
+++ b/public_html/guide/howto/de/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="Einrichtungsanleitung — NeNe Corpus HOWTO"/>
   <meta property="og:description" content="Folge Sakura, einer Café-Besitzerin, und richte NeNe Corpus in 4 Schritten ein — von der Installation bis zum Live-Chat."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Einrichtungsanleitung — NeNe Corpus HOWTO"/>
+  <meta name="twitter:description" content="Folge Sakura, einer Café-Besitzerin, und richte NeNe Corpus in 4 Schritten ein — von der Installation bis zum Live-Chat."/>
+  <meta name="twitter:image" content="../../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/howto/en/index.html
+++ b/public_html/guide/howto/en/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="Setup Guide — NeNe Corpus HOWTO"/>
   <meta property="og:description" content="Follow along with Sakura, a café owner, and set up NeNe Corpus in 4 steps — from install to AI chat going live."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Setup Guide — NeNe Corpus HOWTO"/>
+  <meta name="twitter:description" content="Follow along with Sakura, a café owner, and set up NeNe Corpus in 4 steps — from install to AI chat going live."/>
+  <meta name="twitter:image" content="../../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/howto/fr/index.html
+++ b/public_html/guide/howto/fr/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="Guide d'installation — NeNe Corpus HOWTO"/>
   <meta property="og:description" content="Suivez Sakura, propriétaire d'un café, et configurez NeNe Corpus en 4 étapes — de l'installation à la mise en ligne du chat IA."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Guide d'installation — NeNe Corpus HOWTO"/>
+  <meta name="twitter:description" content="Suivez Sakura, propriétaire d'un café, et configurez NeNe Corpus en 4 étapes — de l'installation à la mise en ligne du chat IA."/>
+  <meta name="twitter:image" content="../../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/howto/ja/index.html
+++ b/public_html/guide/howto/ja/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="セットアップガイド — NeNe Corpus HOWTO"/>
   <meta property="og:description" content="カフェオーナーのさくらさんといっしょに NeNe Corpus のセットアップを体験。インストールから AI チャット公開まで 4 ステップで完了。"/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="セットアップガイド — NeNe Corpus HOWTO"/>
+  <meta name="twitter:description" content="カフェオーナーのさくらさんといっしょに NeNe Corpus のセットアップを体験。インストールから AI チャット公開まで 4 ステップで完了。"/>
+  <meta name="twitter:image" content="../../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/howto/pt-br/index.html
+++ b/public_html/guide/howto/pt-br/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="Guia de Instalação — NeNe Corpus HOWTO"/>
   <meta property="og:description" content="Siga a Sakura, dona de um café, e configure o NeNe Corpus em 4 passos — da instalação ao chat de IA no ar."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="Guia de Instalação — NeNe Corpus HOWTO"/>
+  <meta name="twitter:description" content="Siga a Sakura, dona de um café, e configure o NeNe Corpus em 4 passos — da instalação ao chat de IA no ar."/>
+  <meta name="twitter:image" content="../../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/howto/zh-hans/index.html
+++ b/public_html/guide/howto/zh-hans/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="安装指南 — NeNe Corpus HOWTO"/>
   <meta property="og:description" content="跟随咖啡馆老板 Sakura，4 步完成 NeNe Corpus 的安装与配置，从安装到 AI 聊天上线。"/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="安装指南 — NeNe Corpus HOWTO"/>
+  <meta name="twitter:description" content="跟随咖啡馆老板 Sakura，4 步完成 NeNe Corpus 的安装与配置，从安装到 AI 聊天上线。"/>
+  <meta name="twitter:image" content="../../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/ja/index.html
+++ b/public_html/guide/ja/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="NeNe Corpus — ナレッジチャット for あなたのウェブサイト"/>
   <meta property="og:description" content="PDF・CSV をアップロードしてコーパスを構築し、引用付き AI チャットをウェブサイトに埋め込める OSS ツール。自己ホスト型・MIT ライセンス。"/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="NeNe Corpus — ナレッジチャット for あなたのウェブサイト"/>
+  <meta name="twitter:description" content="PDF・CSV をアップロードしてコーパスを構築し、引用付き AI チャットをウェブサイトに埋め込める OSS ツール。自己ホスト型・MIT ライセンス。"/>
+  <meta name="twitter:image" content="../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/og-image.svg
+++ b/public_html/guide/og-image.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1a2e2b"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4d8f7f"/>
+      <stop offset="100%" stop-color="#3a6e62"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Accent orb top-right -->
+  <circle cx="1100" cy="80" r="200" fill="#4d8f7f" opacity="0.08"/>
+
+  <!-- Accent orb bottom-left -->
+  <circle cx="120" cy="560" r="160" fill="#4d8f7f" opacity="0.06"/>
+
+  <!-- Brand badge -->
+  <rect x="80" y="80" width="120" height="36" rx="18" fill="#4d8f7f" opacity="0.9"/>
+  <text x="140" y="103" font-family="system-ui, sans-serif" font-size="14" font-weight="700" fill="white" text-anchor="middle" letter-spacing="1">NeNe Corpus</text>
+
+  <!-- Main title -->
+  <text x="80" y="210" font-family="system-ui, sans-serif" font-size="72" font-weight="900" fill="white" opacity="0.95">Knowledge Chat</text>
+  <text x="80" y="296" font-family="system-ui, sans-serif" font-size="72" font-weight="900" fill="url(#brand)">for your website.</text>
+
+  <!-- Subtitle -->
+  <text x="80" y="370" font-family="system-ui, sans-serif" font-size="28" fill="#94a3b8" font-weight="400">Open source · Self-hosted · No streaming required</text>
+
+  <!-- Feature pills -->
+  <rect x="80" y="420" width="160" height="44" rx="22" fill="#4d8f7f" opacity="0.2"/>
+  <text x="160" y="447" font-family="system-ui, sans-serif" font-size="16" fill="#4d8f7f" text-anchor="middle" font-weight="600">📄 PDF / CSV</text>
+
+  <rect x="260" y="420" width="180" height="44" rx="22" fill="#4d8f7f" opacity="0.2"/>
+  <text x="350" y="447" font-family="system-ui, sans-serif" font-size="16" fill="#4d8f7f" text-anchor="middle" font-weight="600">💬 Chat Widget</text>
+
+  <rect x="460" y="420" width="200" height="44" rx="22" fill="#4d8f7f" opacity="0.2"/>
+  <text x="560" y="447" font-family="system-ui, sans-serif" font-size="16" fill="#4d8f7f" text-anchor="middle" font-weight="600">🔗 Cited Answers</text>
+
+  <rect x="680" y="420" width="200" height="44" rx="22" fill="#4d8f7f" opacity="0.2"/>
+  <text x="780" y="447" font-family="system-ui, sans-serif" font-size="16" fill="#4d8f7f" text-anchor="middle" font-weight="600">🌐 6 Languages</text>
+
+  <!-- Bottom URL -->
+  <text x="80" y="580" font-family="system-ui, sans-serif" font-size="20" fill="#475569" font-weight="500">github.com/hideyukiMORI/nene-corpus</text>
+</svg>

--- a/public_html/guide/pt-br/index.html
+++ b/public_html/guide/pt-br/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="NeNe Corpus — Chat de Conhecimento para o Seu Site"/>
   <meta property="og:description" content="Envie PDFs e CSVs para construir um corpus e incorpore um widget de chat IA com citações no seu site. Código aberto, auto-hospedado, licença MIT."/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="NeNe Corpus — Chat de Conhecimento para o Seu Site"/>
+  <meta name="twitter:description" content="Envie PDFs e CSVs para construir um corpus e incorpore um widget de chat IA com citações no seu site. Código aberto, auto-hospedado, licença MIT."/>
+  <meta name="twitter:image" content="../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet"/>

--- a/public_html/guide/zh-hans/index.html
+++ b/public_html/guide/zh-hans/index.html
@@ -8,6 +8,13 @@
   <meta property="og:title" content="NeNe Corpus — 为您的网站提供知识问答"/>
   <meta property="og:description" content="上传 PDF 和 CSV 构建语料库，然后在网站上嵌入带引用的 AI 聊天组件。开源，自托管，MIT 许可证。"/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="NeNe Corpus — 为您的网站提供知识问答"/>
+  <meta name="twitter:description" content="上传 PDF 和 CSV 构建语料库，然后在网站上嵌入带引用的 AI 聊天组件。开源，自托管，MIT 许可证。"/>
+  <meta name="twitter:image" content="../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;700;900&display=swap" rel="stylesheet"/>

--- a/scripts/build-guide.mjs
+++ b/scripts/build-guide.mjs
@@ -370,6 +370,13 @@ function buildPage(locale, msgs, allLocales) {
   <meta property="og:title" content="${t('meta.title')}"/>
   <meta property="og:description" content="${t('meta.description')}"/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="${t('meta.title')}"/>
+  <meta name="twitter:description" content="${t('meta.description')}"/>
+  <meta name="twitter:image" content="../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=${locale.googleFont}&display=swap" rel="stylesheet"/>

--- a/scripts/build-howto.mjs
+++ b/scripts/build-howto.mjs
@@ -143,6 +143,13 @@ function buildPage(locale, msgs, allLocales) {
   <meta property="og:title" content="${raw('meta.title')}"/>
   <meta property="og:description" content="${raw('meta.description')}"/>
   <meta property="og:type" content="website"/>
+  <meta property="og:image" content="../../og-image.svg"/>
+  <meta property="og:image:width" content="1200"/>
+  <meta property="og:image:height" content="630"/>
+  <meta name="twitter:card" content="summary_large_image"/>
+  <meta name="twitter:title" content="${raw('meta.title')}"/>
+  <meta name="twitter:description" content="${raw('meta.description')}"/>
+  <meta name="twitter:image" content="../../og-image.svg"/>
   <link rel="preconnect" href="https://fonts.googleapis.com"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=${locale.googleFont}&display=swap" rel="stylesheet"/>


### PR DESCRIPTION
## 概要

Closes #232

ガイド LP（guide/）と HOWTO（guide/howto/）の全 14 ページに OG / Twitter Card メタタグを追加。SNS シェア時にリッチプレビューが表示されるようになる。

## 変更内容

- `public_html/guide/og-image.svg` — 1200×630 の OG 画像を新規作成（ブランドカラー・ダーク背景・フィーチャーピル）
- `scripts/build-guide.mjs` — `og:image` / `og:image:width` / `og:image:height` / `twitter:card` / `twitter:title` / `twitter:description` / `twitter:image` を追加
- `scripts/build-howto.mjs` — 同上（相対パスは `../../og-image.svg`）
- 全 14 ページ（guide × 7 + howto × 7）を再ビルド

## セルフレビュー

- [x] OG タグが guide 各ロケールページに正しく出力されること（`../og-image.svg`）
- [x] OG タグが howto 各ロケールページに正しく出力されること（`../../og-image.svg`）
- [x] Twitter Card タグ（`summary_large_image`）が全ページに存在すること
- [x] og:image:width=1200 / og:image:height=630 が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)