### PR TITLE
perf: .htaccess で widget.js 等の gzip 配信を有効化する (#236)

### DIFF
--- a/public_html/.htaccess
+++ b/public_html/.htaccess
@@ -3,3 +3,11 @@ RewriteEngine On
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]
+
+# Gzip compression for widget and API assets
+<IfModule mod_deflate.c>
+  AddOutputFilterByType DEFLATE application/javascript
+  AddOutputFilterByType DEFLATE text/css
+  AddOutputFilterByType DEFLATE text/html
+  AddOutputFilterByType DEFLATE application/json
+</IfModule>


### PR DESCRIPTION
## 概要

Closes #236

`public_html/.htaccess` に `mod_deflate` 設定を追加し、JS / CSS / HTML / JSON を gzip 圧縮して配信する。Tier A（共用ホスティング）で widget.js の初回ロードを削減。

## 変更内容

```apache
<IfModule mod_deflate.c>
  AddOutputFilterByType DEFLATE application/javascript
  AddOutputFilterByType DEFLATE text/css
  AddOutputFilterByType DEFLATE text/html
  AddOutputFilterByType DEFLATE application/json
</IfModule>
```

## セルフレビュー

- [x] `<IfModule mod_deflate.c>` で安全にガード（mod_deflate がなくても動作する）
- [x] widget.js（application/javascript）が対象に含まれる
- [x] widget.css（text/css）が対象に含まれる
- [x] 既存の RewriteRule は変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)