### PR TITLE
ci: リリース ZIP に guide・howto ページが含まれることを検証する (#234)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -46,3 +46,6 @@ jobs:
           unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/vendor/autoload.php'
           unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/admin/index.html'
           unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/widget.js'
+          unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/guide/en/index.html'
+          unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/guide/howto/en/index.html'
+          unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/guide/og-image.svg'


### PR DESCRIPTION
## 概要

Closes #234

`.github/workflows/release-build.yml` の「Verify ZIP contents」ステップに、ガイドページが ZIP に含まれているかの検証を追加。

## 変更内容

`release-build.yml` Verify ZIP contents ステップに以下を追加:

```bash
unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/guide/en/index.html'
unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/guide/howto/en/index.html'
unzip -l build/release/nene-corpus-*.zip | grep -E 'nene-corpus/public_html/guide/og-image.svg'
```

## セルフレビュー

- [x] `guide/en/index.html` が ZIP に含まれること（代表ロケール）
- [x] `guide/howto/en/index.html` が ZIP に含まれること（代表ロケール）
- [x] `guide/og-image.svg` が ZIP に含まれること
- [x] 既存の verification は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)