### PR TITLE
refactor(frontend): フロントエンド規約違反を修正する

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -188,16 +188,8 @@ function AdminFooter({ locale, t }: { locale: string; t: (key: MsgKey) => string
         >
           NeNe Corpus
         </a>
-        {' · © '}
-        <a
-          href="https://ayane.co.jp"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:underline"
-        >
-          AYANE
-        </a>
-        {' All rights reserved.'}
+        {' · '}
+        {t(resolveMsgKey(Msg.admin.footer?.copyright, 'admin.footer.copyright'))}
       </p>
     </footer>
   );

--- a/frontend/apps/admin/src/NotificationsPanel.tsx
+++ b/frontend/apps/admin/src/NotificationsPanel.tsx
@@ -25,7 +25,7 @@ export function NotificationsPanel({ token }: NotificationsPanelProps) {
   const [smtpPassword, setSmtpPassword] = useState('');
   const [smtpEncryption, setSmtpEncryption] = useState<'tls' | 'ssl' | 'none'>('tls');
   const [smtpFromAddress, setSmtpFromAddress] = useState('');
-  const [smtpFromName, setSmtpFromName] = useState('NeNe Corpus');
+  const [smtpFromName, setSmtpFromName] = useState('');
   const [notifyEmail, setNotifyEmail] = useState('');
   const [rateLimitEnabled, setRateLimitEnabled] = useState(false);
   const [rateLimitCooldown, setRateLimitCooldown] = useState(60);

--- a/frontend/apps/widget/src/widget.css
+++ b/frontend/apps/widget/src/widget.css
@@ -58,7 +58,7 @@
   border: none;
   border-radius: 9999px;
   background: var(--nc-color-primary);
-  color: #fff;
+  color: var(--nc-color-on-primary);
   box-shadow: 0 4px 14px rgb(0 0 0 / 0.18);
   cursor: pointer;
 }
@@ -152,7 +152,7 @@
   border: none;
   border-radius: var(--nc-radius-control, var(--nc-radius-md, 0.5rem));
   background: var(--nc-color-primary);
-  color: #fff;
+  color: var(--nc-color-on-primary);
   font: inherit;
   font-weight: 500;
   cursor: pointer;
@@ -220,12 +220,12 @@
 }
 
 .nene-corpus-chat__avatar--assistant {
-  background: color-mix(in srgb, var(--nc-color-primary) 16%, white);
+  background: color-mix(in srgb, var(--nc-color-primary) 16%, var(--nc-color-surface));
   color: var(--nc-color-primary);
 }
 
 .nene-corpus-chat__avatar--user {
-  background: color-mix(in srgb, var(--nc-color-text) 12%, white);
+  background: color-mix(in srgb, var(--nc-color-text) 12%, var(--nc-color-surface));
   color: var(--nc-color-text);
 }
 
@@ -246,14 +246,14 @@
 }
 
 .nene-corpus-chat__bubble--assistant {
-  --nc-bubble-bg: color-mix(in srgb, var(--nc-color-primary) 12%, white);
+  --nc-bubble-bg: color-mix(in srgb, var(--nc-color-primary) 12%, var(--nc-color-surface));
   background: var(--nc-bubble-bg);
 }
 
 .nene-corpus-chat__bubble--user {
   --nc-bubble-bg: var(--nc-color-primary);
   background: var(--nc-bubble-bg);
-  color: #fff;
+  color: var(--nc-color-on-primary);
 }
 
 .nene-corpus-chat__bubble--assistant.nene-corpus-chat__bubble--tailed {
@@ -378,7 +378,7 @@
 
 .nene-corpus-chat__error {
   margin: 0;
-  color: #b91c1c;
+  color: var(--nc-color-error);
   font-size: 0.875em;
 }
 
@@ -400,7 +400,7 @@
   border: none;
   border-radius: var(--nc-radius-control, var(--nc-radius-md, 0.5rem));
   background: var(--nc-color-primary);
-  color: #fff;
+  color: var(--nc-color-on-primary);
   font: inherit;
   cursor: pointer;
 }

--- a/frontend/packages/api-client/src/account.ts
+++ b/frontend/packages/api-client/src/account.ts
@@ -1,9 +1,11 @@
+import { fetchJson } from './fetch-json';
+
 export async function changeAdminPassword(
   token: string,
   body: { current_password: string; new_password: string },
   base = '',
 ): Promise<void> {
-  const res = await fetch(`${base}/admin/auth/password`, {
+  await fetchJson<unknown>(`${base}/admin/auth/password`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -11,11 +13,6 @@ export async function changeAdminPassword(
     },
     body: JSON.stringify(body),
   });
-
-  if (!res.ok) {
-    const json = await res.json().catch(() => ({}));
-    throw new Error((json as { detail?: string }).detail ?? `HTTP ${res.status}`);
-  }
 }
 
 export async function changeAdminEmail(
@@ -23,7 +20,7 @@ export async function changeAdminEmail(
   body: { current_password: string; new_email: string },
   base = '',
 ): Promise<void> {
-  const res = await fetch(`${base}/admin/auth/email`, {
+  await fetchJson<unknown>(`${base}/admin/auth/email`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -31,9 +28,4 @@ export async function changeAdminEmail(
     },
     body: JSON.stringify(body),
   });
-
-  if (!res.ok) {
-    const json = await res.json().catch(() => ({}));
-    throw new Error((json as { detail?: string }).detail ?? `HTTP ${res.status}`);
-  }
 }

--- a/frontend/packages/api-client/src/documents.ts
+++ b/frontend/packages/api-client/src/documents.ts
@@ -75,13 +75,8 @@ export async function deleteDocument(
   documentId: number,
   apiBase = '',
 ): Promise<void> {
-  const response = await fetch(`${apiBase}/admin/documents/${documentId}`, {
+  await fetchJson<unknown>(`${apiBase}/admin/documents/${documentId}`, {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${token}` },
   });
-
-  if (!response.ok && response.status !== 204) {
-    const text = await response.text();
-    throw new Error(`HTTP ${response.status} for /admin/documents/${documentId}: ${text.slice(0, 160)}`);
-  }
 }

--- a/frontend/packages/api-client/src/notifications.ts
+++ b/frontend/packages/api-client/src/notifications.ts
@@ -1,3 +1,5 @@
+import { fetchJson } from './fetch-json';
+
 export interface NotificationSettings {
   smtp_host: string;
   smtp_port: number;
@@ -33,11 +35,9 @@ export async function getNotificationSettings(
   token: string,
   base = '',
 ): Promise<NotificationSettings> {
-  const res = await fetch(`${base}/admin/notifications/settings`, {
+  return fetchJson<NotificationSettings>(`${base}/admin/notifications/settings`, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json() as Promise<NotificationSettings>;
 }
 
 export async function updateNotificationSettings(
@@ -45,7 +45,7 @@ export async function updateNotificationSettings(
   body: UpdateNotificationSettingsBody,
   base = '',
 ): Promise<NotificationSettings> {
-  const res = await fetch(`${base}/admin/notifications/settings`, {
+  return fetchJson<NotificationSettings>(`${base}/admin/notifications/settings`, {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -53,8 +53,6 @@ export async function updateNotificationSettings(
     },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json() as Promise<NotificationSettings>;
 }
 
 export async function sendTestMail(
@@ -62,7 +60,7 @@ export async function sendTestMail(
   email: string,
   base = '',
 ): Promise<void> {
-  const res = await fetch(`${base}/admin/notifications/test-mail`, {
+  await fetchJson<unknown>(`${base}/admin/notifications/test-mail`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -70,8 +68,4 @@ export async function sendTestMail(
     },
     body: JSON.stringify({ email }),
   });
-  if (!res.ok) {
-    const data = await res.json().catch(() => ({})) as Record<string, unknown>;
-    throw new Error((data['detail'] as string | undefined) ?? `HTTP ${res.status}`);
-  }
 }

--- a/frontend/themes/default.css
+++ b/frontend/themes/default.css
@@ -4,6 +4,8 @@
  */
 .nene-corpus-widget {
   --nc-color-primary: #2563eb;
+  --nc-color-on-primary: #ffffff;
+  --nc-color-error: #b91c1c;
   --nc-color-surface: #ffffff;
   --nc-color-text: #1f2937;
   --nc-font-family: system-ui, sans-serif;


### PR DESCRIPTION
Closes #240

## 変更内容

### widget.css / themes/default.css — CSS変数への統一
| 箇所 | before | after |
|------|--------|-------|
| ランチャー・CTA・送信ボタン・ユーザーバブルの文字色 | `#fff` | `var(--nc-color-on-primary)` |
| エラーメッセージ色 | `#b91c1c` | `var(--nc-color-error)` |
| アバター・バブル背景の color-mix 基色 | `white` | `var(--nc-color-surface)` |

新しく `--nc-color-on-primary: #ffffff` と `--nc-color-error: #b91c1c` を `default.css` に追加。  
color-mix の `white` を `--nc-color-surface` に変更することで、ダークテーマ時も正しく機能する。

### api-client — raw fetch() → fetchJson() に統一
- `account.ts`: `changeAdminPassword()`, `changeAdminEmail()`
- `documents.ts`: `deleteDocument()`
- `notifications.ts`: `getNotificationSettings()`, `updateNotificationSettings()`, `sendTestMail()`

すべてのエラーハンドリングを `fetchJson()` の `ProblemDetails` パーサーに委譲。

### App.tsx — フッター i18n 化
`AYANE` / `All rights reserved.` ハードコード文字列を `Msg.admin.footer.copyright` キーに置換。  
（`admin.footer.copyright` は全ロケールに実装済み）

### NotificationsPanel.tsx — `useState('NeNe Corpus')` 削除
SMTP 送信者名のデフォルト値を `''` に変更。実際の値はサーバーから取得するため問題なし。

## セルフレビュー
- [x] `npm run check --prefix frontend` — グリーン（TypeScript エラーなし）
- [x] `composer check` — 134 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)