### PR TITLE
refactor: アーキテクチャ・命名規約違反を修正する (#238)

### DIFF
--- a/src/Chat/ChatServiceProvider.php
+++ b/src/Chat/ChatServiceProvider.php
@@ -41,6 +41,8 @@ final readonly class ChatServiceProvider implements ServiceProviderInterface
                     $sessions = $container->get(ChatSessionRepositoryInterface::class);
                     $messages = $container->get(ChatMessageRepositoryInterface::class);
                     $generateReply = $container->get(GenerateChatReplyUseCaseInterface::class);
+                    $limitsRepository = $container->get(ChatLimitsRepositoryInterface::class);
+                    $tokenTracker = $container->get(ChatTokenTrackerInterface::class);
 
                     if (!$sessions instanceof ChatSessionRepositoryInterface) {
                         throw new LogicException('Chat session repository service is invalid.');
@@ -54,7 +56,15 @@ final readonly class ChatServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Generate chat reply use case service is invalid.');
                     }
 
-                    return new SendChatMessageUseCase($sessions, $messages, $generateReply);
+                    if (!$limitsRepository instanceof ChatLimitsRepositoryInterface) {
+                        throw new LogicException('Chat limits repository service is invalid.');
+                    }
+
+                    if (!$tokenTracker instanceof ChatTokenTrackerInterface) {
+                        throw new LogicException('Chat token tracker service is invalid.');
+                    }
+
+                    return new SendChatMessageUseCase($sessions, $messages, $generateReply, $limitsRepository, $tokenTracker);
                 },
             )
             ->set(
@@ -79,8 +89,6 @@ final readonly class ChatServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): SendChatMessageHandler {
                     $useCase = $container->get(SendChatMessageUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
-                    $limitsRepository = $container->get(ChatLimitsRepositoryInterface::class);
-                    $tokenTracker = $container->get(ChatTokenTrackerInterface::class);
 
                     if (!$useCase instanceof SendChatMessageUseCaseInterface) {
                         throw new LogicException('Send chat message use case service is invalid.');
@@ -90,15 +98,7 @@ final readonly class ChatServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JSON response factory service is invalid.');
                     }
 
-                    if (!$limitsRepository instanceof ChatLimitsRepositoryInterface) {
-                        throw new LogicException('Chat limits repository service is invalid.');
-                    }
-
-                    if (!$tokenTracker instanceof ChatTokenTrackerInterface) {
-                        throw new LogicException('Chat token tracker service is invalid.');
-                    }
-
-                    return new SendChatMessageHandler($useCase, $response, $limitsRepository, $tokenTracker);
+                    return new SendChatMessageHandler($useCase, $response);
                 },
             )
             ->set(

--- a/src/Chat/SendChatMessageHandler.php
+++ b/src/Chat/SendChatMessageHandler.php
@@ -8,8 +8,6 @@ use Nene2\Http\JsonRequestBodyParser;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Validation\ValidationError;
 use Nene2\Validation\ValidationException;
-use NeneCorpus\ChatLimits\ChatLimitsRepositoryInterface;
-use NeneCorpus\ChatLimits\ChatTokenTrackerInterface;
 use NeneCorpus\Http\RequestMetadataExtractor;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,8 +19,6 @@ final readonly class SendChatMessageHandler
     public function __construct(
         private SendChatMessageUseCaseInterface $useCase,
         private JsonResponseFactory $response,
-        private ChatLimitsRepositoryInterface $limitsRepository,
-        private ChatTokenTrackerInterface $tokenTracker,
     ) {
     }
 
@@ -50,29 +46,13 @@ final readonly class SendChatMessageHandler
             throw new ValidationException($errors);
         }
 
-        // Character limit check (after empty-content guard so the error message is meaningful)
-        $limits = $this->limitsRepository->get();
-
-        if ($limits->maxMessageChars > 0 && mb_strlen($content) > $limits->maxMessageChars) {
-            throw new ValidationException([
-                new ValidationError(
-                    'content',
-                    sprintf('Message must not exceed %d characters.', $limits->maxMessageChars),
-                    'too_long',
-                ),
-            ]);
-        }
+        $clientIp = RequestMetadataExtractor::clientIp($request) ?? 'unknown';
 
         $output = $this->useCase->execute(new SendChatMessageInput(
             sessionToken: $sessionToken,
             content: $content,
+            clientIp: $clientIp,
         ));
-
-        // Track token usage for daily budget enforcement
-        if ($output->inputTokens > 0 || $output->outputTokens > 0) {
-            $ip = RequestMetadataExtractor::clientIp($request) ?? 'unknown';
-            $this->tokenTracker->track($ip, $output->inputTokens, $output->outputTokens);
-        }
 
         return $this->response->create([
             'message_id' => $output->messageId,

--- a/src/Chat/SendChatMessageInput.php
+++ b/src/Chat/SendChatMessageInput.php
@@ -9,6 +9,7 @@ final readonly class SendChatMessageInput
     public function __construct(
         public string $sessionToken,
         public string $content,
+        public string $clientIp = 'unknown',
     ) {
     }
 }

--- a/src/Chat/SendChatMessageUseCase.php
+++ b/src/Chat/SendChatMessageUseCase.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Chat;
 
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use NeneCorpus\ChatLimits\ChatLimitsRepositoryInterface;
+use NeneCorpus\ChatLimits\ChatTokenTrackerInterface;
 use NeneCorpus\Llm\ConversationTurn;
 use NeneCorpus\Llm\GenerateChatReplyInput;
 use NeneCorpus\Llm\GenerateChatReplyUseCaseInterface;
@@ -20,6 +24,8 @@ final readonly class SendChatMessageUseCase implements SendChatMessageUseCaseInt
         private ChatSessionRepositoryInterface $sessions,
         private ChatMessageRepositoryInterface $messages,
         private GenerateChatReplyUseCaseInterface $generateReply,
+        private ChatLimitsRepositoryInterface $limitsRepository,
+        private ChatTokenTrackerInterface $tokenTracker,
     ) {
     }
 
@@ -35,6 +41,19 @@ final readonly class SendChatMessageUseCase implements SendChatMessageUseCaseInt
 
         if ($content === '') {
             throw new \InvalidArgumentException('Message content is required.');
+        }
+
+        // Character limit enforcement
+        $limits = $this->limitsRepository->get();
+
+        if ($limits->maxMessageChars > 0 && mb_strlen($content) > $limits->maxMessageChars) {
+            throw new ValidationException([
+                new ValidationError(
+                    'content',
+                    sprintf('Message must not exceed %d characters.', $limits->maxMessageChars),
+                    'too_long',
+                ),
+            ]);
         }
 
         $this->messages->save(new ChatMessage(
@@ -62,6 +81,11 @@ final readonly class SendChatMessageUseCase implements SendChatMessageUseCaseInt
             inputTokens: $reply->inputTokens > 0 ? $reply->inputTokens : null,
             outputTokens: $reply->outputTokens > 0 ? $reply->outputTokens : null,
         ));
+
+        // Track token usage for daily budget enforcement
+        if ($reply->inputTokens > 0 || $reply->outputTokens > 0) {
+            $this->tokenTracker->track($input->clientIp, $reply->inputTokens, $reply->outputTokens);
+        }
 
         return new SendChatMessageOutput(
             messageId: $assistantMessageId,

--- a/src/ChatLimits/ChatLimitsServiceProvider.php
+++ b/src/ChatLimits/ChatLimitsServiceProvider.php
@@ -62,17 +62,12 @@ final readonly class ChatLimitsServiceProvider implements ServiceProviderInterfa
                 UpdateChatLimitsUseCaseInterface::class,
                 static function (ContainerInterface $container): UpdateChatLimitsUseCaseInterface {
                     $repository = $container->get(ChatLimitsRepositoryInterface::class);
-                    $validator = $container->get(ChatLimitsValidator::class);
 
                     if (!$repository instanceof ChatLimitsRepositoryInterface) {
                         throw new LogicException('Chat limits repository service is invalid.');
                     }
 
-                    if (!$validator instanceof ChatLimitsValidator) {
-                        throw new LogicException('Chat limits validator service is invalid.');
-                    }
-
-                    return new UpdateChatLimitsUseCase($repository, $validator);
+                    return new UpdateChatLimitsUseCase($repository);
                 },
             )
             ->set(
@@ -97,6 +92,7 @@ final readonly class ChatLimitsServiceProvider implements ServiceProviderInterfa
                 static function (ContainerInterface $container): UpdateChatLimitsHandler {
                     $useCase = $container->get(UpdateChatLimitsUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $validator = $container->get(ChatLimitsValidator::class);
 
                     if (!$useCase instanceof UpdateChatLimitsUseCaseInterface) {
                         throw new LogicException('Update chat limits use case service is invalid.');
@@ -106,7 +102,11 @@ final readonly class ChatLimitsServiceProvider implements ServiceProviderInterfa
                         throw new LogicException('JSON response factory service is invalid.');
                     }
 
-                    return new UpdateChatLimitsHandler($useCase, $response);
+                    if (!$validator instanceof ChatLimitsValidator) {
+                        throw new LogicException('Chat limits validator service is invalid.');
+                    }
+
+                    return new UpdateChatLimitsHandler($useCase, $response, $validator);
                 },
             )
             ->set(

--- a/src/ChatLimits/UpdateChatLimitsHandler.php
+++ b/src/ChatLimits/UpdateChatLimitsHandler.php
@@ -14,13 +14,15 @@ final readonly class UpdateChatLimitsHandler
     public function __construct(
         private UpdateChatLimitsUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private ChatLimitsValidator $validator,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $body = JsonRequestBodyParser::parse($request);
+        $input = $this->validator->validateUpdate($body);
 
-        return $this->response->create($this->useCase->executeFromBody($body)->toArray());
+        return $this->response->create($this->useCase->execute($input)->toArray());
     }
 }

--- a/src/ChatLimits/UpdateChatLimitsUseCase.php
+++ b/src/ChatLimits/UpdateChatLimitsUseCase.php
@@ -8,7 +8,6 @@ final readonly class UpdateChatLimitsUseCase implements UpdateChatLimitsUseCaseI
 {
     public function __construct(
         private ChatLimitsRepositoryInterface $repository,
-        private ChatLimitsValidator $validator,
     ) {
     }
 
@@ -30,11 +29,4 @@ final readonly class UpdateChatLimitsUseCase implements UpdateChatLimitsUseCaseI
         return ChatLimitsView::fromSettings($settings);
     }
 
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): ChatLimitsView
-    {
-        return $this->execute($this->validator->validateUpdate($body));
-    }
 }

--- a/src/ChatLimits/UpdateChatLimitsUseCaseInterface.php
+++ b/src/ChatLimits/UpdateChatLimitsUseCaseInterface.php
@@ -7,9 +7,4 @@ namespace NeneCorpus\ChatLimits;
 interface UpdateChatLimitsUseCaseInterface
 {
     public function execute(UpdateChatLimitsInput $input): ChatLimitsView;
-
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): ChatLimitsView;
 }

--- a/src/ChatSettings/ChatSettingsServiceProvider.php
+++ b/src/ChatSettings/ChatSettingsServiceProvider.php
@@ -50,17 +50,12 @@ final readonly class ChatSettingsServiceProvider implements ServiceProviderInter
                 UpdateChatSettingsUseCaseInterface::class,
                 static function (ContainerInterface $container): UpdateChatSettingsUseCaseInterface {
                     $repository = $container->get(ChatSettingsRepositoryInterface::class);
-                    $validator = $container->get(ChatSettingsValidator::class);
 
                     if (!$repository instanceof ChatSettingsRepositoryInterface) {
                         throw new LogicException('Chat settings repository service is invalid.');
                     }
 
-                    if (!$validator instanceof ChatSettingsValidator) {
-                        throw new LogicException('Chat settings validator service is invalid.');
-                    }
-
-                    return new UpdateChatSettingsUseCase($repository, $validator);
+                    return new UpdateChatSettingsUseCase($repository);
                 },
             )
             ->set(
@@ -85,6 +80,7 @@ final readonly class ChatSettingsServiceProvider implements ServiceProviderInter
                 static function (ContainerInterface $container): UpdateChatSettingsHandler {
                     $useCase = $container->get(UpdateChatSettingsUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $validator = $container->get(ChatSettingsValidator::class);
 
                     if (!$useCase instanceof UpdateChatSettingsUseCaseInterface) {
                         throw new LogicException('Update chat settings use case service is invalid.');
@@ -94,7 +90,11 @@ final readonly class ChatSettingsServiceProvider implements ServiceProviderInter
                         throw new LogicException('JSON response factory service is invalid.');
                     }
 
-                    return new UpdateChatSettingsHandler($useCase, $response);
+                    if (!$validator instanceof ChatSettingsValidator) {
+                        throw new LogicException('Chat settings validator service is invalid.');
+                    }
+
+                    return new UpdateChatSettingsHandler($useCase, $response, $validator);
                 },
             )
             ->set(

--- a/src/ChatSettings/UpdateChatSettingsHandler.php
+++ b/src/ChatSettings/UpdateChatSettingsHandler.php
@@ -14,13 +14,15 @@ final readonly class UpdateChatSettingsHandler
     public function __construct(
         private UpdateChatSettingsUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private ChatSettingsValidator $validator,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $body = JsonRequestBodyParser::parse($request);
+        $input = $this->validator->validateUpdate($body);
 
-        return $this->response->create($this->useCase->executeFromBody($body)->toArray());
+        return $this->response->create($this->useCase->execute($input)->toArray());
     }
 }

--- a/src/ChatSettings/UpdateChatSettingsUseCase.php
+++ b/src/ChatSettings/UpdateChatSettingsUseCase.php
@@ -8,7 +8,6 @@ final readonly class UpdateChatSettingsUseCase implements UpdateChatSettingsUseC
 {
     public function __construct(
         private ChatSettingsRepositoryInterface $repository,
-        private ChatSettingsValidator $validator,
     ) {
     }
 
@@ -24,11 +23,4 @@ final readonly class UpdateChatSettingsUseCase implements UpdateChatSettingsUseC
         return ChatSettingsView::fromSettings($settings);
     }
 
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): ChatSettingsView
-    {
-        return $this->execute($this->validator->validateUpdate($body));
-    }
 }

--- a/src/ChatSettings/UpdateChatSettingsUseCaseInterface.php
+++ b/src/ChatSettings/UpdateChatSettingsUseCaseInterface.php
@@ -7,9 +7,4 @@ namespace NeneCorpus\ChatSettings;
 interface UpdateChatSettingsUseCaseInterface
 {
     public function execute(UpdateChatSettingsInput $input): ChatSettingsView;
-
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): ChatSettingsView;
 }

--- a/src/Llm/CorpusSearchTool.php
+++ b/src/Llm/CorpusSearchTool.php
@@ -8,7 +8,7 @@ use NeneCorpus\Search\ChunkSearchResult;
 use NeneCorpus\Search\SearchChunksInput;
 use NeneCorpus\Search\SearchChunksUseCaseInterface;
 
-final readonly class CorpusSearchToolHandler
+final readonly class CorpusSearchTool
 {
     private const EXCERPT_MAX_LENGTH = 240;
 

--- a/src/Llm/GenerateChatReplyUseCase.php
+++ b/src/Llm/GenerateChatReplyUseCase.php
@@ -17,7 +17,7 @@ final readonly class GenerateChatReplyUseCase implements GenerateChatReplyUseCas
 
     public function __construct(
         private ClaudeMessagesClientInterface $client,
-        private CorpusSearchToolHandler $searchTool,
+        private CorpusSearchTool $searchTool,
         private ChatSettingsRepositoryInterface $chatSettings,
     ) {
     }

--- a/src/Llm/LlmServiceProvider.php
+++ b/src/Llm/LlmServiceProvider.php
@@ -21,15 +21,15 @@ final readonly class LlmServiceProvider implements ServiceProviderInterface
                 static fn (ContainerInterface $container): AnthropicConfig => AnthropicConfig::fromEnvironment(),
             )
             ->set(
-                CorpusSearchToolHandler::class,
-                static function (ContainerInterface $container): CorpusSearchToolHandler {
+                CorpusSearchTool::class,
+                static function (ContainerInterface $container): CorpusSearchTool {
                     $search = $container->get(SearchChunksUseCaseInterface::class);
 
                     if (!$search instanceof SearchChunksUseCaseInterface) {
                         throw new LogicException('Search chunks use case service is invalid.');
                     }
 
-                    return new CorpusSearchToolHandler($search);
+                    return new CorpusSearchTool($search);
                 },
             )
             ->set(
@@ -52,14 +52,14 @@ final readonly class LlmServiceProvider implements ServiceProviderInterface
                 GenerateChatReplyUseCaseInterface::class,
                 static function (ContainerInterface $container): GenerateChatReplyUseCaseInterface {
                     $client = $container->get(ClaudeMessagesClientInterface::class);
-                    $searchTool = $container->get(CorpusSearchToolHandler::class);
+                    $searchTool = $container->get(CorpusSearchTool::class);
                     $chatSettings = $container->get(ChatSettingsRepositoryInterface::class);
 
                     if (!$client instanceof ClaudeMessagesClientInterface) {
                         throw new LogicException('Claude messages client service is invalid.');
                     }
 
-                    if (!$searchTool instanceof CorpusSearchToolHandler) {
+                    if (!$searchTool instanceof CorpusSearchTool) {
                         throw new LogicException('Corpus search tool handler service is invalid.');
                     }
 

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -55,6 +55,7 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                 static function (ContainerInterface $container): UpdateNotificationSettingsUseCase {
                     $envWriter = $container->get(EnvFileWriter::class);
                     $envUpdater = $container->get(EnvironmentVariableUpdater::class);
+                    $getUseCase = $container->get(GetNotificationSettingsUseCase::class);
 
                     if (!$envWriter instanceof EnvFileWriter) {
                         throw new LogicException('EnvFileWriter service is invalid.');
@@ -64,7 +65,11 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                         throw new LogicException('EnvironmentVariableUpdater service is invalid.');
                     }
 
-                    return new UpdateNotificationSettingsUseCase($envWriter, $envUpdater);
+                    if (!$getUseCase instanceof GetNotificationSettingsUseCase) {
+                        throw new LogicException('GetNotificationSettingsUseCase service is invalid.');
+                    }
+
+                    return new UpdateNotificationSettingsUseCase($envWriter, $envUpdater, $getUseCase);
                 },
             )
             ->set(

--- a/src/Notification/UpdateNotificationSettingsUseCase.php
+++ b/src/Notification/UpdateNotificationSettingsUseCase.php
@@ -13,6 +13,7 @@ final readonly class UpdateNotificationSettingsUseCase
     public function __construct(
         private EnvFileWriter $envFileWriter,
         private EnvironmentVariableUpdater $environmentUpdater,
+        private GetNotificationSettingsUseCase $getUseCase,
     ) {
     }
 
@@ -60,8 +61,6 @@ final readonly class UpdateNotificationSettingsUseCase
             'NOTIFY_DAILY_REPORT_TOKEN'             => $token,
         ]);
 
-        $getUseCase = new GetNotificationSettingsUseCase();
-
-        return $getUseCase->execute();
+        return $this->getUseCase->execute();
     }
 }

--- a/src/Settings/SettingsServiceProvider.php
+++ b/src/Settings/SettingsServiceProvider.php
@@ -49,7 +49,6 @@ final readonly class SettingsServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): UpdateLlmSettingsUseCaseInterface {
                     $envWriter = $container->get(EnvFileWriter::class);
                     $environmentUpdater = $container->get(EnvironmentVariableUpdater::class);
-                    $validator = $container->get(LlmSettingsValidator::class);
                     $tester = $container->get(AnthropicConnectionTesterInterface::class);
 
                     if (!$envWriter instanceof EnvFileWriter) {
@@ -60,32 +59,23 @@ final readonly class SettingsServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Environment variable updater service is invalid.');
                     }
 
-                    if (!$validator instanceof LlmSettingsValidator) {
-                        throw new LogicException('LLM settings validator service is invalid.');
-                    }
-
                     if (!$tester instanceof AnthropicConnectionTesterInterface) {
                         throw new LogicException('Anthropic connection tester service is invalid.');
                     }
 
-                    return new UpdateLlmSettingsUseCase($envWriter, $environmentUpdater, $validator, $tester);
+                    return new UpdateLlmSettingsUseCase($envWriter, $environmentUpdater, $tester);
                 },
             )
             ->set(
                 TestLlmConnectionUseCaseInterface::class,
                 static function (ContainerInterface $container): TestLlmConnectionUseCaseInterface {
-                    $validator = $container->get(LlmSettingsValidator::class);
                     $tester = $container->get(AnthropicConnectionTesterInterface::class);
-
-                    if (!$validator instanceof LlmSettingsValidator) {
-                        throw new LogicException('LLM settings validator service is invalid.');
-                    }
 
                     if (!$tester instanceof AnthropicConnectionTesterInterface) {
                         throw new LogicException('Anthropic connection tester service is invalid.');
                     }
 
-                    return new TestLlmConnectionUseCase($validator, $tester);
+                    return new TestLlmConnectionUseCase($tester);
                 },
             )
             ->set(
@@ -110,6 +100,7 @@ final readonly class SettingsServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): UpdateLlmSettingsHandler {
                     $useCase = $container->get(UpdateLlmSettingsUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $validator = $container->get(LlmSettingsValidator::class);
 
                     if (!$useCase instanceof UpdateLlmSettingsUseCaseInterface) {
                         throw new LogicException('Update LLM settings use case service is invalid.');
@@ -119,7 +110,11 @@ final readonly class SettingsServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JSON response factory service is invalid.');
                     }
 
-                    return new UpdateLlmSettingsHandler($useCase, $response);
+                    if (!$validator instanceof LlmSettingsValidator) {
+                        throw new LogicException('LLM settings validator service is invalid.');
+                    }
+
+                    return new UpdateLlmSettingsHandler($useCase, $response, $validator);
                 },
             )
             ->set(
@@ -127,6 +122,7 @@ final readonly class SettingsServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): TestLlmConnectionHandler {
                     $useCase = $container->get(TestLlmConnectionUseCaseInterface::class);
                     $response = $container->get(JsonResponseFactory::class);
+                    $validator = $container->get(LlmSettingsValidator::class);
 
                     if (!$useCase instanceof TestLlmConnectionUseCaseInterface) {
                         throw new LogicException('Test LLM connection use case service is invalid.');
@@ -136,7 +132,11 @@ final readonly class SettingsServiceProvider implements ServiceProviderInterface
                         throw new LogicException('JSON response factory service is invalid.');
                     }
 
-                    return new TestLlmConnectionHandler($useCase, $response);
+                    if (!$validator instanceof LlmSettingsValidator) {
+                        throw new LogicException('LLM settings validator service is invalid.');
+                    }
+
+                    return new TestLlmConnectionHandler($useCase, $response, $validator);
                 },
             )
             ->set(

--- a/src/Settings/TestLlmConnectionHandler.php
+++ b/src/Settings/TestLlmConnectionHandler.php
@@ -17,15 +17,17 @@ final readonly class TestLlmConnectionHandler
     public function __construct(
         private TestLlmConnectionUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private LlmSettingsValidator $validator,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $body = JsonRequestBodyParser::parse($request);
+        $input = $this->validator->validateTest($body);
 
         try {
-            $this->useCase->executeFromBody($body);
+            $this->useCase->execute($input);
         } catch (RuntimeException $exception) {
             throw new ValidationException([
                 new ValidationError('api_key', $exception->getMessage(), 'invalid'),

--- a/src/Settings/TestLlmConnectionUseCase.php
+++ b/src/Settings/TestLlmConnectionUseCase.php
@@ -11,17 +11,12 @@ use RuntimeException;
 final readonly class TestLlmConnectionUseCase implements TestLlmConnectionUseCaseInterface
 {
     public function __construct(
-        private LlmSettingsValidator $validator,
         private AnthropicConnectionTesterInterface $connectionTester,
     ) {
     }
 
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): void
+    public function execute(TestLlmConnectionInput $input): void
     {
-        $input = $this->validator->validateTest($body);
         $apiKey = $input->apiKey ?? AnthropicConfig::fromEnvironment()->apiKey ?? '';
 
         if ($apiKey === '') {

--- a/src/Settings/TestLlmConnectionUseCaseInterface.php
+++ b/src/Settings/TestLlmConnectionUseCaseInterface.php
@@ -6,8 +6,5 @@ namespace NeneCorpus\Settings;
 
 interface TestLlmConnectionUseCaseInterface
 {
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): void;
+    public function execute(TestLlmConnectionInput $input): void;
 }

--- a/src/Settings/UpdateLlmSettingsHandler.php
+++ b/src/Settings/UpdateLlmSettingsHandler.php
@@ -14,13 +14,15 @@ final readonly class UpdateLlmSettingsHandler
     public function __construct(
         private UpdateLlmSettingsUseCaseInterface $useCase,
         private JsonResponseFactory $response,
+        private LlmSettingsValidator $validator,
     ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $body = JsonRequestBodyParser::parse($request);
+        $input = $this->validator->validateUpdate($body);
 
-        return $this->response->create($this->useCase->executeFromBody($body)->toArray());
+        return $this->response->create($this->useCase->execute($input)->toArray());
     }
 }

--- a/src/Settings/UpdateLlmSettingsUseCase.php
+++ b/src/Settings/UpdateLlmSettingsUseCase.php
@@ -16,7 +16,6 @@ final readonly class UpdateLlmSettingsUseCase implements UpdateLlmSettingsUseCas
     public function __construct(
         private EnvFileWriter $envFileWriter,
         private EnvironmentVariableUpdater $environmentUpdater,
-        private LlmSettingsValidator $validator,
         private AnthropicConnectionTesterInterface $connectionTester,
     ) {
     }
@@ -60,11 +59,4 @@ final readonly class UpdateLlmSettingsUseCase implements UpdateLlmSettingsUseCas
         );
     }
 
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): LlmSettingsView
-    {
-        return $this->execute($this->validator->validateUpdate($body));
-    }
 }

--- a/src/Settings/UpdateLlmSettingsUseCaseInterface.php
+++ b/src/Settings/UpdateLlmSettingsUseCaseInterface.php
@@ -7,9 +7,4 @@ namespace NeneCorpus\Settings;
 interface UpdateLlmSettingsUseCaseInterface
 {
     public function execute(UpdateLlmSettingsInput $input): LlmSettingsView;
-
-    /**
-     * @param array<string, mixed> $body
-     */
-    public function executeFromBody(array $body): LlmSettingsView;
 }

--- a/tests/Chat/SendChatMessageUseCaseTest.php
+++ b/tests/Chat/SendChatMessageUseCaseTest.php
@@ -9,6 +9,9 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Chat\SendChatMessageInput;
 use NeneCorpus\Chat\SendChatMessageUseCase;
+use NeneCorpus\ChatLimits\ChatLimitsRepositoryInterface;
+use NeneCorpus\ChatLimits\ChatLimitsSettings;
+use NeneCorpus\ChatLimits\ChatTokenTrackerInterface;
 use NeneCorpus\Llm\Citation;
 use NeneCorpus\Llm\GenerateChatReplyOutput;
 use NeneCorpus\Llm\GenerateChatReplyUseCaseInterface;
@@ -57,10 +60,25 @@ final class SendChatMessageUseCaseTest extends TestCase
                 ],
             ));
 
+        $limitsRepository = $this->createMock(ChatLimitsRepositoryInterface::class);
+        $limitsRepository->method('get')->willReturn(new ChatLimitsSettings(
+            maxMessageChars: 0,
+            messageIntervalSeconds: 0,
+            sessionRequestsPerHour: 0,
+            ipRequestsPerHour: 0,
+            dailyRequestsPerIp: 0,
+            dailyRequestsGlobal: 0,
+            dailyTokensPerIp: 0,
+            dailyTokensGlobal: 0,
+        ));
+        $tokenTracker = $this->createMock(ChatTokenTrackerInterface::class);
+
         $output = (new SendChatMessageUseCase(
             $sessions,
             new PdoChatMessageRepository($executor),
             $generateReply,
+            $limitsRepository,
+            $tokenTracker,
         ))->execute(new SendChatMessageInput(
             sessionToken: 'token-abc',
             content: 'User question?',

--- a/tests/Llm/GenerateChatReplyUseCaseTest.php
+++ b/tests/Llm/GenerateChatReplyUseCaseTest.php
@@ -12,7 +12,7 @@ use NeneCorpus\Chunk\Chunk;
 use NeneCorpus\Chunk\PdoChunkRepository;
 use NeneCorpus\Document\Document;
 use NeneCorpus\Document\PdoDocumentRepository;
-use NeneCorpus\Llm\CorpusSearchToolHandler;
+use NeneCorpus\Llm\CorpusSearchTool;
 use NeneCorpus\Llm\GenerateChatReplyInput;
 use NeneCorpus\Llm\GenerateChatReplyUseCase;
 use NeneCorpus\Llm\StubClaudeMessagesClient;
@@ -69,7 +69,7 @@ final class GenerateChatReplyUseCaseTest extends TestCase
         $search = new SearchChunksUseCase(new PdoChunkSearchRepository($executor));
         $useCase = new GenerateChatReplyUseCase(
             new StubClaudeMessagesClient(),
-            new CorpusSearchToolHandler($search),
+            new CorpusSearchTool($search),
             new InMemoryChatSettingsRepository(ChatSettings::defaults()),
         );
 


### PR DESCRIPTION
## 概要

Closes #238

コードレビューで発見された4種類の違反を全て修正。

## 変更内容

### 1. SendChatMessageHandler のビジネスロジックを UseCase に移動
- 文字数制限チェック・トークン記録を Handler から UseCase に移動
- `SendChatMessageInput` に `clientIp` フィールド追加（デフォルト `'unknown''`）

### 2. `executeFromBody(array $body)` パターンを除去
UseCase のメソッドを `execute(Input $input)` に統一。Validator は UseCase から剥がして Handler に移動。

| UseCase | 変更内容 |
|---|---|
| `UpdateLlmSettingsUseCase` | validator 除去、executeFromBody 削除 |
| `TestLlmConnectionUseCase` | validator 除去、execute(Input) に改名 |
| `UpdateChatLimitsUseCase` | validator 除去、executeFromBody 削除 |
| `UpdateChatSettingsUseCase` | validator 除去、executeFromBody 削除 |

### 3. `CorpusSearchToolHandler` → `CorpusSearchTool` リネーム
HTTP ハンドラーでないクラスから `*Handler` サフィックスを除去。

### 4. `UpdateNotificationSettingsUseCase` DI 修正
`new GetNotificationSettingsUseCase()` 直接生成をコンストラクタインジェクションに変更。

## セルフレビュー

- [x] `composer check` 全 green（134 tests / PHPStan / CS-Fixer / OpenAPI / MCP）
- [x] UseCase のメソッドが全て `execute(Input)` になっていること
- [x] Handler が業務ロジックを持っていないこと
- [x] `CorpusSearchTool` の参照が全ファイルで更新されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)