### PR TITLE
docs: README と roadmap を現状に合わせて更新する

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Ops / AI (MCP)         ───────────────────
 
 - **Backend**: PHP 8.4, NENE2, Handler → UseCase → Repository
 - **API contract**: OpenAPI 3.1 ([`docs/openapi/openapi.yaml`](./docs/openapi/openapi.yaml))
-- **Ingestion**: PDF text extraction, CSV row mapping (planned)
+- **Ingestion**: PDF text extraction, CSV row mapping, plain-text direct input
 - **Chat**: **sync JSON chat** + citations, rate limits; widget CSS for loading/motion UX
 - **Deploy**: dual path — [`docs/deployment/README.md`](./docs/deployment/README.md)
 
@@ -68,9 +68,13 @@ Phases 1–3 core deliverables are complete. See [`docs/roadmap.md`](./docs/road
 
 | Area | State |
 | --- | --- |
-| Corpus ingestion + admin API | ✅ |
-| Sync JSON chat + citations | ✅ |
-| Admin UI + embed widget | ✅ |
+| Corpus ingestion (PDF / CSV / plain text) + admin API | ✅ |
+| Sync JSON chat + citations + rate limits | ✅ |
+| Admin UI + embed widget (i18n 6 locales, custom CSS, avatar, HERO) | ✅ |
+| Operator settings (LLM key, chat limits, notifications, appearance) | ✅ |
+| Conversation analytics dashboard + CSV export | ✅ |
+| Brute-force protection + password reset | ✅ |
+| Admin E2E tests (157 Playwright specs) | ✅ |
 | Tier A — installer + release ZIP + operator docs | ✅ |
 | Phase 4 — upstream integrations | Planned |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,16 +60,24 @@ Goal: operable product without curl; Tier A install path.
 
 **Status: complete (2026-05-25).** Milestone: [`milestones/2026-05-admin-ui-and-widget.md`](./milestones/2026-05-admin-ui-and-widget.md).
 
-## Phase 3+: Operator UX & settings (backlog)
+## Phase 3+: Operator UX & settings ✅ 完了
 
 Goal: day-2 operations without SSH or hosting-panel `.env` edits where possible.
 
-- **Conversation log metadata** — client IP, User-Agent (optional referer) on session create; admin detail view; privacy/retention notes
-- **LLM API key management** — rotate or switch Anthropic account from Admin (installer is first-time only today); masked key, test-before-save, never expose full secret in API responses
-- **Prompt / scope / fallback settings UI** — deferred from Phase 3 roadmap line
-- Widget UX polish (HERO, bubbles, CSS motion) — see [`todo/current.md`](./todo/current.md)
+- **Conversation log metadata** ✅ — client IP, User-Agent, referer on session create; admin detail view
+- **LLM API key management** ✅ — masked key, test-before-save, `.env` update from Admin (#130)
+- **Prompt / scope / fallback settings UI** ✅ — custom system prompt, fallback message (#163)
+- **Widget UX polish** ✅ — HERO, speech bubbles, avatar upload, CSS motion, custom CSS (#133 #134 #146 #165 #169)
+- **Chat limits** ✅ — message length, rate intervals, daily token budget per IP and global (#197 #199)
+- **Email notifications** ✅ — limit-exceeded alerts, daily chat report (PHPMailer, cron, Admin UI) (#211)
+- **Settings modal** ✅ — full-screen `<dialog>` unifying LLM / chat / limits / appearance / account tabs (#204 #205 #208)
+- **Login brute-force protection** ✅ — IP-based 10 attempts / 15 min (#224)
+- **Password reset** ✅ — email flow with SHA-256 token, 1 h TTL, single-use (#226)
+- **Conversation analytics dashboard** ✅ — KPI cards, daily trend chart, hourly distribution, top questions, CSV/JSON export (#255)
+- **Admin E2E test suite** ✅ — 157 Playwright specs covering all major flows (#250 #252)
+- **Persona UX scenario tests** ✅ — 200 personas × 10 patterns, 200/200 pass, UX analysis report (#253)
 
-Issue 化してから実装。詳細バックログ: [`docs/todo/current.md`](./todo/current.md) § Phase 3+.
+詳細バックログ: [`docs/todo/current.md`](./todo/current.md).
 
 ## Phase 4: Upstream Integrations
 


### PR DESCRIPTION
Closes #257

## 変更概要

Phase 3+ 全完了・会話分析ダッシュボード追加を受けたドキュメント鮮度更新。

## 変更内容

**README.md**
- Ingestion から `(planned)` を削除（CSV・plain text は実装済み）
- Current Status テーブルを実装済み機能に合わせて更新
  - analytics dashboard, E2E tests, brute-force protection, operator settings 等を追加

**docs/roadmap.md**
- Phase 3+ を「backlog」表記から全項目 ✅ 完了に更新
- 会話分析ダッシュボード・Admin E2E テスト（157 件）・ペルソナ UX テスト（200 件）を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)