### PR TITLE
feat(admin-ui): v2 リデザインの基盤を導入する (#259)

### DIFF
--- a/frontend/apps/admin/package.json
+++ b/frontend/apps/admin/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/noto-sans-jp": "^5.2.9",
     "@fontsource/noto-sans-sc": "^5.2.9",
     "@nene-corpus/api-client": "*",

--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -1,198 +1,89 @@
 import { useEffect, useState } from 'react';
-import { Msg, resolveMsgKey, applyLocaleFontFamily, toBcp47, useLocale, useMsg, type MsgKey } from '@nene-corpus/i18n';
-import { getLlmSettings } from '@nene-corpus/api-client/llm-settings';
-import { LoginForm, SourcesPanel } from './SourcesPanel';
-import { IngestionPanel } from './IngestionPanel';
-import { ConversationLogsPanel, ConversationLogsSummary } from './ConversationLogsPanel';
-import { AnalyticsPanel } from './AnalyticsPanel';
-import { LlmUnconfiguredBanner } from './LlmUnconfiguredBanner';
-import { SettingsModal } from './SettingsModal';
-import type { SettingsSection } from './SettingsModal';
-import { HelpPanel } from './HelpPanel';
-import { LocaleSelector } from './LocaleSelector';
-import { ThemeToggle } from './ThemeToggle';
-import { scrollToHelp } from './scrollToHelp';
+import { applyLocaleFontFamily, toBcp47, useLocale } from '@nene-corpus/i18n';
 import { useAdminAuth } from './useAdminAuth';
-import { adminApiBase } from './config';
-import { PasswordResetRequestForm, PasswordResetConfirmForm } from './PasswordResetForms';
+import { LoginPage } from './v2/pages/LoginPage';
+import { DashboardPage } from './v2/pages/DashboardPage';
+import { SourcesPage } from './v2/pages/SourcesPage';
+import { ConversationsPage } from './v2/pages/ConversationsPage';
+import { SettingsPage } from './v2/pages/SettingsPage';
 
-type AuthView = 'login' | 'reset-request' | 'reset-confirm';
+type V2Route = 'login' | 'dashboard' | 'sources' | 'conversations' | 'settings';
+
+function resolveRoute(): V2Route {
+  const hash = window.location.hash;
+  if (hash.startsWith('#/sources'))        return 'sources';
+  if (hash.startsWith('#/conversations'))  return 'conversations';
+  if (hash.startsWith('#/settings'))       return 'settings';
+  if (hash.startsWith('#/login'))          return 'login';
+  if (hash.startsWith('#/dashboard'))      return 'dashboard';
+  // デフォルト
+  return 'dashboard';
+}
 
 export function App() {
-  const t = useMsg();
   const { locale } = useLocale();
-  const { token, profile, isReady, error, login, logout } = useAdminAuth();
-  const [sourcesReloadKey, setSourcesReloadKey] = useState(0);
-  const [logsOpen, setLogsOpen] = useState(false);
+  const { token, isReady, login, logout } = useAdminAuth();
+  const [route, setRoute] = useState<V2Route>(resolveRoute);
 
-  const [authView, setAuthView] = useState<AuthView>(() => {
-    const params = new URLSearchParams(window.location.search);
-    return params.has('reset_token') ? 'reset-confirm' : 'login';
-  });
-  const resetToken = new URLSearchParams(window.location.search).get('reset_token') ?? '';
-
-  // LLM 設定済みフラグ（null = ロード中 / 未チェック）
-  const [isLlmConfigured, setIsLlmConfigured] = useState<boolean | null>(null);
-
-  // 設定モーダル
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsSection, setSettingsSection] = useState<SettingsSection>('overview');
-
+  // ロケール適用（既存ロジックを維持）
   useEffect(() => {
     document.documentElement.lang = toBcp47(locale);
     applyLocaleFontFamily(locale);
   }, [locale]);
 
-  // ログイン直後に LLM 設定状態を取得してバナー表示を決定
+  // hash 変化を監視してルートを更新
   useEffect(() => {
-    if (token === null) {
-      setIsLlmConfigured(null);
-      return;
+    function handleHashChange() {
+      setRoute(resolveRoute());
     }
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
 
-    let cancelled = false;
-    getLlmSettings(token, adminApiBase)
-      .then((s) => { if (!cancelled) setIsLlmConfigured(s.configured); })
-      .catch(() => { /* 取得失敗時はバナーを出さない */ });
+  // 認証チェック: token なしで保護ルートにいたら #/login へ
+  useEffect(() => {
+    if (!isReady) return;
+    if (token === null && route !== 'login') {
+      window.location.hash = '#/login';
+    }
+  }, [isReady, token, route]);
 
-    return () => { cancelled = true; };
-  }, [token]);
-
-  function openSettings(section: SettingsSection = 'overview'): void {
-    setSettingsSection(section);
-    setSettingsOpen(true);
-  }
+  // ログイン後: #/login にいたら #/dashboard へリダイレクト
+  useEffect(() => {
+    if (!isReady) return;
+    if (token !== null && route === 'login') {
+      window.location.hash = '#/dashboard';
+    }
+  }, [isReady, token, route]);
 
   if (!isReady) {
     return (
-      <div className="flex min-h-screen items-center justify-center nc-text-muted">
-        {t(Msg.common.loading)}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        fontFamily: '"Inter", system-ui, sans-serif',
+        fontSize: 14,
+        color: 'var(--ink-muted, #6E7081)',
+        background: 'var(--bg, #F7F5EE)',
+      }}>
+        読み込み中...
       </div>
     );
   }
 
-  return (
-    <div className="min-h-screen text-fg">
-      <header className="sticky top-0 z-40 border-b border-border bg-header/80 px-6 py-4 backdrop-blur-md">
-        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4">
-          <div>
-            <h1 className="text-xl font-semibold tracking-tight text-brand">{t(Msg.admin.app.title)}</h1>
-            {profile && <p className="nc-text-muted">{profile.email}</p>}
-          </div>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <ThemeToggle />
-            <LocaleSelector />
-            {token !== null && (
-              <button className="nc-btn nc-header-btn" type="button" onClick={() => openSettings('overview')}>
-                {t(Msg.admin.app.settings)}
-              </button>
-            )}
-            <button className="nc-btn nc-header-btn" type="button" onClick={scrollToHelp}>
-              {t(resolveMsgKey(Msg.admin.help?.open, 'admin.help.open'))}
-            </button>
-            {profile && (
-              <button className="nc-btn nc-header-btn" type="button" onClick={logout}>
-                {t(Msg.common.signOut)}
-              </button>
-            )}
-          </div>
-        </div>
-      </header>
-      <main className="mx-auto max-w-5xl space-y-6 px-6 py-8">
-        {token === null ? (
-          <>
-            {authView === 'reset-request' && (
-              <PasswordResetRequestForm onBack={() => setAuthView('login')} />
-            )}
-            {authView === 'reset-confirm' && (
-              <PasswordResetConfirmForm
-                rawToken={resetToken}
-                onBack={() => {
-                  const url = new URL(window.location.href);
-                  url.searchParams.delete('reset_token');
-                  window.history.replaceState({}, '', url.toString());
-                  setAuthView('login');
-                }}
-              />
-            )}
-            {authView === 'login' && (
-              <LoginForm
-                error={error}
-                onLogin={login}
-                onForgotPassword={() => setAuthView('reset-request')}
-              />
-            )}
-            <HelpPanel />
-          </>
-        ) : (
-          <>
-            {/* ── LLM 未設定アラート ── */}
-            {isLlmConfigured === false && (
-              <LlmUnconfiguredBanner onConfigureLlm={() => openSettings('llm')} />
-            )}
-            {/* ── コンテンツ管理 ── */}
-            <IngestionPanel token={token} onUploaded={() => setSourcesReloadKey((key) => key + 1)} />
-            <SourcesPanel
-              token={token}
-              reloadKey={sourcesReloadKey}
-              onDocumentsChanged={() => setSourcesReloadKey((key) => key + 1)}
-            />
-            {/* ── 運用監視 ── */}
-            <AnalyticsPanel token={token} />
-            <ConversationLogsSummary
-              token={token}
-              onOpenLogs={() => setLogsOpen(true)}
-            />
-            {logsOpen && (
-              <ConversationLogsPanel token={token} onClose={() => setLogsOpen(false)} />
-            )}
-            <HelpPanel />
-          </>
-        )}
-      </main>
+  // 未認証: ログインページ
+  if (token === null || route === 'login') {
+    return <LoginPage onLogin={login} />;
+  }
 
-      {/* ── 設定モーダル ── */}
-      {settingsOpen && token !== null && (
-        <SettingsModal
-          token={token}
-          initialSection={settingsSection}
-          onClose={() => setSettingsOpen(false)}
-          onLlmConfiguredChange={setIsLlmConfigured}
-        />
-      )}
-
-      {/* ── フッター ── */}
-      <AdminFooter locale={locale} t={t} />
-    </div>
-  );
-}
-
-const GUIDE_URL_MAP: Record<string, string> = {
-  ja: '/guide/ja/',
-  en: '/guide/en/',
-  de: '/guide/de/',
-  fr: '/guide/fr/',
-  'pt-BR': '/guide/pt-br/',
-  'zh-Hans': '/guide/zh-hans/',
-};
-
-function AdminFooter({ locale, t }: { locale: string; t: (key: MsgKey) => string }) {
-  const guideUrl = GUIDE_URL_MAP[locale] ?? '/guide/en/';
-  return (
-    <footer className="mt-12 border-t border-border px-6 py-6 text-center text-xs nc-text-muted">
-      <p>
-        {t(resolveMsgKey(Msg.admin.footer?.poweredBy, 'admin.footer.poweredBy'))}{' '}
-        <a
-          href={guideUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-medium text-brand hover:underline"
-        >
-          NeNe Corpus
-        </a>
-        {' · '}
-        {t(resolveMsgKey(Msg.admin.footer?.copyright, 'admin.footer.copyright'))}
-      </p>
-    </footer>
-  );
+  // 認証済み: ルーティング
+  switch (route) {
+    case 'sources':       return <SourcesPage />;
+    case 'conversations': return <ConversationsPage />;
+    case 'settings':      return <SettingsPage token={token} onLogout={logout} />;
+    case 'dashboard':
+    default:              return <DashboardPage token={token} onLogout={logout} />;
+  }
 }

--- a/frontend/apps/admin/src/fonts.ts
+++ b/frontend/apps/admin/src/fonts.ts
@@ -1,6 +1,7 @@
 /**
  * Admin 用 @fontsource 同梱。Widget には含めない。
  * Latin: Inter（en, fr, de, pt-BR） / CJK: Noto Sans JP, Noto Sans SC
+ * Mono: JetBrains Mono（v2 eyebrow / timestamp / ID 表示用）
  */
 import '@fontsource/inter/latin-400.css';
 import '@fontsource/inter/latin-500.css';
@@ -16,3 +17,7 @@ import '@fontsource/noto-sans-jp/japanese-600.css';
 import '@fontsource/noto-sans-sc/chinese-simplified-400.css';
 import '@fontsource/noto-sans-sc/chinese-simplified-500.css';
 import '@fontsource/noto-sans-sc/chinese-simplified-600.css';
+
+import '@fontsource/jetbrains-mono/latin-400.css';
+import '@fontsource/jetbrains-mono/latin-600.css';
+import '@fontsource/jetbrains-mono/latin-700.css';

--- a/frontend/apps/admin/src/index.css
+++ b/frontend/apps/admin/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import './v2.css';
 
 @theme inline {
   --font-sans: var(--nc-admin-font-family);

--- a/frontend/apps/admin/src/v2.css
+++ b/frontend/apps/admin/src/v2.css
@@ -1,0 +1,782 @@
+/* ════════════════════════════════════════════════════════════════════
+   NeNe Corpus Admin · v2 B-soft design tokens + component styles
+   Appended to index.css to coexist with existing Tailwind tokens.
+   - Light default: :root additions via [data-v2] aware tokens
+   - Dark mode: [data-theme="dark"]  (matches <html data-theme="dark">)
+   ════════════════════════════════════════════════════════════════════ */
+
+/* ── v2 colour tokens: added to :root (won't conflict with nc-admin-*) ── */
+:root {
+  /* Paper & surface */
+  --bg:                #F7F5EE;
+  --bg-soft:           #F1EEE2;
+  --surface:           #FFFFFF;
+  --surface-hover:     #F8F6EE;
+  --side-bg:           #F0EDE0;
+  --side-bg-soft:      #E7E3D2;
+
+  --hair:              #E0DBC8;
+  --hair-soft:         #ECE7D4;
+  --hair-strong:       #CDC7B0;
+
+  --ink:               #1F2937;
+  --ink-strong:        #0F172A;
+  --ink-soft:          #4B5563;
+  --ink-muted:         #6E7081;
+  --ink-faint:         #9A9C90;
+
+  /* Accent: navy / business-tool */
+  --primary:           #3D5A8C;
+  --primary-hover:     #2E4670;
+  --primary-tint:      rgba(61,90,140,.10);
+  --primary-soft:      #E8EEF7;
+  --primary-border:    #B3C2DC;
+  --primary-fg:        #FFFFFF;
+
+  --success:           #4F7A4F;
+  --success-fg:        #3D6440;
+  --success-soft:      #EAF1EA;
+  --success-border:    #BCD2BD;
+
+  --warning:           #B07D2D;
+  --warning-soft:      #FAF1DD;
+  --warning-border:    #E8CE94;
+  --warning-text:      #6E4D17;
+
+  --danger:            #B14444;
+  --danger-soft:       #F8E5E5;
+  --danger-border:     #E5B9B9;
+  --danger-text:       #7A2828;
+
+  /* File type accents */
+  --type-csv:          #4F7A4F;  --type-csv-bg:  #EAF1EA;
+  --type-pdf:          #A85440;  --type-pdf-bg:  #F4E2DC;
+  --type-text:         #5A6E8C;  --type-text-bg: #E8ECF3;
+  --type-web:          #7B5C8C;  --type-web-bg:  #EFE4F2;
+
+  --shadow-card:       0 1px 2px rgba(15,23,42,.05);
+  --shadow-elev:       0 8px 24px -8px rgba(15,23,42,.18), 0 2px 6px rgba(15,23,42,.05);
+}
+
+[data-theme="dark"] {
+  --bg:                #14171C;
+  --bg-soft:           #1A1F26;
+  --surface:           #1B2028;
+  --surface-hover:     #22272F;
+  --side-bg:           #0F1218;
+  --side-bg-soft:      #1A1F26;
+
+  --hair:              #2A2F37;
+  --hair-soft:         #20242C;
+  --hair-strong:       #353B45;
+
+  --ink:               #DCDDE0;
+  --ink-strong:        #F4F4F5;
+  --ink-soft:          #B4B7BD;
+  --ink-muted:         #8B8F97;
+  --ink-faint:         #6A6E76;
+
+  --primary:           #8AA8D8;
+  --primary-hover:     #A4BEE6;
+  --primary-tint:      rgba(138,168,216,.16);
+  --primary-soft:      rgba(138,168,216,.10);
+  --primary-border:    rgba(138,168,216,.35);
+  --primary-fg:        #14171C;
+
+  --success:           #7FB069;
+  --success-fg:        #93C476;
+  --success-soft:      rgba(127,176,105,.14);
+  --success-border:    rgba(127,176,105,.30);
+
+  --warning:           #E5A552;
+  --warning-soft:      rgba(229,165,82,.14);
+  --warning-border:    rgba(229,165,82,.30);
+  --warning-text:      #E5A552;
+
+  --danger:            #E26B5F;
+  --danger-soft:       rgba(226,107,95,.14);
+  --danger-border:     rgba(226,107,95,.32);
+  --danger-text:       #E26B5F;
+
+  --type-csv:          #7FB069;  --type-csv-bg:  rgba(127,176,105,.14);
+  --type-pdf:          #E26B5F;  --type-pdf-bg:  rgba(226,107,95,.14);
+  --type-text:         #8AA8D8;  --type-text-bg: rgba(138,168,216,.14);
+  --type-web:          #C77AB5;  --type-web-bg:  rgba(199,122,181,.14);
+
+  --shadow-card:       0 1px 2px rgba(0,0,0,.30);
+  --shadow-elev:       0 12px 32px -10px rgba(0,0,0,.55), 0 2px 6px rgba(0,0,0,.30);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   v2 component styles — scoped to .v2-shell to avoid collisions
+   with existing Admin SPA while both coexist during migration.
+   Outside .v2-shell, only global reset additions are applied.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Mono utility class (used inside v2 pages) */
+.v2-shell .mono {
+  font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+  font-feature-settings: 'tnum';
+}
+
+/* ── Top bar ── */
+.v2-shell .topbar {
+  height: 52px; flex-shrink: 0;
+  display: flex; align-items: center;
+  padding: 0 22px;
+  border-bottom: 1px solid var(--hair-strong);
+  background: var(--surface);
+}
+.v2-shell .brand {
+  display: flex; align-items: center; gap: 10px;
+}
+.v2-shell .brand-mark {
+  width: 28px; height: 28px; border-radius: 7px;
+  background: var(--primary);
+  display: flex; align-items: center; justify-content: center;
+  position: relative;
+  color: var(--primary-fg);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 13px; font-weight: 700;
+  letter-spacing: -0.04em;
+  flex-shrink: 0;
+}
+.v2-shell .brand-mark::after {
+  content: ''; position: absolute;
+  left: 6px; right: 6px; bottom: 6px; height: 2px;
+  background: rgba(255,255,255,.55);
+  border-radius: 1px;
+}
+[data-theme="dark"] .v2-shell .brand-mark::after { background: rgba(20,23,28,.55); }
+.v2-shell .brand-name {
+  font-size: 14.5px; font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink-strong);
+  display: flex; align-items: baseline; gap: 8px;
+  line-height: 1;
+}
+.v2-shell .brand-name .dim { color: var(--ink-muted); font-weight: 400; }
+.v2-shell .brand-name .admin {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--primary);
+  padding: 2px 6px;
+  border: 1px solid var(--primary-border);
+  border-radius: 3px;
+  background: var(--primary-soft);
+}
+.v2-shell .topbar-mid {
+  display: flex; align-items: center; gap: 4px;
+  margin-left: 28px;
+  font-size: 13px;
+  color: var(--ink-muted);
+}
+.v2-shell .topbar-mid .crumb { color: var(--ink-soft); }
+.v2-shell .topbar-mid .sep { color: var(--ink-faint); font-size: 11px; }
+.v2-shell .topbar-mid .leaf { color: var(--ink-strong); font-weight: 600; }
+.v2-shell .topbar-right {
+  margin-left: auto;
+  display: flex; align-items: center; gap: 10px;
+}
+.v2-shell .kbd-search {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-soft);
+  border: 1px solid var(--hair-strong);
+  border-radius: 6px;
+  color: var(--ink-muted);
+  font-size: 13px;
+  min-width: 220px;
+  cursor: default;
+}
+.v2-shell .kbd-search svg { color: var(--ink-faint); }
+.v2-shell .kbd-search .kbd {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  padding: 1px 5px;
+  background: var(--surface);
+  border: 1px solid var(--hair-strong);
+  border-radius: 3px;
+  margin-left: auto;
+  color: var(--ink-muted);
+}
+.v2-shell .icon-btn {
+  width: 30px; height: 30px;
+  border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--ink-muted);
+  transition: background 120ms ease, color 120ms ease;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+.v2-shell .icon-btn:hover { background: var(--bg-soft); color: var(--ink); }
+.v2-shell .who {
+  display: flex; align-items: center; gap: 9px;
+  padding-left: 12px;
+  border-left: 1px solid var(--hair);
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+.v2-shell .avatar {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--primary-tint);
+  color: var(--primary);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px; font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--primary-border);
+}
+.v2-shell .theme-toggle {
+  display: inline-flex;
+  background: var(--bg-soft);
+  border: 1px solid var(--hair-strong);
+  border-radius: 6px;
+  padding: 2px;
+}
+.v2-shell .theme-toggle button {
+  width: 26px; height: 22px;
+  border-radius: 4px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ink-faint);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.v2-shell .theme-toggle button.on {
+  background: var(--surface);
+  color: var(--primary);
+  box-shadow: 0 1px 2px rgba(15,23,42,.06);
+}
+
+/* ── Shell layout ── */
+.v2-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", "Hiragino Kaku Gothic ProN", "Noto Sans JP", -apple-system, system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.v2-shell .shell {
+  display: grid;
+  grid-template-columns: 248px 1fr;
+  grid-template-rows: 1fr 28px;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+/* ── Sidebar ── */
+.v2-shell .side {
+  grid-column: 1; grid-row: 1;
+  background: var(--side-bg);
+  border-right: 1px solid var(--hair-strong);
+  padding: 14px 0 24px;
+  overflow-y: auto;
+  font-size: 13.5px;
+}
+.v2-shell .side-section {
+  padding: 14px 16px 4px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.v2-shell .side-section .count {
+  font-family: inherit; color: var(--ink-faint);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+.v2-shell .nav-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 12px; margin: 1px 8px;
+  color: var(--ink-soft);
+  border-radius: 5px;
+  position: relative;
+  cursor: pointer;
+  font-size: 13px;
+  text-decoration: none;
+  background: none;
+  border: none;
+  width: calc(100% - 16px);
+  text-align: left;
+}
+.v2-shell .nav-item:hover { background: var(--side-bg-soft); color: var(--ink); }
+.v2-shell .nav-item.active {
+  background: var(--surface);
+  color: var(--ink-strong);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(15,23,42,.04);
+}
+[data-theme="dark"] .v2-shell .nav-item.active { box-shadow: 0 1px 2px rgba(0,0,0,.20); }
+.v2-shell .nav-item.active::before {
+  content: ''; position: absolute; left: -8px; top: 5px; bottom: 5px;
+  width: 2px; background: var(--primary); border-radius: 2px;
+}
+.v2-shell .nav-item .icon { flex-shrink: 0; color: var(--ink-faint); display: inline-flex; }
+.v2-shell .nav-item.active .icon { color: var(--primary); }
+.v2-shell .nav-item .ja { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-shell .nav-item .badge {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px; font-weight: 600;
+  padding: 1px 6px; border-radius: 99px;
+  background: var(--bg-soft);
+  color: var(--ink-muted);
+  letter-spacing: 0.02em;
+}
+.v2-shell .nav-item.active .badge { background: var(--primary-tint); color: var(--primary); }
+.v2-shell .nav-item .status-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+}
+.v2-shell .nav-item .status-dot.bad { background: var(--danger); }
+.v2-shell .nav-item .status-dot.ok { background: var(--success); }
+
+/* Corpus tree */
+.v2-shell .tree-item {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  gap: 8px;
+  padding: 5px 12px 5px 16px;
+  margin: 0 8px;
+  color: var(--ink-soft);
+  font-size: 13px;
+  align-items: center;
+  cursor: pointer;
+  border-radius: 5px;
+}
+.v2-shell .tree-item:hover { background: var(--side-bg-soft); }
+.v2-shell .tree-item .glyph { color: var(--ink-faint); font-size: 11px; }
+.v2-shell .tree-item .lbl { min-width: 0; overflow: hidden; }
+.v2-shell .tree-item .lbl .ja { color: var(--ink); font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v2-shell .tree-item .lbl .meta {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px; color: var(--ink-faint);
+  letter-spacing: 0.02em;
+}
+.v2-shell .tree-item .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.v2-shell .tree-item .dot.ok { background: var(--success); }
+.v2-shell .tree-item .dot.bg {
+  background: var(--warning);
+  animation: v2-pulse 1.4s ease-in-out infinite;
+}
+@keyframes v2-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+/* ── Main ── */
+.v2-shell .main {
+  grid-column: 2; grid-row: 1;
+  overflow-y: auto;
+  background: var(--bg);
+}
+.v2-shell .main-inner {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 24px 28px 40px;
+}
+
+/* ── Page head ── */
+.v2-shell .page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 18px;
+  margin-bottom: 22px;
+  border-bottom: 1px solid var(--hair);
+}
+.v2-shell .page-head .eyebrow {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--primary);
+  margin-bottom: 6px;
+  display: flex; align-items: center; gap: 8px;
+}
+.v2-shell .page-head h1 {
+  font-size: 26px; font-weight: 700;
+  color: var(--ink-strong);
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin: 0;
+}
+.v2-shell .page-head .desc {
+  font-size: 13.5px;
+  color: var(--ink-muted);
+  margin-top: 4px;
+}
+.v2-shell .head-actions { display: flex; align-items: center; gap: 8px; }
+
+/* ── Status bar ── */
+.v2-shell .statusbar {
+  grid-column: 1 / -1; grid-row: 2;
+  display: flex; align-items: center;
+  background: var(--surface);
+  border-top: 1px solid var(--hair-strong);
+  font-size: 11.5px;
+  color: var(--ink-muted);
+  padding: 0;
+}
+.v2-shell .statusbar .chunk {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 0 14px; height: 100%;
+  border-right: 1px solid var(--hair);
+}
+.v2-shell .statusbar .chunk:last-of-type { border-right: none; }
+.v2-shell .statusbar .chunk .lbl {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--ink-faint);
+  letter-spacing: 0.08em; text-transform: uppercase;
+}
+.v2-shell .statusbar .chunk .val { color: var(--ink-soft); font-weight: 500; }
+.v2-shell .statusbar .chunk .val.danger { color: var(--danger); font-weight: 700; }
+.v2-shell .statusbar .chunk .val.ok { color: var(--success-fg); }
+.v2-shell .statusbar .chunk .val.accent { color: var(--primary); }
+.v2-shell .statusbar .right { margin-left: auto; border-left: 1px solid var(--hair); border-right: none; }
+.v2-shell .statusbar .env {
+  background: var(--primary); color: var(--primary-fg);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  border-right: none;
+}
+.v2-shell .statusbar .dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
+.v2-shell .statusbar .dot.ok { background: var(--success); box-shadow: 0 0 6px rgba(79,122,79,.45); }
+.v2-shell .statusbar .dot.bad { background: var(--danger); box-shadow: 0 0 6px rgba(177,68,68,.45); }
+
+/* ── Buttons ── */
+.v2-shell .btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 13px; font-weight: 600;
+  padding: 7px 12px;
+  border-radius: 6px;
+  transition: background 120ms ease, border-color 120ms ease;
+  line-height: 1;
+  cursor: pointer;
+  border: none;
+}
+.v2-shell .btn-ghost {
+  background: var(--surface);
+  border: 1px solid var(--hair-strong);
+  color: var(--ink-soft);
+}
+.v2-shell .btn-ghost:hover { background: var(--bg-soft); border-color: var(--hair-strong); color: var(--ink); }
+.v2-shell .btn-primary {
+  background: var(--primary); color: var(--primary-fg);
+  border: 1px solid var(--primary);
+}
+.v2-shell .btn-primary:hover { background: var(--primary-hover); border-color: var(--primary-hover); }
+.v2-shell .btn-sm { padding: 5px 10px; font-size: 12px; }
+
+/* ── Alert ── */
+.v2-shell .alert {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 16px;
+  background: var(--warning-soft);
+  border: 1px solid var(--warning-border);
+  border-left: 3px solid var(--warning);
+  border-radius: 6px;
+  margin-bottom: 18px;
+}
+.v2-shell .alert.alert-danger {
+  background: var(--danger-soft);
+  border-color: var(--danger-border);
+  border-left-color: var(--danger);
+}
+
+/* ── Section head ── */
+.v2-shell .section-head {
+  display: flex; align-items: baseline; gap: 12px;
+  margin: 22px 0 12px;
+}
+.v2-shell .section-head h2 {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--ink-strong);
+  letter-spacing: -0.005em;
+  margin: 0;
+}
+.v2-shell .section-head .en {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+.v2-shell .section-head .rule { flex: 1; height: 1px; background: var(--hair); }
+
+/* ── KPI rows ── */
+.v2-shell .kpi-block {
+  background: var(--surface);
+  border: 1px solid var(--hair);
+  border-radius: 8px;
+  padding: 6px 18px;
+}
+.v2-shell .kpi-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  column-gap: 28px;
+}
+.v2-shell .kpi-row {
+  display: grid;
+  grid-template-columns: 8px 1fr auto;
+  gap: 10px;
+  align-items: baseline;
+  padding: 12px 0;
+  border-bottom: 1px dotted var(--hair);
+}
+.v2-shell .kpi-row:last-child { border-bottom: none; }
+.v2-shell .kpi-row .swatch {
+  width: 8px; height: 8px; border-radius: 50%; align-self: center;
+}
+.v2-shell .kpi-row .swatch.ok { background: var(--success); }
+.v2-shell .kpi-row .swatch.warn { background: var(--warning); }
+.v2-shell .kpi-row .swatch.bad { background: var(--danger); }
+.v2-shell .kpi-row .swatch.info { background: var(--primary); }
+
+/* ── Panel ── */
+.v2-shell .panel {
+  background: var(--surface);
+  border: 1px solid var(--hair);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.v2-shell .panel-head {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--hair);
+  display: flex; align-items: center; justify-content: space-between;
+}
+
+/* ── Pills ── */
+.v2-shell .pill {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px; font-weight: 600;
+  font-family: "JetBrains Mono", monospace;
+  letter-spacing: 0.02em;
+}
+.v2-shell .pill::before { content: ''; width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+.v2-shell .pill-ready { background: var(--success-soft); color: var(--success-fg); }
+.v2-shell .pill-processing { background: var(--warning-soft); color: var(--warning); }
+.v2-shell .pill-failed { background: var(--danger-soft); color: var(--danger); border: 1px solid var(--danger-border); }
+.v2-shell .pill-active { background: var(--primary-soft); color: var(--primary); }
+
+/* ── Type tags ── */
+.v2-shell .type-tag {
+  display: inline-flex; align-items: center;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.v2-shell .type-tag.csv  { color: var(--type-csv);  background: var(--type-csv-bg); }
+.v2-shell .type-tag.pdf  { color: var(--type-pdf);  background: var(--type-pdf-bg); }
+.v2-shell .type-tag.text { color: var(--type-text); background: var(--type-text-bg); }
+.v2-shell .type-tag.web  { color: var(--type-web);  background: var(--type-web-bg); }
+
+/* ── Auth (Login page – no shell) ── */
+.auth-shell {
+  min-height: 100vh;
+  display: flex; align-items: stretch;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: "Inter", "Hiragino Kaku Gothic ProN", "Noto Sans JP", -apple-system, system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+.auth-pane {
+  flex: 1;
+  display: flex; align-items: center; justify-content: center;
+  padding: 40px;
+}
+.auth-card {
+  width: 100%; max-width: 380px;
+  background: var(--surface);
+  border: 1px solid var(--hair);
+  border-radius: 10px;
+  padding: 32px 32px 28px;
+  box-shadow: var(--shadow-card);
+}
+.auth-brand {
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 24px;
+}
+.auth-brand .brand-mark {
+  width: 36px; height: 36px; font-size: 16px; border-radius: 9px;
+  background: var(--primary);
+  display: flex; align-items: center; justify-content: center;
+  position: relative;
+  color: var(--primary-fg);
+  font-family: "JetBrains Mono", monospace;
+  font-weight: 700;
+}
+.auth-brand .brand-mark::after {
+  content: ''; position: absolute;
+  left: 8px; right: 8px; bottom: 8px; height: 2px;
+  background: rgba(255,255,255,.55);
+  border-radius: 1px;
+}
+[data-theme="dark"] .auth-brand .brand-mark::after { background: rgba(20,23,28,.55); }
+.auth-brand .stack { display: flex; flex-direction: column; gap: 2px; line-height: 1.2; }
+.auth-brand .stack .name {
+  font-size: 16px; font-weight: 700; color: var(--ink-strong);
+  letter-spacing: -0.01em;
+}
+.auth-brand .stack .name .dim { color: var(--ink-muted); font-weight: 400; }
+.auth-brand .stack .role {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--primary);
+}
+.auth-side {
+  display: none;
+  background: var(--side-bg);
+  border-left: 1px solid var(--hair-strong);
+  padding: 40px;
+  flex: 1;
+}
+@media (min-width: 880px) {
+  .auth-side { display: flex; flex-direction: column; justify-content: space-between; }
+  .auth-pane { flex: 0 0 460px; }
+}
+
+/* ── Form fields ── */
+.v2-shell .field { display: block; margin-bottom: 14px; }
+.v2-shell .field-label {
+  display: flex; align-items: baseline; gap: 8px;
+  font-size: 13px; font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+.v2-shell .field-label .en {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px; font-weight: 500;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+.v2-shell .field-input,
+.v2-shell .field-select,
+.v2-shell .field-textarea {
+  width: 100%; padding: 7px 10px;
+  height: 32px;
+  box-sizing: border-box;
+  border-radius: 5px;
+  border: 1px solid var(--hair-strong);
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 13.5px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+  font-family: inherit;
+}
+.v2-shell .field-input:focus,
+.v2-shell .field-select:focus,
+.v2-shell .field-textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-tint);
+}
+.v2-shell .field-textarea { height: auto; min-height: 80px; padding: 8px 10px; line-height: 1.5; font-family: "JetBrains Mono", monospace; font-size: 12.5px; resize: vertical; }
+.v2-shell .field-hint { font-size: 11.5px; color: var(--ink-faint); margin-top: 4px; line-height: 1.5; }
+
+/* ── Codeblock ── */
+.v2-shell .codeblock {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  background: var(--bg-soft);
+  border: 1px solid var(--hair);
+  border-radius: 5px;
+  padding: 10px 12px;
+  color: var(--ink-soft);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+  position: relative;
+}
+
+/* ── Dropzone ── */
+.v2-shell .dropzone {
+  border: 1.5px dashed var(--hair-strong);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
+  background: var(--surface);
+  color: var(--ink-muted);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.v2-shell .dropzone:hover { background: var(--bg-soft); border-color: var(--primary-border); }
+
+/* ── Chat stream ── */
+.v2-shell .chat-stream {
+  display: flex; flex-direction: column;
+  gap: 10px;
+  padding: 16px 18px;
+  max-height: 540px;
+  overflow-y: auto;
+}
+.v2-shell .chat-msg {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 10px;
+  align-items: flex-start;
+}
+.v2-shell .chat-msg.user { grid-template-columns: 1fr 24px; }
+.v2-shell .chat-bubble {
+  background: var(--bg-soft);
+  border: 1px solid var(--hair);
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 13px; line-height: 1.55;
+  color: var(--ink);
+  max-width: 95%;
+}
+
+/* ── Meta grid ── */
+.v2-shell .meta-grid {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 8px 14px;
+  font-size: 13px;
+}
+.v2-shell .meta-grid .k {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-muted);
+  letter-spacing: 0.06em; text-transform: uppercase;
+  align-self: center;
+}
+.v2-shell .meta-grid .v { color: var(--ink); }
+
+/* ── Settings cards ── */
+.v2-shell .settings-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.v2-shell .set-card {
+  background: var(--surface);
+  border: 1px solid var(--hair);
+  border-radius: 8px;
+  padding: 16px 18px;
+  display: flex; gap: 14px; align-items: flex-start;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.v2-shell .set-card:hover {
+  border-color: var(--primary-border);
+  background: var(--surface-hover);
+}

--- a/frontend/apps/admin/src/v2/Layout.tsx
+++ b/frontend/apps/admin/src/v2/Layout.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import type { ActivePage } from './Sidebar';
+import { Topbar } from './Topbar';
+import { Sidebar } from './Sidebar';
+import { Statusbar } from './Statusbar';
+import { useAdminTheme } from '../ThemeProvider';
+
+export type { ActivePage };
+
+export interface LayoutProps {
+  active: ActivePage;
+  crumb: string;
+  corpusStatus?: string;
+  modelStatus?: 'ok' | 'warn' | 'bad';
+  stats?: string;
+  children: ReactNode;
+}
+
+export function Layout({
+  active,
+  crumb,
+  corpusStatus,
+  modelStatus,
+  stats,
+  children,
+}: LayoutProps) {
+  const { theme, toggleTheme } = useAdminTheme();
+
+  return (
+    <div className="v2-shell">
+      <Topbar crumb={crumb} theme={theme} onToggleTheme={toggleTheme} />
+      <div className="shell">
+        <Sidebar active={active} corpusStatus={corpusStatus} modelStatus={modelStatus} />
+        <main className="main">
+          <div className="main-inner">
+            {children}
+          </div>
+        </main>
+        <Statusbar corpusStatus={corpusStatus} modelStatus={modelStatus} stats={stats} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/v2/Sidebar.tsx
+++ b/frontend/apps/admin/src/v2/Sidebar.tsx
@@ -1,0 +1,203 @@
+export type ActivePage =
+  | 'dashboard'
+  | 'sources'
+  | 'conversations'
+  | 'analytics'
+  | 'llm'
+  | 'embeddings'
+  | 'appearance'
+  | 'settings';
+
+interface SidebarProps {
+  active: ActivePage;
+  corpusStatus?: string;
+  modelStatus?: 'ok' | 'warn' | 'bad';
+}
+
+interface NavItemDef {
+  id: ActivePage | 'logout';
+  ja: string;
+  hash: string;
+  icon: React.ReactNode;
+  badge?: string;
+  dot?: 'ok' | 'warn' | 'bad';
+}
+
+interface CorpusItem {
+  ja: string;
+  meta: string;
+  status: 'ok' | 'bg';
+  glyph: '▾' | '▸';
+}
+
+const CORPUS_TREE: CorpusItem[] = [
+  { ja: '商品カタログ 2026 春',    meta: 'csv · 32 chunks',   status: 'ok', glyph: '▾' },
+  { ja: 'FAQ and serving guide', meta: 'pdf · 12 chunks',   status: 'ok', glyph: '▾' },
+  { ja: 'Seasonal campaign note', meta: '取り込み中…',         status: 'bg', glyph: '▸' },
+];
+
+export function Sidebar({ active, corpusStatus = '3 / 4 取り込み済み', modelStatus = 'bad' }: SidebarProps) {
+  const countStr = corpusStatus.split(' ')[0] ?? '';
+
+  const navOperation: NavItemDef[] = [
+    { id: 'dashboard',     ja: 'ダッシュボード', hash: '#/dashboard',     icon: <DashboardIcon /> },
+    { id: 'sources',       ja: 'ソース',         hash: '#/sources',       icon: <SourcesIcon />, badge: '3' },
+    { id: 'conversations', ja: '会話ログ',       hash: '#/conversations', icon: <ConversationsIcon />, badge: '86' },
+    { id: 'analytics',     ja: '分析',           hash: '#/analytics',     icon: <AnalyticsIcon /> },
+  ];
+
+  const navModel: NavItemDef[] = [
+    { id: 'llm',        ja: 'LLM',    hash: '#/settings',     icon: <LlmIcon />,        dot: modelStatus },
+    { id: 'embeddings', ja: '埋め込み', hash: '#/settings',   icon: <EmbeddingsIcon /> },
+    { id: 'appearance', ja: '外観',   hash: '#/settings',     icon: <AppearanceIcon /> },
+  ];
+
+  const navSystem: NavItemDef[] = [
+    { id: 'settings', ja: '設定',      hash: '#/settings', icon: <SettingsIcon /> },
+    { id: 'logout',   ja: 'ログアウト', hash: '#/login',    icon: <LogoutIcon /> },
+  ];
+
+  function handleNav(hash: string): void {
+    window.location.hash = hash.replace('#/', '#/');
+  }
+
+  function renderItem(item: NavItemDef) {
+    const isActive = item.id === active;
+    return (
+      <button
+        key={item.id}
+        type="button"
+        className={isActive ? 'nav-item active' : 'nav-item'}
+        onClick={() => handleNav(item.hash)}
+        aria-current={isActive ? 'page' : undefined}
+      >
+        <span className="icon">{item.icon}</span>
+        <span className="ja">{item.ja}</span>
+        {item.badge && <span className="badge">{item.badge}</span>}
+        {item.dot && <span className={`status-dot ${item.dot}`} />}
+      </button>
+    );
+  }
+
+  return (
+    <aside className="side">
+      <div className="side-section">
+        運用 <span className="count">workspace</span>
+      </div>
+      {navOperation.map(renderItem)}
+
+      <div className="side-section">
+        モデル <span className="count">model</span>
+      </div>
+      {navModel.map(renderItem)}
+
+      <div className="side-section">
+        コーパス <span className="count">{countStr}</span>
+      </div>
+      {CORPUS_TREE.map((item, i) => (
+        <div key={i} className="tree-item">
+          <span className="glyph">{item.glyph}</span>
+          <span className="lbl">
+            <div className="ja">{item.ja}</div>
+            <div className="meta">{item.meta}</div>
+          </span>
+          <span className={`dot ${item.status}`} />
+        </div>
+      ))}
+
+      <div className="side-section">システム</div>
+      {navSystem.map(renderItem)}
+    </aside>
+  );
+}
+
+/* ── Inline SVG icons ── */
+function DashboardIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="7" height="9" /><rect x="14" y="3" width="7" height="5" />
+      <rect x="14" y="12" width="7" height="9" /><rect x="3" y="16" width="7" height="5" />
+    </svg>
+  );
+}
+
+function SourcesIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <ellipse cx="12" cy="5" rx="9" ry="3" />
+      <path d="M3 5v6a9 3 0 0 0 18 0V5" />
+      <path d="M3 11v6a9 3 0 0 0 18 0v-6" />
+    </svg>
+  );
+}
+
+function ConversationsIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}
+
+function AnalyticsIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="12" y1="20" x2="12" y2="10" />
+      <line x1="18" y1="20" x2="18" y2="4" />
+      <line x1="6" y1="20" x2="6" y2="14" />
+    </svg>
+  );
+}
+
+function LlmIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="4" y="4" width="16" height="16" rx="2" /><rect x="9" y="9" width="6" height="6" />
+      <line x1="9" y1="2" x2="9" y2="4" /><line x1="15" y1="2" x2="15" y2="4" />
+      <line x1="9" y1="20" x2="9" y2="22" /><line x1="15" y1="20" x2="15" y2="22" />
+      <line x1="20" y1="9" x2="22" y2="9" /><line x1="20" y1="15" x2="22" y2="15" />
+      <line x1="2" y1="9" x2="4" y2="9" /><line x1="2" y1="15" x2="4" y2="15" />
+    </svg>
+  );
+}
+
+function EmbeddingsIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="6" cy="6" r="2" /><circle cx="18" cy="6" r="2" />
+      <circle cx="6" cy="18" r="2" /><circle cx="18" cy="18" r="2" />
+      <circle cx="12" cy="12" r="2" />
+      <path d="M8 6h8M8 18h8M6 8v8M18 8v8" />
+    </svg>
+  );
+}
+
+function AppearanceIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="8" cy="9" r="1.2" fill="currentColor" />
+      <circle cx="15" cy="8" r="1.2" fill="currentColor" />
+      <circle cx="16.5" cy="13" r="1.2" fill="currentColor" />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
+
+function LogoutIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  );
+}

--- a/frontend/apps/admin/src/v2/Statusbar.tsx
+++ b/frontend/apps/admin/src/v2/Statusbar.tsx
@@ -1,0 +1,41 @@
+interface StatusbarProps {
+  corpusStatus?: string;
+  modelStatus?: 'ok' | 'warn' | 'bad';
+  stats?: string;
+}
+
+export function Statusbar({
+  corpusStatus = '3 / 4 取り込み済み',
+  modelStatus = 'bad',
+  stats = '86 セッション · 428 通 · 引用 91.8%',
+}: StatusbarProps) {
+  const modelInfo = {
+    ok:   { cls: 'val ok',     dot: 'ok',  text: '稼働中' },
+    warn: { cls: 'val danger', dot: 'bad', text: '要確認' },
+    bad:  { cls: 'val danger', dot: 'bad', text: '未設定' },
+  }[modelStatus];
+
+  return (
+    <div className="statusbar">
+      <span className="chunk env">本番 PROD</span>
+      <span className="chunk">
+        <span className="dot ok" />
+        <span className="lbl">corpus:</span>
+        <span className="val ok">{corpusStatus}</span>
+      </span>
+      <span className="chunk">
+        <span className={`dot ${modelInfo.dot}`} />
+        <span className="lbl">model:</span>
+        <span className={modelInfo.cls}>{modelInfo.text}</span>
+      </span>
+      <span className="chunk">
+        <span className="lbl">7d:</span>
+        <span className="val">{stats}</span>
+      </span>
+      <span className="chunk right">
+        <span className="lbl">最終取得:</span>
+        <span className="val">2026-05-28 14:38:12 JST</span>
+      </span>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/v2/Topbar.tsx
+++ b/frontend/apps/admin/src/v2/Topbar.tsx
@@ -1,0 +1,106 @@
+import type { V2Theme } from './theme';
+
+interface TopbarProps {
+  crumb: string;
+  theme: V2Theme;
+  onToggleTheme: () => void;
+  userEmail?: string;
+}
+
+export function Topbar({ crumb, theme, onToggleTheme, userEmail = 'admin@example.com' }: TopbarProps) {
+  const initials = userEmail.charAt(0).toLowerCase();
+
+  return (
+    <header className="topbar">
+      <div className="brand">
+        <div className="brand-mark">n</div>
+        <div className="brand-name">
+          NeNe <span className="dim">Corpus</span>
+          <span className="admin">Admin</span>
+        </div>
+      </div>
+      <div className="topbar-mid">
+        <span>AYANE</span>
+        <span className="sep">/</span>
+        <span className="crumb">本番</span>
+        <span className="sep">/</span>
+        <span className="leaf">{crumb}</span>
+      </div>
+      <div className="topbar-right">
+        {/* 検索 pill — 仮実装、クリック不能 */}
+        <div className="kbd-search" aria-label="検索（未実装）" role="button">
+          <SearchIcon />
+          <span>検索...</span>
+          <span className="kbd">⌘K</span>
+        </div>
+
+        {/* テーマトグル */}
+        <div className="theme-toggle" role="group" aria-label="テーマ切替">
+          <button
+            type="button"
+            className={theme === 'light' ? 'on' : ''}
+            aria-label="ライトモード"
+            onClick={() => theme !== 'light' && onToggleTheme()}
+          >
+            <SunIcon />
+          </button>
+          <button
+            type="button"
+            className={theme === 'dark' ? 'on' : ''}
+            aria-label="ダークモード"
+            onClick={() => theme !== 'dark' && onToggleTheme()}
+          >
+            <MoonIcon />
+          </button>
+        </div>
+
+        {/* 通知ベル */}
+        <button type="button" className="icon-btn" aria-label="お知らせ">
+          <BellIcon />
+        </button>
+
+        {/* ユーザー */}
+        <div className="who">
+          <div className="avatar">{initials}</div>
+          <span>{userEmail}</span>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+/* ── Inline SVG icons ── */
+function SearchIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+function SunIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </svg>
+  );
+}

--- a/frontend/apps/admin/src/v2/pages/ConversationsPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/ConversationsPage.tsx
@@ -1,0 +1,54 @@
+/**
+ * ConversationsPage — v2 placeholder
+ * 実装は #263 で行う。
+ */
+import { Layout } from '../Layout';
+
+export function ConversationsPage() {
+  return (
+    <Layout
+      active="conversations"
+      crumb="会話ログ"
+      corpusStatus="3 / 4 取り込み済み"
+      modelStatus="bad"
+      stats="86 セッション · 428 通 · 引用 91.8%"
+    >
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">// conversations</div>
+          <h1>会話ログ</h1>
+        </div>
+      </div>
+      <PlaceholderNotice name="ConversationsPage" issue={263} />
+    </Layout>
+  );
+}
+
+function PlaceholderNotice({ name, issue }: { name: string; issue: number }) {
+  return (
+    <div style={{
+      background: 'var(--primary-soft)',
+      border: '1px dashed var(--primary-border)',
+      borderRadius: 8,
+      padding: '24px 28px',
+    }}>
+      <div style={{
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: 10.5,
+        fontWeight: 600,
+        letterSpacing: '0.16em',
+        textTransform: 'uppercase',
+        color: 'var(--primary)',
+        marginBottom: 8,
+      }}>
+        // placeholder
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--ink-strong)', marginBottom: 4 }}>
+        {name}
+      </div>
+      <div style={{ fontSize: 13, color: 'var(--ink-muted)' }}>
+        {name} placeholder — implementing in #{issue}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/v2/pages/DashboardPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/DashboardPage.tsx
@@ -1,0 +1,59 @@
+/**
+ * DashboardPage — v2 placeholder
+ * 実装は #261 で行う。
+ */
+import { Layout } from '../Layout';
+
+interface DashboardPageProps {
+  token?: string;
+  onLogout?: () => void;
+}
+
+export function DashboardPage({ token: _token, onLogout: _onLogout }: DashboardPageProps) {
+  return (
+    <Layout
+      active="dashboard"
+      crumb="ダッシュボード"
+      corpusStatus="3 / 4 取り込み済み"
+      modelStatus="bad"
+      stats="86 セッション · 428 通 · 引用 91.8%"
+    >
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">// dashboard</div>
+          <h1>ダッシュボード</h1>
+        </div>
+      </div>
+      <PlaceholderNotice name="DashboardPage" issue={261} />
+    </Layout>
+  );
+}
+
+function PlaceholderNotice({ name, issue }: { name: string; issue: number }) {
+  return (
+    <div style={{
+      background: 'var(--primary-soft)',
+      border: '1px dashed var(--primary-border)',
+      borderRadius: 8,
+      padding: '24px 28px',
+    }}>
+      <div style={{
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: 10.5,
+        fontWeight: 600,
+        letterSpacing: '0.16em',
+        textTransform: 'uppercase',
+        color: 'var(--primary)',
+        marginBottom: 8,
+      }}>
+        // placeholder
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--ink-strong)', marginBottom: 4 }}>
+        {name}
+      </div>
+      <div style={{ fontSize: 13, color: 'var(--ink-muted)' }}>
+        {name} placeholder — implementing in #{issue}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/v2/pages/LoginPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/LoginPage.tsx
@@ -1,0 +1,54 @@
+/**
+ * LoginPage — v2 placeholder
+ * シェル無し・中央カード。実装は #260 で行う。
+ */
+
+interface LoginPageProps {
+  onLogin?: (email: string, password: string) => Promise<void>;
+}
+
+export function LoginPage({ onLogin: _onLogin }: LoginPageProps) {
+  return (
+    <div className="auth-shell">
+      <div className="auth-pane">
+        <div className="auth-card">
+          <div className="auth-brand">
+            <div className="brand-mark">n</div>
+            <div className="stack">
+              <div className="name">
+                NeNe <span className="dim">Corpus</span>
+              </div>
+              <div className="role">Admin</div>
+            </div>
+          </div>
+          <div className="page-head" style={{ borderBottom: 'none', paddingBottom: 0, marginBottom: 12 }}>
+            <div>
+              <div className="eyebrow">// login</div>
+              <h1 style={{ fontSize: 20 }}>ログイン</h1>
+            </div>
+          </div>
+          <p style={{ fontSize: 13, color: 'var(--ink-muted)', marginBottom: 16 }}>
+            LoginPage placeholder — implementing in #260
+          </p>
+          <div style={{
+            background: 'var(--primary-soft)',
+            border: '1px solid var(--primary-border)',
+            borderRadius: 6,
+            padding: '8px 12px',
+            fontFamily: '"JetBrains Mono", monospace',
+            fontSize: 11,
+            color: 'var(--primary)',
+          }}>
+            Issue #260 で実装予定
+          </div>
+        </div>
+      </div>
+      <div className="auth-side">
+        <div>
+          <h2>NeNe Corpus</h2>
+          <p>引用付き sync JSON chat — 自社ナレッジをコーパスに変える OSS</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/v2/pages/SettingsPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/SettingsPage.tsx
@@ -1,0 +1,59 @@
+/**
+ * SettingsPage — v2 placeholder
+ * 実装は #264 で行う。
+ */
+import { Layout } from '../Layout';
+
+interface SettingsPageProps {
+  token?: string;
+  onLogout?: () => void;
+}
+
+export function SettingsPage({ token: _token, onLogout: _onLogout }: SettingsPageProps) {
+  return (
+    <Layout
+      active="settings"
+      crumb="設定"
+      corpusStatus="3 / 4 取り込み済み"
+      modelStatus="bad"
+      stats="86 セッション · 428 通 · 引用 91.8%"
+    >
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">// settings</div>
+          <h1>設定</h1>
+        </div>
+      </div>
+      <PlaceholderNotice name="SettingsPage" issue={264} />
+    </Layout>
+  );
+}
+
+function PlaceholderNotice({ name, issue }: { name: string; issue: number }) {
+  return (
+    <div style={{
+      background: 'var(--primary-soft)',
+      border: '1px dashed var(--primary-border)',
+      borderRadius: 8,
+      padding: '24px 28px',
+    }}>
+      <div style={{
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: 10.5,
+        fontWeight: 600,
+        letterSpacing: '0.16em',
+        textTransform: 'uppercase',
+        color: 'var(--primary)',
+        marginBottom: 8,
+      }}>
+        // placeholder
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--ink-strong)', marginBottom: 4 }}>
+        {name}
+      </div>
+      <div style={{ fontSize: 13, color: 'var(--ink-muted)' }}>
+        {name} placeholder — implementing in #{issue}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/v2/pages/SourcesPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/SourcesPage.tsx
@@ -1,0 +1,54 @@
+/**
+ * SourcesPage — v2 placeholder
+ * 実装は #262 で行う。
+ */
+import { Layout } from '../Layout';
+
+export function SourcesPage() {
+  return (
+    <Layout
+      active="sources"
+      crumb="ソース"
+      corpusStatus="3 / 4 取り込み済み"
+      modelStatus="bad"
+      stats="86 セッション · 428 通 · 引用 91.8%"
+    >
+      <div className="page-head">
+        <div>
+          <div className="eyebrow">// sources</div>
+          <h1>ソース</h1>
+        </div>
+      </div>
+      <PlaceholderNotice name="SourcesPage" issue={262} />
+    </Layout>
+  );
+}
+
+function PlaceholderNotice({ name, issue }: { name: string; issue: number }) {
+  return (
+    <div style={{
+      background: 'var(--primary-soft)',
+      border: '1px dashed var(--primary-border)',
+      borderRadius: 8,
+      padding: '24px 28px',
+    }}>
+      <div style={{
+        fontFamily: '"JetBrains Mono", monospace',
+        fontSize: 10.5,
+        fontWeight: 600,
+        letterSpacing: '0.16em',
+        textTransform: 'uppercase',
+        color: 'var(--primary)',
+        marginBottom: 8,
+      }}>
+        // placeholder
+      </div>
+      <div style={{ fontSize: 16, fontWeight: 700, color: 'var(--ink-strong)', marginBottom: 4 }}>
+        {name}
+      </div>
+      <div style={{ fontSize: 13, color: 'var(--ink-muted)' }}>
+        {name} placeholder — implementing in #{issue}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/admin/src/v2/theme.ts
+++ b/frontend/apps/admin/src/v2/theme.ts
@@ -1,0 +1,52 @@
+/**
+ * v2 テーマユーティリティ
+ * - <html data-theme="dark"> 属性を操作する
+ * - 既存の ThemeProvider / theme.ts と共存する
+ *   (既存コードは .dark クラスも付与するので両方が機能する)
+ */
+
+export const V2_THEME_STORAGE_KEY = 'corpus-admin-theme';
+
+export type V2Theme = 'light' | 'dark';
+
+/**
+ * localStorage から保存済みテーマを読み込む。
+ * 存在しない場合は prefers-color-scheme で推定する。
+ */
+export function resolveV2Theme(): V2Theme {
+  try {
+    const stored = localStorage.getItem(V2_THEME_STORAGE_KEY);
+    if (stored === 'dark' || stored === 'light') return stored;
+  } catch {
+    // ignore
+  }
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+/**
+ * <html data-theme="dark|light"> を設定する。
+ * 既存 theme.ts の applyAdminTheme は .dark クラスも設定するので
+ * ここでは data-theme 属性のみを担う。
+ */
+export function applyV2Theme(theme: V2Theme): void {
+  if (theme === 'dark') {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  } else {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+}
+
+/** テーマを保存して適用する */
+export function setV2Theme(theme: V2Theme): void {
+  applyV2Theme(theme);
+  try {
+    localStorage.setItem(V2_THEME_STORAGE_KEY, theme);
+  } catch {
+    // ignore
+  }
+}
+
+/** 現在のテーマをトグルして返す */
+export function toggleV2Theme(current: V2Theme): V2Theme {
+  return current === 'light' ? 'dark' : 'light';
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/noto-sans-jp": "^5.2.9",
         "@fontsource/noto-sans-sc": "^5.2.9",
         "@nene-corpus/api-client": "*",
@@ -782,6 +783,15 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
       "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"


### PR DESCRIPTION
Closes #259

## 内容
- 新 design tokens を `src/v2.css` に追加（light + dark）、`index.css` から `@import` で取り込み（既存 Tailwind トークンと共存）
- `src/v2/` 配下に Layout / Topbar / Sidebar / Statusbar を新設（既存パネル群は手つかず）
- hash ルーター（`#/dashboard`, `#/sources`, `#/conversations`, `#/settings`, `#/login`）を `App.tsx` に実装
- 5 画面の placeholder ページ（`LoginPage`, `DashboardPage`, `SourcesPage`, `ConversationsPage`, `SettingsPage`）
- `ThemeProvider`（既存）を介してテーマ切替を v2 Layout に統合、`<html data-theme="dark">` で v2 dark トークンが有効化される
- `@fontsource/jetbrains-mono` を `package.json` と `fonts.ts` に追加

## チェックリスト
- docs/review/docs-policy.md

## 備考
- 旧パネル群（`SourcesPanel.tsx`, `IngestionPanel.tsx` 等）は削除していない。後続 #260-264 の page エージェントが参照する
- E2E テストの修正は後続 Issue で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)