### PR TITLE
feat(admin-ui): v2 リデザイン Login ページを実装する (#260)

### DIFF
--- a/frontend/apps/admin/src/v2.css
+++ b/frontend/apps/admin/src/v2.css
@@ -780,3 +780,216 @@
   border-color: var(--primary-border);
   background: var(--surface-hover);
 }
+
+/* ════════════════════════════════════════════════════════════════════
+   Auth — Login page extras (#260)
+   These classes live outside .v2-shell (login has no shell wrapper).
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Floating theme toggle (top-right, login page) */
+.auth-toptoggle {
+  position: fixed; top: 14px; right: 18px;
+  z-index: 10;
+}
+.auth-theme-toggle {
+  display: inline-flex;
+  background: var(--surface);
+  border: 1px solid var(--hair-strong);
+  border-radius: 6px;
+  padding: 2px;
+  box-shadow: var(--shadow-card);
+}
+.auth-theme-toggle button {
+  width: 26px; height: 22px;
+  border-radius: 4px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ink-faint);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+.auth-theme-toggle button.on {
+  background: var(--primary-soft);
+  color: var(--primary);
+  box-shadow: 0 1px 2px rgba(15,23,42,.06);
+}
+
+/* Login card heading + sub */
+.auth-heading {
+  font-size: 19px; font-weight: 700;
+  color: var(--ink-strong);
+  margin-bottom: 4px;
+  line-height: 1.3;
+}
+.auth-heading .en {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px; font-weight: 500;
+  color: var(--ink-faint);
+  letter-spacing: 0.06em;
+  display: block;
+  margin-top: 2px;
+  text-transform: none;
+}
+.auth-subheading {
+  font-size: 13px;
+  color: var(--ink-muted);
+  margin-bottom: 22px;
+}
+
+/* Error alert */
+.auth-error {
+  background: var(--danger-soft);
+  border: 1px solid var(--danger-border);
+  border-left: 3px solid var(--danger);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--danger-text);
+  margin-bottom: 16px;
+}
+
+/* Form field (auth context – outside .v2-shell) */
+.signin-field { margin-bottom: 14px; }
+.auth-field-label {
+  display: flex; align-items: baseline; gap: 8px;
+  font-size: 13px; font-weight: 600;
+  color: var(--ink);
+  margin-bottom: 6px;
+}
+.auth-field-label .en {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px; font-weight: 500;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+}
+.auth-field-input {
+  width: 100%; padding: 7px 10px;
+  height: 36px;
+  box-sizing: border-box;
+  border-radius: 5px;
+  border: 1px solid var(--hair-strong);
+  background: var(--surface);
+  color: var(--ink);
+  font-size: 13.5px;
+  font-family: inherit;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.auth-field-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-tint);
+}
+.auth-field-input:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* Forgot password inline link */
+.auth-forgot-link {
+  font-size: 11px;
+  color: var(--primary);
+  font-weight: 600;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+.auth-forgot-link:hover { text-decoration: underline; }
+
+/* Remember checkbox row */
+.auth-remember {
+  display: flex; align-items: center; gap: 8px;
+  margin: 4px 0 16px;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+.auth-remember input[type="checkbox"] { margin: 0; cursor: pointer; }
+.auth-remember label { cursor: pointer; }
+
+/* Primary button (auth context) */
+.auth-btn-primary {
+  display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  width: 100%;
+  height: 38px;
+  font-size: 14px; font-weight: 600;
+  background: var(--primary); color: var(--primary-fg);
+  border: 1px solid var(--primary);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+  font-family: inherit;
+}
+.auth-btn-primary:hover:not(:disabled) {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+}
+.auth-btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* Spinner keyframe */
+@keyframes auth-spin { to { transform: rotate(360deg); } }
+
+/* Side panel extras */
+.auth-side h2 {
+  font-size: 18px; font-weight: 700;
+  color: var(--ink-strong);
+  margin-bottom: 8px;
+}
+.auth-side p {
+  font-size: 13px;
+  color: var(--ink-muted);
+  line-height: 1.6;
+}
+.auth-side-head {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--primary);
+  padding: 4px 8px;
+  background: var(--primary-soft);
+  border: 1px solid var(--primary-border);
+  border-radius: 3px;
+  display: inline-block;
+  margin-bottom: 14px;
+}
+.auth-feature-list {
+  display: flex; flex-direction: column;
+  gap: 14px;
+  margin-top: 18px;
+  margin-bottom: 24px;
+}
+.auth-feature {
+  display: flex; gap: 12px; align-items: flex-start;
+}
+.auth-feature-ic {
+  width: 28px; height: 28px; flex-shrink: 0;
+  border-radius: 6px;
+  background: var(--surface);
+  border: 1px solid var(--hair-strong);
+  color: var(--primary);
+  display: flex; align-items: center; justify-content: center;
+}
+.auth-feature-txt .t {
+  font-size: 13.5px; font-weight: 600;
+  color: var(--ink-strong);
+  margin-bottom: 1px;
+}
+.auth-feature-txt .d {
+  font-size: 12px;
+  color: var(--ink-muted);
+  line-height: 1.55;
+}
+.auth-inline-code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11px;
+  background: var(--bg-soft);
+  padding: 0 4px;
+  border-radius: 3px;
+}
+.auth-side-footer {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  color: var(--ink-faint);
+  letter-spacing: 0.04em;
+  border-top: 1px solid var(--hair);
+  padding-top: 14px;
+}

--- a/frontend/apps/admin/src/v2/pages/LoginPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/LoginPage.tsx
@@ -1,54 +1,331 @@
 /**
- * LoginPage — v2 placeholder
- * シェル無し・中央カード。実装は #260 で行う。
+ * LoginPage — v2 リデザイン実装 (#260)
+ * auth-shell の 2 カラム構成。シェル（Topbar/Sidebar）は使わない。
  */
+import { type FormEvent, useEffect, useState } from 'react';
+import { useAdminAuth } from '../../useAdminAuth';
+import { PasswordResetRequestForm, PasswordResetConfirmForm } from '../../PasswordResetForms';
+import { useAdminTheme } from '../../ThemeProvider';
+
+type LoginView = 'login' | 'reset-request' | 'reset-confirm';
+
+function resolveInitialView(): LoginView {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('reset_token')) return 'reset-confirm';
+  } catch {
+    // ignore
+  }
+  return 'login';
+}
+
+// ── アイコン SVG ─────────────────────────────────────────────────────────────
+
+function SunIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="4"/>
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="14" height="14" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"
+      style={{ animation: 'auth-spin 0.7s linear infinite', flexShrink: 0 }}
+    >
+      <circle cx="12" cy="12" r="10" strokeOpacity="0.25"/>
+      <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor"/>
+    </svg>
+  );
+}
+
+// ── テーマトグル（フローティング） ────────────────────────────────────────────
+
+function AuthThemeToggle() {
+  const { theme, toggleTheme } = useAdminTheme();
+
+  return (
+    <div className="auth-toptoggle">
+      <div className="auth-theme-toggle">
+        <button
+          className={theme === 'light' ? 'on' : ''}
+          onClick={toggleTheme}
+          aria-label="ライトモード"
+          type="button"
+        >
+          <SunIcon />
+        </button>
+        <button
+          className={theme === 'dark' ? 'on' : ''}
+          onClick={toggleTheme}
+          aria-label="ダークモード"
+          type="button"
+        >
+          <MoonIcon />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── ログインフォーム ───────────────────────────────────────────────────────────
+
+interface LoginFormProps {
+  onForgotPassword: () => void;
+}
+
+function LoginForm({ onForgotPassword }: LoginFormProps) {
+  const { login, error } = useAdminAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await login(email, password);
+      window.location.hash = '#/dashboard';
+    } catch {
+      // エラーは useAdminAuth の error state に入る
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="auth-brand">
+        <div className="brand-mark">n</div>
+        <div className="stack">
+          <span className="name">
+            NeNe <span className="dim">Corpus</span>
+          </span>
+          <span className="role">Admin</span>
+        </div>
+      </div>
+
+      <h1 className="auth-heading">
+        管理画面にログイン <span className="en">// welcome back</span>
+      </h1>
+      <p className="auth-subheading">
+        運営者のアカウントでサインインしてください。
+      </p>
+
+      {error !== null && (
+        <div className="auth-error" role="alert">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={(e) => void handleSubmit(e)}>
+        <div className="signin-field">
+          <label className="auth-field-label" htmlFor="auth-email">
+            メールアドレス <span className="en">// email</span>
+          </label>
+          <input
+            id="auth-email"
+            className="auth-field-input"
+            type="email"
+            autoFocus
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div className="signin-field">
+          <label className="auth-field-label" htmlFor="auth-password" style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+            <span>
+              パスワード <span className="en">// password</span>
+            </span>
+            <button
+              type="button"
+              className="auth-forgot-link"
+              onClick={onForgotPassword}
+            >
+              忘れた場合 →
+            </button>
+          </label>
+          <input
+            id="auth-password"
+            className="auth-field-input"
+            type="password"
+            autoComplete="current-password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={isSubmitting}
+          />
+        </div>
+
+        <div className="auth-remember">
+          <input
+            id="auth-remember"
+            type="checkbox"
+            checked={remember}
+            onChange={(e) => setRemember(e.target.checked)}
+          />
+          <label htmlFor="auth-remember">このブラウザを記憶する</label>
+        </div>
+
+        <button
+          className="auth-btn-primary"
+          type="submit"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? (
+            <>
+              <SpinnerIcon />
+              サインイン中...
+            </>
+          ) : (
+            'サインイン'
+          )}
+        </button>
+      </form>
+    </>
+  );
+}
+
+// ── サイドパネル ──────────────────────────────────────────────────────────────
+
+function AuthSide() {
+  return (
+    <aside className="auth-side">
+      <div>
+        <div className="auth-side-head">NeNe Corpus · v0.4</div>
+        <h2>商品情報を、信頼できる回答に。</h2>
+        <p>
+          PDF・CSV・テキストをアップロードして、出典付きのチャット回答を自社サイトに埋め込めます。
+          共有ホスティング（Tier A / PHP）でも VPS（Tier B）でも動く同一コードベースの OSS。
+        </p>
+
+        <div className="auth-feature-list">
+          <div className="auth-feature">
+            <div className="auth-feature-ic">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <ellipse cx="12" cy="5" rx="9" ry="3"/>
+                <path d="M3 5v6a9 3 0 0 0 18 0V5"/>
+                <path d="M3 11v6a9 3 0 0 0 18 0v-6"/>
+              </svg>
+            </div>
+            <div className="auth-feature-txt">
+              <div className="t">資料を入れるだけ</div>
+              <div className="d">
+                商品カタログ PDF や FAQ CSV をアップロード。チャンク化と埋め込みは自動。
+              </div>
+            </div>
+          </div>
+
+          <div className="auth-feature">
+            <div className="auth-feature-ic">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+              </svg>
+            </div>
+            <div className="auth-feature-txt">
+              <div className="t">引用付きで回答</div>
+              <div className="d">
+                Claude が資料から該当箇所を引いて、引用 ID 付きでエンドユーザに回答します。
+              </div>
+            </div>
+          </div>
+
+          <div className="auth-feature">
+            <div className="auth-feature-ic">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <polyline points="16 18 22 12 16 6"/>
+                <polyline points="8 6 2 12 8 18"/>
+              </svg>
+            </div>
+            <div className="auth-feature-txt">
+              <div className="t">スニペット 1 行で埋め込み</div>
+              <div className="d">
+                既存サイトの <code className="auth-inline-code">&lt;/body&gt;</code> に script タグを 1 つ貼るだけ。
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="auth-side-footer">
+        MIT License · open-source · github.com/hideyukiMORI/nene-corpus
+      </div>
+    </aside>
+  );
+}
+
+// ── メインエクスポート ─────────────────────────────────────────────────────────
 
 interface LoginPageProps {
   onLogin?: (email: string, password: string) => Promise<void>;
 }
 
 export function LoginPage({ onLogin: _onLogin }: LoginPageProps) {
+  const [view, setView] = useState<LoginView>(resolveInitialView);
+
+  // URL に reset_token が無くなったら login ビューへ戻す
+  useEffect(() => {
+    function handlePopState() {
+      const params = new URLSearchParams(window.location.search);
+      if (!params.get('reset_token') && view === 'reset-confirm') {
+        setView('login');
+      }
+    }
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [view]);
+
+  function handleBack() {
+    setView('login');
+  }
+
+  const rawToken = (() => {
+    try {
+      return new URLSearchParams(window.location.search).get('reset_token') ?? '';
+    } catch {
+      return '';
+    }
+  })();
+
   return (
-    <div className="auth-shell">
-      <div className="auth-pane">
-        <div className="auth-card">
-          <div className="auth-brand">
-            <div className="brand-mark">n</div>
-            <div className="stack">
-              <div className="name">
-                NeNe <span className="dim">Corpus</span>
-              </div>
-              <div className="role">Admin</div>
-            </div>
-          </div>
-          <div className="page-head" style={{ borderBottom: 'none', paddingBottom: 0, marginBottom: 12 }}>
-            <div>
-              <div className="eyebrow">// login</div>
-              <h1 style={{ fontSize: 20 }}>ログイン</h1>
-            </div>
-          </div>
-          <p style={{ fontSize: 13, color: 'var(--ink-muted)', marginBottom: 16 }}>
-            LoginPage placeholder — implementing in #260
-          </p>
-          <div style={{
-            background: 'var(--primary-soft)',
-            border: '1px solid var(--primary-border)',
-            borderRadius: 6,
-            padding: '8px 12px',
-            fontFamily: '"JetBrains Mono", monospace',
-            fontSize: 11,
-            color: 'var(--primary)',
-          }}>
-            Issue #260 で実装予定
+    <>
+      <AuthThemeToggle />
+      <div className="auth-shell">
+        {/* サインインペイン */}
+        <div className="auth-pane">
+          <div className="auth-card">
+            {view === 'login' && (
+              <LoginForm onForgotPassword={() => setView('reset-request')} />
+            )}
+            {view === 'reset-request' && (
+              <PasswordResetRequestForm onBack={handleBack} />
+            )}
+            {view === 'reset-confirm' && (
+              <PasswordResetConfirmForm rawToken={rawToken} onBack={handleBack} />
+            )}
           </div>
         </div>
+
+        {/* 商品紹介サイドパネル（≥880px のみ表示） */}
+        <AuthSide />
       </div>
-      <div className="auth-side">
-        <div>
-          <h2>NeNe Corpus</h2>
-          <p>引用付き sync JSON chat — 自社ナレッジをコーパスに変える OSS</p>
-        </div>
-      </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #260

## 内容

- `LoginPage.tsx` を auth-shell の 2 カラム構成（左サインインカード + 右商品紹介サイドパネル）へ完全置換
- 既存 `useAdminAuth().login()` を呼び出し、成功時 `#/dashboard` へリダイレクト
- `PasswordResetRequestForm` / `PasswordResetConfirmForm` を統合（state で view 切替）
- URL に `?reset_token=...` が存在する場合は `reset-confirm` ビューを初期表示
- 浮かぶテーマトグル（light/dark）を右上に配置し `useAdminTheme` と接続
- SSO ボタン / サインアップリンクは仕様 9 章により削除
- `v2.css` に auth ページ専用スタイルを追加（`.auth-toptoggle`, `.auth-theme-toggle`, `.auth-heading`, `.auth-field-*`, `.auth-btn-primary`, `.auth-feature-*`, `.auth-side-footer` 等）

## チェックリスト

- [x] docs/review/middleware-security.md（認証フロー: 既存 useAdminAuth を使用、新規ロジックなし）
- [x] `tsc --noEmit` 0 エラー確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)