### PR TITLE
test(notification): Notification モジュール単体テストを追加する (#244)

### DIFF
--- a/tests/Chat/SendChatMessageUseCaseTest.php
+++ b/tests/Chat/SendChatMessageUseCaseTest.php
@@ -60,7 +60,7 @@ final class SendChatMessageUseCaseTest extends TestCase
                 ],
             ));
 
-        $limitsRepository = $this->createMock(ChatLimitsRepositoryInterface::class);
+        $limitsRepository = $this->createStub(ChatLimitsRepositoryInterface::class);
         $limitsRepository->method('get')->willReturn(new ChatLimitsSettings(
             maxMessageChars: 0,
             messageIntervalSeconds: 0,
@@ -71,7 +71,7 @@ final class SendChatMessageUseCaseTest extends TestCase
             dailyTokensPerIp: 0,
             dailyTokensGlobal: 0,
         ));
-        $tokenTracker = $this->createMock(ChatTokenTrackerInterface::class);
+        $tokenTracker = $this->createStub(ChatTokenTrackerInterface::class);
 
         $output = (new SendChatMessageUseCase(
             $sessions,

--- a/tests/Notification/GetNotificationSettingsUseCaseTest.php
+++ b/tests/Notification/GetNotificationSettingsUseCaseTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Notification;
+
+use NeneCorpus\Notification\GetNotificationSettingsUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class GetNotificationSettingsUseCaseTest extends TestCase
+{
+    /** @var array<string, string|false> */
+    private array $envBackup = [];
+
+    private const ENV_KEYS = [
+        'MAIL_HOST', 'MAIL_PORT', 'MAIL_USERNAME', 'MAIL_PASSWORD',
+        'MAIL_ENCRYPTION', 'MAIL_FROM_ADDRESS', 'MAIL_FROM_NAME',
+        'NOTIFY_EMAIL', 'NOTIFY_RATE_LIMIT_ENABLED',
+        'NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES', 'NOTIFY_DAILY_REPORT_ENABLED',
+        'NOTIFY_DAILY_REPORT_TOKEN',
+    ];
+
+    protected function setUp(): void
+    {
+        foreach (self::ENV_KEYS as $key) {
+            $this->envBackup[$key] = $_ENV[$key] ?? false;
+            unset($_ENV[$key]);
+            putenv($key);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $key => $value) {
+            if ($value === false) {
+                unset($_ENV[$key]);
+                putenv($key);
+            } else {
+                $_ENV[$key] = $value;
+                putenv("{$key}={$value}");
+            }
+        }
+    }
+
+    public function test_returns_smtp_not_configured_when_no_mail_host(): void
+    {
+        $view = (new GetNotificationSettingsUseCase())->execute();
+
+        self::assertFalse($view->smtpConfigured);
+        self::assertFalse($view->smtpPasswordSet);
+        self::assertSame('', $view->smtpHost);
+        self::assertSame(587, $view->smtpPort);
+        self::assertSame('tls', $view->smtpEncryption);
+    }
+
+    public function test_returns_smtp_configured_when_mail_host_set(): void
+    {
+        $_ENV['MAIL_HOST'] = 'smtp.example.com';
+        $_ENV['MAIL_PORT'] = '465';
+        $_ENV['MAIL_USERNAME'] = 'user@example.com';
+        $_ENV['MAIL_PASSWORD'] = 'secret';
+        $_ENV['MAIL_ENCRYPTION'] = 'ssl';
+        $_ENV['MAIL_FROM_ADDRESS'] = 'noreply@example.com';
+        $_ENV['MAIL_FROM_NAME'] = 'My App';
+
+        $view = (new GetNotificationSettingsUseCase())->execute();
+
+        self::assertTrue($view->smtpConfigured);
+        self::assertSame('smtp.example.com', $view->smtpHost);
+        self::assertSame(465, $view->smtpPort);
+        self::assertSame('user@example.com', $view->smtpUsername);
+        self::assertTrue($view->smtpPasswordSet);
+        self::assertSame('ssl', $view->smtpEncryption);
+        self::assertSame('noreply@example.com', $view->smtpFromAddress);
+        self::assertSame('My App', $view->smtpFromName);
+    }
+
+    public function test_smtp_password_set_false_when_empty(): void
+    {
+        $_ENV['MAIL_HOST'] = 'smtp.example.com';
+        $_ENV['MAIL_PASSWORD'] = '';
+
+        $view = (new GetNotificationSettingsUseCase())->execute();
+
+        self::assertFalse($view->smtpPasswordSet);
+    }
+
+    public function test_password_not_exposed_in_view(): void
+    {
+        $_ENV['MAIL_HOST'] = 'smtp.example.com';
+        $_ENV['MAIL_PASSWORD'] = 'topsecret';
+
+        $view = (new GetNotificationSettingsUseCase())->execute();
+
+        // View has smtpPasswordSet flag but never exposes the raw password
+        self::assertTrue($view->smtpPasswordSet);
+        $arr = $view->toArray();
+        self::assertArrayNotHasKey('smtp_password', $arr);
+        self::assertArrayHasKey('smtp_password_set', $arr);
+    }
+
+    public function test_notification_config_fields_reflected(): void
+    {
+        $_ENV['NOTIFY_EMAIL']                       = 'ops@example.com';
+        $_ENV['NOTIFY_RATE_LIMIT_ENABLED']          = 'true';
+        $_ENV['NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES'] = '20';
+        $_ENV['NOTIFY_DAILY_REPORT_ENABLED']        = 'true';
+        $_ENV['NOTIFY_DAILY_REPORT_TOKEN']          = 'tok-abc';
+
+        $view = (new GetNotificationSettingsUseCase())->execute();
+
+        self::assertSame('ops@example.com', $view->notifyEmail);
+        self::assertTrue($view->rateLimitNotifyEnabled);
+        self::assertSame(20, $view->rateLimitCooldownMinutes);
+        self::assertTrue($view->dailyReportEnabled);
+        self::assertSame('tok-abc', $view->dailyReportToken);
+    }
+
+    public function test_to_array_contains_expected_keys(): void
+    {
+        $view = (new GetNotificationSettingsUseCase())->execute();
+        $arr  = $view->toArray();
+
+        self::assertArrayHasKey('smtp_host', $arr);
+        self::assertArrayHasKey('smtp_configured', $arr);
+        self::assertArrayHasKey('notify_email', $arr);
+        self::assertArrayHasKey('rate_limit_notify_enabled', $arr);
+        self::assertArrayHasKey('daily_report_enabled', $arr);
+        self::assertArrayHasKey('daily_report_token', $arr);
+    }
+}

--- a/tests/Notification/NotificationConfigTest.php
+++ b/tests/Notification/NotificationConfigTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Notification;
+
+use NeneCorpus\Notification\NotificationConfig;
+use PHPUnit\Framework\TestCase;
+
+final class NotificationConfigTest extends TestCase
+{
+    /** @var array<string, string|false> */
+    private array $envBackup = [];
+
+    private const ENV_KEYS = [
+        'NOTIFY_EMAIL',
+        'NOTIFY_RATE_LIMIT_ENABLED',
+        'NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES',
+        'NOTIFY_DAILY_REPORT_ENABLED',
+        'NOTIFY_DAILY_REPORT_TOKEN',
+    ];
+
+    protected function setUp(): void
+    {
+        foreach (self::ENV_KEYS as $key) {
+            $this->envBackup[$key] = $_ENV[$key] ?? false;
+            unset($_ENV[$key]);
+            putenv($key);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $key => $value) {
+            if ($value === false) {
+                unset($_ENV[$key]);
+                putenv($key);
+            } else {
+                $_ENV[$key] = $value;
+                putenv("{$key}={$value}");
+            }
+        }
+    }
+
+    public function test_defaults_when_no_env_vars_set(): void
+    {
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertSame('', $config->notifyEmail);
+        self::assertFalse($config->rateLimitNotifyEnabled);
+        self::assertSame(60, $config->rateLimitCooldownMinutes);
+        self::assertFalse($config->dailyReportEnabled);
+        self::assertSame('', $config->dailyReportToken);
+    }
+
+    public function test_notify_email_from_env(): void
+    {
+        $_ENV['NOTIFY_EMAIL'] = 'admin@example.com';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertSame('admin@example.com', $config->notifyEmail);
+    }
+
+    public function test_rate_limit_notify_enabled_true(): void
+    {
+        $_ENV['NOTIFY_RATE_LIMIT_ENABLED'] = 'true';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertTrue($config->rateLimitNotifyEnabled);
+    }
+
+    public function test_rate_limit_notify_enabled_false_string(): void
+    {
+        $_ENV['NOTIFY_RATE_LIMIT_ENABLED'] = 'false';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertFalse($config->rateLimitNotifyEnabled);
+    }
+
+    public function test_cooldown_minutes_from_env(): void
+    {
+        $_ENV['NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES'] = '30';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertSame(30, $config->rateLimitCooldownMinutes);
+    }
+
+    public function test_cooldown_minutes_falls_back_to_default_when_zero_string(): void
+    {
+        // PHP の `?: 60` 演算子では '0' が偽値のためデフォルト (60) にフォールバックする
+        $_ENV['NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES'] = '0';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertSame(60, $config->rateLimitCooldownMinutes);
+    }
+
+    public function test_cooldown_minutes_clamped_to_min_1_when_negative(): void
+    {
+        $_ENV['NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES'] = '-10';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertSame(1, $config->rateLimitCooldownMinutes);
+    }
+
+    public function test_daily_report_enabled_true(): void
+    {
+        $_ENV['NOTIFY_DAILY_REPORT_ENABLED'] = 'true';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertTrue($config->dailyReportEnabled);
+    }
+
+    public function test_daily_report_token_from_env(): void
+    {
+        $_ENV['NOTIFY_DAILY_REPORT_TOKEN'] = 'my-secret-token-abc123';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertSame('my-secret-token-abc123', $config->dailyReportToken);
+    }
+
+    public function test_all_fields_populated_together(): void
+    {
+        $_ENV['NOTIFY_EMAIL']                        = 'ops@example.com';
+        $_ENV['NOTIFY_RATE_LIMIT_ENABLED']           = 'true';
+        $_ENV['NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES']  = '15';
+        $_ENV['NOTIFY_DAILY_REPORT_ENABLED']         = 'true';
+        $_ENV['NOTIFY_DAILY_REPORT_TOKEN']           = 'tok123';
+
+        $config = NotificationConfig::fromEnvironment();
+
+        self::assertSame('ops@example.com', $config->notifyEmail);
+        self::assertTrue($config->rateLimitNotifyEnabled);
+        self::assertSame(15, $config->rateLimitCooldownMinutes);
+        self::assertTrue($config->dailyReportEnabled);
+        self::assertSame('tok123', $config->dailyReportToken);
+    }
+}

--- a/tests/Notification/PdoDailyReportRepositoryTest.php
+++ b/tests/Notification/PdoDailyReportRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Notification;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Notification\PdoDailyReportRepository;
+use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoDailyReportRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private PdoDailyReportRepository $repo;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        ChatSchemaSetup::create($this->executor);
+        RateLimitSchemaSetup::create($this->executor);
+
+        $this->repo = new PdoDailyReportRepository($this->executor);
+    }
+
+    public function test_returns_zeros_for_empty_database(): void
+    {
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame('2026-01-15', $stats->reportDate);
+        self::assertSame(0, $stats->totalSessions);
+        self::assertSame(0, $stats->totalMessages);
+        self::assertSame(0, $stats->uniqueIps);
+        self::assertSame(0, $stats->rateLimitHits);
+    }
+
+    public function test_counts_sessions_on_target_date(): void
+    {
+        $this->insertSession('2026-01-15 10:00:00', 'tok1', '1.1.1.1');
+        $this->insertSession('2026-01-15 14:30:00', 'tok2', '2.2.2.2');
+
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame(2, $stats->totalSessions);
+    }
+
+    public function test_excludes_sessions_outside_target_date(): void
+    {
+        $this->insertSession('2026-01-14 23:59:59', 'tok-prev', '1.1.1.1');
+        $this->insertSession('2026-01-15 10:00:00', 'tok-today', '2.2.2.2');
+        $this->insertSession('2026-01-16 00:00:00', 'tok-next', '3.3.3.3');
+
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame(1, $stats->totalSessions);
+    }
+
+    public function test_counts_messages_on_target_date(): void
+    {
+        $sessionId = $this->insertSession('2026-01-15 10:00:00', 'tok1', '1.1.1.1');
+        $this->insertMessage($sessionId, '2026-01-15 10:01:00');
+        $this->insertMessage($sessionId, '2026-01-15 10:02:00');
+        $this->insertMessage($sessionId, '2026-01-15 10:03:00');
+
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame(3, $stats->totalMessages);
+    }
+
+    public function test_excludes_messages_outside_target_date(): void
+    {
+        $sessionId = $this->insertSession('2026-01-14 10:00:00', 'tok1', '1.1.1.1');
+        $this->insertMessage($sessionId, '2026-01-14 10:01:00'); // yesterday
+        $sessionId2 = $this->insertSession('2026-01-15 10:00:00', 'tok2', '2.2.2.2');
+        $this->insertMessage($sessionId2, '2026-01-15 11:00:00'); // today
+
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame(1, $stats->totalMessages);
+    }
+
+    public function test_counts_unique_ips(): void
+    {
+        $this->insertSession('2026-01-15 10:00:00', 'tok1', '1.1.1.1');
+        $this->insertSession('2026-01-15 11:00:00', 'tok2', '1.1.1.1'); // same IP
+        $this->insertSession('2026-01-15 12:00:00', 'tok3', '2.2.2.2'); // different IP
+
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame(2, $stats->uniqueIps);
+    }
+
+    public function test_counts_rate_limit_hits_from_bucket(): void
+    {
+        $today = '2026-01-15';
+        $this->executor->execute(
+            'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
+            ["notify:ratelimit:hits:{$today}", 17, time() + 86400, '2026-01-15 10:00:00'],
+        );
+
+        $stats = $this->repo->getStats($today);
+
+        self::assertSame(17, $stats->rateLimitHits);
+    }
+
+    public function test_rate_limit_hits_zero_when_bucket_missing(): void
+    {
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame(0, $stats->rateLimitHits);
+    }
+
+    public function test_rate_limit_hits_from_different_date_not_counted(): void
+    {
+        $this->executor->execute(
+            'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
+            ['notify:ratelimit:hits:2026-01-14', 99, time() + 86400, '2026-01-14 00:00:00'],
+        );
+
+        $stats = $this->repo->getStats('2026-01-15');
+
+        self::assertSame(0, $stats->rateLimitHits);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private function insertSession(string $createdAt, string $token, string $ip): int
+    {
+        $this->executor->execute(
+            'INSERT INTO chat_sessions (public_token, client_ip, user_agent, referer, created_at, updated_at)
+             VALUES (?, ?, NULL, NULL, ?, ?)',
+            [$token, $ip, $createdAt, $createdAt],
+        );
+
+        $row = $this->executor->fetchOne('SELECT last_insert_rowid() AS id', []);
+
+        return (int) ($row['id'] ?? 0);
+    }
+
+    private function insertMessage(int $sessionId, string $createdAt): void
+    {
+        $this->executor->execute(
+            'INSERT INTO chat_messages (session_id, role, content, citations_json, created_at, updated_at)
+             VALUES (?, ?, ?, NULL, ?, ?)',
+            [$sessionId, 'user', 'hello', $createdAt, $createdAt],
+        );
+    }
+}

--- a/tests/Notification/RateLimitNotifierTest.php
+++ b/tests/Notification/RateLimitNotifierTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Notification;
+
+use Nene2\Middleware\RateLimitStorageInterface;
+use NeneCorpus\Mail\MailSendException;
+use NeneCorpus\Mail\MailerInterface;
+use NeneCorpus\Notification\NotificationConfig;
+use NeneCorpus\Notification\RateLimitNotifier;
+use PHPUnit\Framework\TestCase;
+
+final class RateLimitNotifierTest extends TestCase
+{
+    private function makeConfig(bool $enabled = true, int $cooldownMinutes = 60): NotificationConfig
+    {
+        return new NotificationConfig(
+            notifyEmail: 'ops@example.com',
+            rateLimitNotifyEnabled: $enabled,
+            rateLimitCooldownMinutes: $cooldownMinutes,
+            dailyReportEnabled: false,
+            dailyReportToken: '',
+        );
+    }
+
+    public function test_does_nothing_when_rate_limit_notify_disabled(): void
+    {
+        $mailer  = $this->createMock(MailerInterface::class);
+        $storage = $this->createMock(RateLimitStorageInterface::class);
+
+        $mailer->expects(self::never())->method('send');
+        $storage->expects(self::never())->method('hit');
+
+        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+            $this->makeConfig(enabled: false),
+            'ops@example.com',
+            '1.2.3.4',
+            'session_hourly',
+        );
+    }
+
+    public function test_does_nothing_when_mailer_not_configured(): void
+    {
+        $mailer  = $this->createMock(MailerInterface::class);
+        $storage = $this->createStub(RateLimitStorageInterface::class);
+
+        $mailer->expects(self::once())->method('isConfigured')->willReturn(false);
+        $mailer->expects(self::never())->method('send');
+
+        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+            $this->makeConfig(enabled: true),
+            'ops@example.com',
+            '1.2.3.4',
+            'session_hourly',
+        );
+    }
+
+    public function test_sends_mail_on_first_hit(): void
+    {
+        $mailer  = $this->createMock(MailerInterface::class);
+        $storage = $this->createStub(RateLimitStorageInterface::class);
+
+        $mailer->expects(self::once())->method('isConfigured')->willReturn(true);
+        $mailer->expects(self::once())->method('send');
+
+        // Both calls: daily hits tracking + cooldown gate
+        $storage->method('hit')->willReturn(['count' => 1, 'reset_at' => time() + 3600]);
+
+        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+            $this->makeConfig(),
+            'ops@example.com',
+            '1.2.3.4',
+            'session_hourly',
+        );
+    }
+
+    public function test_does_not_send_when_cooldown_active(): void
+    {
+        $mailer  = $this->createMock(MailerInterface::class);
+        $storage = $this->createStub(RateLimitStorageInterface::class);
+
+        $mailer->expects(self::once())->method('isConfigured')->willReturn(true);
+        $mailer->expects(self::never())->method('send');
+
+        // Cooldown hit returns count > 1 → still inside window
+        $callCount = 0;
+        $storage->method('hit')->willReturnCallback(
+            static function () use (&$callCount): array {
+                $callCount++;
+                // First call = daily hits key (count doesn't matter for gate)
+                // Second call = cooldown key → count > 1 suppresses mail
+                return ['count' => $callCount === 1 ? 5 : 2, 'reset_at' => time() + 3600];
+            },
+        );
+
+        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+            $this->makeConfig(),
+            'ops@example.com',
+            '192.168.0.1',
+            'ip_hourly',
+        );
+    }
+
+    public function test_mail_exception_is_swallowed_silently(): void
+    {
+        $mailer  = $this->createStub(MailerInterface::class);
+        $storage = $this->createStub(RateLimitStorageInterface::class);
+
+        $mailer->method('isConfigured')->willReturn(true);
+        $mailer->method('send')->willThrowException(new MailSendException('SMTP error'));
+        $storage->method('hit')->willReturn(['count' => 1, 'reset_at' => time() + 3600]);
+
+        // Must not throw
+        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+            $this->makeConfig(),
+            'ops@example.com',
+            '10.0.0.1',
+            'daily_global',
+        );
+
+        $this->addToAssertionCount(1); // reached here without exception
+    }
+
+    public function test_tracks_daily_hits_regardless_of_cooldown(): void
+    {
+        $mailer  = $this->createStub(MailerInterface::class);
+        $storage = $this->createMock(RateLimitStorageInterface::class);
+
+        $mailer->method('isConfigured')->willReturn(true);
+
+        $today = date('Y-m-d');
+        $hitsKeyPrefix = 'notify:ratelimit:hits:' . $today;
+
+        // hit() must be called for the daily hits key
+        $storage->expects(self::atLeastOnce())
+            ->method('hit')
+            ->with(self::logicalOr(
+                self::stringStartsWith($hitsKeyPrefix),
+                self::stringStartsWith('notify:ratelimit:cooldown'),
+            ))
+            ->willReturn(['count' => 2, 'reset_at' => time() + 86400]);
+
+        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+            $this->makeConfig(),
+            'ops@example.com',
+            '1.2.3.4',
+            'session_hourly',
+        );
+    }
+}

--- a/tests/Notification/RateLimitNotifierTest.php
+++ b/tests/Notification/RateLimitNotifierTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace NeneCorpus\Tests\Notification;
 
 use Nene2\Middleware\RateLimitStorageInterface;
-use NeneCorpus\Mail\MailSendException;
 use NeneCorpus\Mail\MailerInterface;
+use NeneCorpus\Mail\MailSendException;
 use NeneCorpus\Notification\NotificationConfig;
 use NeneCorpus\Notification\RateLimitNotifier;
 use PHPUnit\Framework\TestCase;

--- a/tests/Notification/SendDailyReportUseCaseTest.php
+++ b/tests/Notification/SendDailyReportUseCaseTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Notification;
+
+use NeneCorpus\Mail\MailerInterface;
+use NeneCorpus\Mail\MailMessage;
+use NeneCorpus\Notification\DailyReportRepositoryInterface;
+use NeneCorpus\Notification\DailyReportStats;
+use NeneCorpus\Notification\NotificationException;
+use NeneCorpus\Notification\SendDailyReportUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class SendDailyReportUseCaseTest extends TestCase
+{
+    private function makeStats(string $date = '2026-01-15'): DailyReportStats
+    {
+        return new DailyReportStats(
+            reportDate: $date,
+            totalSessions: 10,
+            totalMessages: 42,
+            uniqueIps: 7,
+            rateLimitHits: 3,
+        );
+    }
+
+    public function test_throws_when_smtp_not_configured(): void
+    {
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(false);
+
+        $repo = $this->createStub(DailyReportRepositoryInterface::class);
+
+        $this->expectException(NotificationException::class);
+        $this->expectExceptionMessage('SMTP is not configured');
+
+        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2026-01-15');
+    }
+
+    public function test_sends_mail_and_returns_stats(): void
+    {
+        $stats = $this->makeStats('2026-01-15');
+
+        $repo = $this->createStub(DailyReportRepositoryInterface::class);
+        $repo->method('getStats')->willReturn($stats);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+        $mailer->expects(self::once())->method('send');
+
+        $result = (new SendDailyReportUseCase($mailer, $repo))->execute('ops@example.com', '2026-01-15');
+
+        self::assertSame($stats, $result);
+    }
+
+    public function test_mail_sent_to_correct_recipient(): void
+    {
+        $repo = $this->createStub(DailyReportRepositoryInterface::class);
+        $repo->method('getStats')->willReturn($this->makeStats());
+
+        $capturedMessage = null;
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+        $mailer->method('send')->willReturnCallback(
+            static function (MailMessage $msg) use (&$capturedMessage): void {
+                $capturedMessage = $msg;
+            },
+        );
+
+        (new SendDailyReportUseCase($mailer, $repo))->execute('report@example.com', '2026-01-15');
+
+        self::assertNotNull($capturedMessage);
+        self::assertSame('report@example.com', $capturedMessage->to);
+    }
+
+    public function test_mail_subject_contains_date(): void
+    {
+        $repo = $this->createStub(DailyReportRepositoryInterface::class);
+        $repo->method('getStats')->willReturn($this->makeStats('2026-01-15'));
+
+        $capturedMessage = null;
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+        $mailer->method('send')->willReturnCallback(
+            static function (MailMessage $msg) use (&$capturedMessage): void {
+                $capturedMessage = $msg;
+            },
+        );
+
+        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2026-01-15');
+
+        self::assertNotNull($capturedMessage);
+        self::assertStringContainsString('2026-01-15', $capturedMessage->subject);
+    }
+
+    public function test_mail_html_body_contains_stats(): void
+    {
+        $repo = $this->createStub(DailyReportRepositoryInterface::class);
+        $repo->method('getStats')->willReturn($this->makeStats('2026-01-15'));
+
+        $capturedMessage = null;
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+        $mailer->method('send')->willReturnCallback(
+            static function (MailMessage $msg) use (&$capturedMessage): void {
+                $capturedMessage = $msg;
+            },
+        );
+
+        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2026-01-15');
+
+        self::assertNotNull($capturedMessage);
+        // Stats values should appear in the HTML body
+        self::assertStringContainsString('10', $capturedMessage->htmlBody);  // totalSessions
+        self::assertStringContainsString('42', $capturedMessage->htmlBody);  // totalMessages
+        self::assertStringContainsString('7', $capturedMessage->htmlBody);   // uniqueIps
+        self::assertStringContainsString('3', $capturedMessage->htmlBody);   // rateLimitHits
+    }
+
+    public function test_date_passed_to_repository(): void
+    {
+        $capturedDate = null;
+        $repo = $this->createStub(DailyReportRepositoryInterface::class);
+        $repo->method('getStats')->willReturnCallback(
+            static function (string $date) use (&$capturedDate): DailyReportStats {
+                $capturedDate = $date;
+                return new DailyReportStats($date, 0, 0, 0, 0);
+            },
+        );
+
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+
+        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2025-12-31');
+
+        self::assertSame('2025-12-31', $capturedDate);
+    }
+
+    public function test_uses_today_when_date_not_specified(): void
+    {
+        $today = date('Y-m-d');
+        $capturedDate = null;
+
+        $repo = $this->createStub(DailyReportRepositoryInterface::class);
+        $repo->method('getStats')->willReturnCallback(
+            static function (string $date) use (&$capturedDate): DailyReportStats {
+                $capturedDate = $date;
+                return new DailyReportStats($date, 0, 0, 0, 0);
+            },
+        );
+
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+
+        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com');
+
+        self::assertSame($today, $capturedDate);
+    }
+}

--- a/tests/Notification/SendTestMailUseCaseTest.php
+++ b/tests/Notification/SendTestMailUseCaseTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Notification;
+
+use NeneCorpus\Mail\MailerInterface;
+use NeneCorpus\Mail\MailMessage;
+use NeneCorpus\Notification\NotificationException;
+use NeneCorpus\Notification\SendTestMailUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class SendTestMailUseCaseTest extends TestCase
+{
+    public function test_throws_when_smtp_not_configured(): void
+    {
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(false);
+
+        $this->expectException(NotificationException::class);
+        $this->expectExceptionMessage('SMTP is not configured');
+
+        (new SendTestMailUseCase($mailer))->execute('to@example.com');
+    }
+
+    public function test_sends_mail_when_configured(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+        $mailer->expects(self::once())
+            ->method('send')
+            ->with(self::callback(static function (MailMessage $msg): bool {
+                return $msg->to === 'to@example.com'
+                    && str_contains($msg->subject, 'テスト送信');
+            }));
+
+        (new SendTestMailUseCase($mailer))->execute('to@example.com');
+    }
+
+    public function test_mail_contains_html_and_text_body(): void
+    {
+        $capturedMessage = null;
+
+        $mailer = $this->createStub(MailerInterface::class);
+        $mailer->method('isConfigured')->willReturn(true);
+        $mailer->method('send')->willReturnCallback(
+            static function (MailMessage $msg) use (&$capturedMessage): void {
+                $capturedMessage = $msg;
+            },
+        );
+
+        (new SendTestMailUseCase($mailer))->execute('recipient@example.com');
+
+        self::assertNotNull($capturedMessage);
+        self::assertNotEmpty($capturedMessage->textBody);
+        self::assertNotEmpty($capturedMessage->htmlBody);
+        self::assertSame('recipient@example.com', $capturedMessage->to);
+    }
+}

--- a/tests/Notification/UpdateNotificationSettingsUseCaseTest.php
+++ b/tests/Notification/UpdateNotificationSettingsUseCaseTest.php
@@ -91,6 +91,7 @@ final class UpdateNotificationSettingsUseCaseTest extends TestCase
         );
     }
 
+    /** @param array<string, mixed> $overrides */
     private function makeInput(array $overrides = []): UpdateNotificationSettingsInput
     {
         return new UpdateNotificationSettingsInput(
@@ -145,7 +146,7 @@ final class UpdateNotificationSettingsUseCaseTest extends TestCase
         ]));
 
         // After execute, env should have the new password
-        self::assertSame('brandnewpass', $_ENV['MAIL_PASSWORD'] ?? '');
+        self::assertSame('brandnewpass', (string) $_ENV['MAIL_PASSWORD']);
     }
 
     public function test_regenerates_daily_report_token_when_requested(): void

--- a/tests/Notification/UpdateNotificationSettingsUseCaseTest.php
+++ b/tests/Notification/UpdateNotificationSettingsUseCaseTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Notification;
+
+use NeneCorpus\Config\EnvironmentVariableUpdater;
+use NeneCorpus\Install\EnvFileWriter;
+use NeneCorpus\Notification\GetNotificationSettingsUseCase;
+use NeneCorpus\Notification\UpdateNotificationSettingsInput;
+use NeneCorpus\Notification\UpdateNotificationSettingsUseCase;
+use PHPUnit\Framework\TestCase;
+
+final class UpdateNotificationSettingsUseCaseTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    /** @var array<string, string|false> */
+    private array $envBackup = [];
+
+    private const ENV_KEYS = [
+        'MAIL_HOST', 'MAIL_PORT', 'MAIL_USERNAME', 'MAIL_PASSWORD',
+        'MAIL_ENCRYPTION', 'MAIL_FROM_ADDRESS', 'MAIL_FROM_NAME',
+        'NOTIFY_EMAIL', 'NOTIFY_RATE_LIMIT_ENABLED',
+        'NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES', 'NOTIFY_DAILY_REPORT_ENABLED',
+        'NOTIFY_DAILY_REPORT_TOKEN',
+    ];
+
+    protected function setUp(): void
+    {
+        // Backup and clear env vars
+        foreach (self::ENV_KEYS as $key) {
+            $this->envBackup[$key] = $_ENV[$key] ?? false;
+            unset($_ENV[$key]);
+            putenv($key);
+        }
+
+        // Create temp dir with a minimal .env.example
+        $this->tmpDir = sys_get_temp_dir() . '/nene_test_' . uniqid('', true);
+        mkdir($this->tmpDir, 0700, true);
+
+        $envExample = implode("\n", [
+            'MAIL_HOST=',
+            'MAIL_PORT=587',
+            'MAIL_USERNAME=',
+            'MAIL_PASSWORD=',
+            'MAIL_ENCRYPTION=tls',
+            'MAIL_FROM_ADDRESS=',
+            'MAIL_FROM_NAME=NeNe Corpus',
+            'NOTIFY_EMAIL=',
+            'NOTIFY_RATE_LIMIT_ENABLED=false',
+            'NOTIFY_RATE_LIMIT_COOLDOWN_MINUTES=60',
+            'NOTIFY_DAILY_REPORT_ENABLED=false',
+            'NOTIFY_DAILY_REPORT_TOKEN=',
+        ]) . "\n";
+
+        file_put_contents($this->tmpDir . '/.env.example', $envExample);
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore env vars
+        foreach ($this->envBackup as $key => $value) {
+            if ($value === false) {
+                unset($_ENV[$key]);
+                putenv($key);
+            } else {
+                $_ENV[$key] = $value;
+                putenv("{$key}={$value}");
+            }
+        }
+
+        // Remove temp files
+        if (is_file($this->tmpDir . '/.env')) {
+            unlink($this->tmpDir . '/.env');
+        }
+        if (is_file($this->tmpDir . '/.env.example')) {
+            unlink($this->tmpDir . '/.env.example');
+        }
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    private function makeUseCase(): UpdateNotificationSettingsUseCase
+    {
+        return new UpdateNotificationSettingsUseCase(
+            new EnvFileWriter($this->tmpDir),
+            new EnvironmentVariableUpdater(),
+            new GetNotificationSettingsUseCase(),
+        );
+    }
+
+    private function makeInput(array $overrides = []): UpdateNotificationSettingsInput
+    {
+        return new UpdateNotificationSettingsInput(
+            smtpHost:                   $overrides['smtpHost'] ?? 'smtp.example.com',
+            smtpPort:                   $overrides['smtpPort'] ?? 587,
+            smtpUsername:               $overrides['smtpUsername'] ?? 'user@example.com',
+            smtpPassword:               $overrides['smtpPassword'] ?? 'newpass',
+            smtpEncryption:             $overrides['smtpEncryption'] ?? 'tls',
+            smtpFromAddress:            $overrides['smtpFromAddress'] ?? 'from@example.com',
+            smtpFromName:               $overrides['smtpFromName'] ?? 'NeNe Corpus',
+            notifyEmail:                $overrides['notifyEmail'] ?? 'ops@example.com',
+            rateLimitNotifyEnabled:     $overrides['rateLimitNotifyEnabled'] ?? false,
+            rateLimitCooldownMinutes:   $overrides['rateLimitCooldownMinutes'] ?? 60,
+            dailyReportEnabled:         $overrides['dailyReportEnabled'] ?? false,
+            regenerateDailyReportToken: $overrides['regenerateDailyReportToken'] ?? false,
+        );
+    }
+
+    public function test_returns_view_with_updated_smtp_settings(): void
+    {
+        $view = $this->makeUseCase()->execute($this->makeInput([
+            'smtpHost' => 'mail.corp.com',
+            'smtpPort' => 465,
+        ]));
+
+        self::assertTrue($view->smtpConfigured);
+        self::assertSame('mail.corp.com', $view->smtpHost);
+        self::assertSame(465, $view->smtpPort);
+    }
+
+    public function test_keeps_existing_password_when_smtp_password_null(): void
+    {
+        // Seed an existing password in env
+        $_ENV['MAIL_HOST']     = 'smtp.example.com';
+        $_ENV['MAIL_PASSWORD'] = 'existingpass';
+
+        $view = $this->makeUseCase()->execute($this->makeInput([
+            'smtpPassword' => null, // keep existing
+        ]));
+
+        // The view should show password is still set
+        self::assertTrue($view->smtpPasswordSet);
+    }
+
+    public function test_uses_new_password_when_provided(): void
+    {
+        $_ENV['MAIL_HOST']     = 'smtp.example.com';
+        $_ENV['MAIL_PASSWORD'] = 'oldpass';
+
+        $this->makeUseCase()->execute($this->makeInput([
+            'smtpPassword' => 'brandnewpass',
+        ]));
+
+        // After execute, env should have the new password
+        self::assertSame('brandnewpass', $_ENV['MAIL_PASSWORD'] ?? '');
+    }
+
+    public function test_regenerates_daily_report_token_when_requested(): void
+    {
+        $_ENV['NOTIFY_DAILY_REPORT_TOKEN'] = 'old-token';
+
+        $view = $this->makeUseCase()->execute($this->makeInput([
+            'regenerateDailyReportToken' => true,
+        ]));
+
+        self::assertNotSame('old-token', $view->dailyReportToken);
+        self::assertNotEmpty($view->dailyReportToken);
+    }
+
+    public function test_keeps_existing_token_when_regenerate_false_and_token_exists(): void
+    {
+        $_ENV['NOTIFY_DAILY_REPORT_TOKEN'] = 'keep-this-token';
+
+        $view = $this->makeUseCase()->execute($this->makeInput([
+            'regenerateDailyReportToken' => false,
+        ]));
+
+        self::assertSame('keep-this-token', $view->dailyReportToken);
+    }
+
+    public function test_generates_new_token_when_current_token_empty(): void
+    {
+        $_ENV['NOTIFY_DAILY_REPORT_TOKEN'] = '';
+
+        $view = $this->makeUseCase()->execute($this->makeInput([
+            'regenerateDailyReportToken' => false,
+        ]));
+
+        self::assertNotEmpty($view->dailyReportToken);
+    }
+
+    public function test_generated_token_is_48_char_hex(): void
+    {
+        $view = $this->makeUseCase()->execute($this->makeInput([
+            'regenerateDailyReportToken' => true,
+        ]));
+
+        self::assertMatchesRegularExpression('/^[0-9a-f]{48}$/', $view->dailyReportToken);
+    }
+
+    public function test_writes_env_file(): void
+    {
+        $this->makeUseCase()->execute($this->makeInput([
+            'smtpHost' => 'test.smtp.local',
+        ]));
+
+        $envContent = file_get_contents($this->tmpDir . '/.env');
+        self::assertIsString($envContent);
+        self::assertStringContainsString('MAIL_HOST=test.smtp.local', $envContent);
+    }
+
+    public function test_updates_notification_settings(): void
+    {
+        $view = $this->makeUseCase()->execute($this->makeInput([
+            'notifyEmail'             => 'alert@example.com',
+            'rateLimitNotifyEnabled'  => true,
+            'rateLimitCooldownMinutes' => 30,
+            'dailyReportEnabled'      => true,
+        ]));
+
+        self::assertSame('alert@example.com', $view->notifyEmail);
+        self::assertTrue($view->rateLimitNotifyEnabled);
+        self::assertSame(30, $view->rateLimitCooldownMinutes);
+        self::assertTrue($view->dailyReportEnabled);
+    }
+}


### PR DESCRIPTION
Closes #244

## 変更内容

### Notification テスト（新規 7 ファイル・50 ケース）

| ファイル | 対象クラス | ケース数 |
|---|---|---|
| `NotificationConfigTest` | `NotificationConfig::fromEnvironment()` | 10 |
| `GetNotificationSettingsUseCaseTest` | `GetNotificationSettingsUseCase` | 6 |
| `UpdateNotificationSettingsUseCaseTest` | `UpdateNotificationSettingsUseCase` | 10 |
| `SendDailyReportUseCaseTest` | `SendDailyReportUseCase` | 7 |
| `SendTestMailUseCaseTest` | `SendTestMailUseCase` | 3 |
| `RateLimitNotifierTest` | `RateLimitNotifier` | 6 |
| `PdoDailyReportRepositoryTest` | `PdoDailyReportRepository` | 8 |

### PHPUnit Notice 修正

`SendChatMessageUseCaseTest`: 期待なし `createMock()` → `createStub()` に変更（2 箇所）

### テスト数推移

| | before | after |
|---|---|---|
| Tests | 280 | 330 |
| Assertions | 990 | 1097 |
| PHPUnit Notices | 1 | 0 |

## セルフレビュー
- [x] `composer check` — 330 tests passed、PHPUnit Notice ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)