### PR TITLE
feat(tenancy): multi-tenant 基盤を導入する (#274)

### DIFF
--- a/database/migrations/20260529000000_create_tenancy_tables_and_org_id_columns.php
+++ b/database/migrations/20260529000000_create_tenancy_tables_and_org_id_columns.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * マルチテナント基盤 Phase A — DB スキーマ変更
+ *
+ * 変更内容:
+ *  1. organizations テーブル新設
+ *  2. system_config テーブル新設 + 初期 seed
+ *  3. 全 12 既存テーブルに organization_id カラム追加（DEFAULT 1 = default org）
+ *  4. admin_users に role カラム追加
+ *  5. 既存の最初の admin_user を superadmin に昇格
+ */
+final class CreateTenancyTablesAndOrgIdColumns extends AbstractMigration
+{
+    public function up(): void
+    {
+        // 1. organizations テーブル作成
+        $this->execute(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS organizations (
+                id          INT UNSIGNED  NOT NULL AUTO_INCREMENT,
+                name        VARCHAR(255)  NOT NULL,
+                slug        VARCHAR(100)  NOT NULL,
+                custom_domain VARCHAR(255) NULL DEFAULT NULL,
+                plan        VARCHAR(32)   NOT NULL DEFAULT 'free',
+                is_active   TINYINT(1)    NOT NULL DEFAULT 1,
+                external_id VARCHAR(255)  NULL DEFAULT NULL,
+                created_at  DATETIME      NOT NULL,
+                updated_at  DATETIME      NOT NULL,
+                PRIMARY KEY (id),
+                UNIQUE KEY uq_organizations_slug (slug),
+                UNIQUE KEY uq_organizations_custom_domain (custom_domain),
+                UNIQUE KEY uq_organizations_external_id (external_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL);
+
+        // 2. system_config テーブル作成
+        $this->execute(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS system_config (
+                `key`        VARCHAR(191)  NOT NULL,
+                `value`      VARCHAR(1024) NOT NULL DEFAULT '',
+                `updated_at` DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (`key`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL);
+
+        // 3. Default Organization の seed
+        $now = date('Y-m-d H:i:s');
+        $this->execute(<<<SQL
+            INSERT IGNORE INTO organizations (id, name, slug, plan, is_active, created_at, updated_at)
+            VALUES (1, 'Default Organization', 'default', 'free', 1, '{$now}', '{$now}')
+        SQL);
+
+        // 4. system_config 初期値 seed
+        $this->execute(<<<'SQL'
+            INSERT IGNORE INTO system_config (`key`, `value`) VALUES
+                ('tenant_resolution_mode', 'single'),
+                ('tenant_org_slug',        'default'),
+                ('tenant_base_domain',     'localhost')
+        SQL);
+
+        // 5. 既存テーブルに organization_id カラム追加（べき等: INFORMATION_SCHEMA でチェック）
+        $tables = [
+            'sources',
+            'documents',
+            'chunks',
+            'chat_sessions',
+            'chat_messages',
+            'rate_limit_buckets',
+            'appearance_settings',
+            'corpus_chat_settings',
+            'chat_limits_settings',
+            'admin_users',
+            'admin_password_resets',
+        ];
+
+        foreach ($tables as $table) {
+            if ($this->hasTable($table) && !$this->columnExists($table, 'organization_id')) {
+                $this->execute("
+                    ALTER TABLE `{$table}`
+                        ADD COLUMN organization_id INT NOT NULL DEFAULT 1,
+                        ADD INDEX idx_{$table}_org_id (organization_id)
+                ");
+            }
+        }
+
+        // 6. admin_users に role カラム追加
+        if ($this->hasTable('admin_users') && !$this->columnExists('admin_users', 'role')) {
+            $this->execute("
+                ALTER TABLE admin_users
+                    ADD COLUMN role VARCHAR(32) NOT NULL DEFAULT 'admin'
+            ");
+        }
+
+        // 7. 既存の最初の admin_user を superadmin に昇格、organization_id を NULL に
+        //    （Tier A 自動アップグレード経路: 最初の admin が全テナントを管理）
+        if ($this->hasTable('admin_users')) {
+            if ($this->columnExists('admin_users', 'role')) {
+                $this->execute("
+                    UPDATE admin_users
+                    SET role = 'superadmin', organization_id = 0
+                    ORDER BY id ASC
+                    LIMIT 1
+                ");
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // admin_users: superadmin を admin に戻す（逆順）
+        if ($this->hasTable('admin_users') && $this->columnExists('admin_users', 'role')) {
+            $this->execute("
+                UPDATE admin_users SET role = 'admin', organization_id = 1
+                WHERE role = 'superadmin'
+            ");
+        }
+
+        // admin_users: role カラム削除
+        if ($this->hasTable('admin_users') && $this->columnExists('admin_users', 'role')) {
+            $this->execute('ALTER TABLE admin_users DROP COLUMN role');
+        }
+
+        // 既存テーブルから organization_id 削除
+        $tables = [
+            'admin_password_resets',
+            'admin_users',
+            'chat_limits_settings',
+            'corpus_chat_settings',
+            'appearance_settings',
+            'rate_limit_buckets',
+            'chat_messages',
+            'chat_sessions',
+            'chunks',
+            'documents',
+            'sources',
+        ];
+
+        foreach ($tables as $table) {
+            if ($this->hasTable($table) && $this->columnExists($table, 'organization_id')) {
+                $this->execute("ALTER TABLE `{$table}` DROP COLUMN organization_id");
+            }
+        }
+
+        // system_config テーブル削除
+        $this->execute('DROP TABLE IF EXISTS system_config');
+
+        // organizations テーブル削除
+        $this->execute('DROP TABLE IF EXISTS organizations');
+    }
+
+    private function columnExists(string $table, string $column): bool
+    {
+        $row = $this->fetchRow("
+            SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = '{$table}'
+              AND COLUMN_NAME = '{$column}'
+            LIMIT 1
+        ");
+
+        return $row !== false;
+    }
+}

--- a/src/AdminAuth/AdminAuthServiceProvider.php
+++ b/src/AdminAuth/AdminAuthServiceProvider.php
@@ -26,6 +26,8 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
 
     public const LOGIN_RATE_LIMIT_MIDDLEWARE = 'nene-corpus.middleware.admin_login_rate_limit';
 
+    public const SUPERADMIN_MIDDLEWARE = 'nene-corpus.middleware.superadmin';
+
     public const TOKEN_ISSUER = 'nene-corpus.admin_auth.token_issuer';
 
     public function register(ContainerBuilder $builder): void
@@ -339,6 +341,18 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                     }
 
                     return new AdminAuthRouteRegistrar($login, $me, $changePassword, $changeEmail, $requestReset, $confirmReset);
+                },
+            )
+            ->set(
+                self::SUPERADMIN_MIDDLEWARE,
+                static function (ContainerInterface $container): SuperadminMiddleware {
+                    $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new SuperadminMiddleware($problemDetails);
                 },
             )
             ->set(

--- a/src/AdminAuth/AdminBearerTokenMiddleware.php
+++ b/src/AdminAuth/AdminBearerTokenMiddleware.php
@@ -36,6 +36,28 @@ final readonly class AdminBearerTokenMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        return $this->bearer->process($request, $handler);
+        // Wrap handler to extract role + org_id from JWT claims into typed request attributes
+        $wrappedHandler = new class ($handler) implements RequestHandlerInterface {
+            public function __construct(private readonly RequestHandlerInterface $inner)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                /** @var array<string, mixed>|null $claims */
+                $claims = $request->getAttribute('nene2.auth.claims');
+
+                if (is_array($claims)) {
+                    $orgId = isset($claims['org_id']) && is_int($claims['org_id']) ? $claims['org_id'] : null;
+                    $request = $request
+                        ->withAttribute('nene-corpus.auth.role', (string) ($claims['role'] ?? 'admin'))
+                        ->withAttribute('nene-corpus.auth.org_id', $orgId);
+                }
+
+                return $this->inner->handle($request);
+            }
+        };
+
+        return $this->bearer->process($request, $wrappedHandler);
     }
 }

--- a/src/AdminAuth/AdminUser.php
+++ b/src/AdminAuth/AdminUser.php
@@ -10,6 +10,8 @@ final readonly class AdminUser
         public string $email,
         public string $passwordHash,
         public ?int $id = null,
+        public string $role = 'admin',
+        public ?int $organizationId = null,
         public ?string $createdAt = null,
         public ?string $updatedAt = null,
     ) {

--- a/src/AdminAuth/LoginAdminUseCase.php
+++ b/src/AdminAuth/LoginAdminUseCase.php
@@ -36,11 +36,12 @@ final readonly class LoginAdminUseCase implements LoginAdminUseCaseInterface
         $expiresAt = $now + self::TOKEN_TTL_SECONDS;
 
         $token = $this->tokenIssuer->issue([
-            'sub' => $user->id,
-            'email' => $user->email,
-            'role' => 'admin',
-            'iat' => $now,
-            'exp' => $expiresAt,
+            'sub'    => $user->id,
+            'email'  => $user->email,
+            'role'   => $user->role,
+            'org_id' => $user->organizationId,
+            'iat'    => $now,
+            'exp'    => $expiresAt,
         ]);
 
         return new LoginAdminOutput(

--- a/src/AdminAuth/PdoAdminUserRepository.php
+++ b/src/AdminAuth/PdoAdminUserRepository.php
@@ -16,7 +16,7 @@ final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterf
     public function findByEmail(string $email): ?AdminUser
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, created_at, updated_at FROM admin_users WHERE email = ?',
+            'SELECT id, email, password_hash, role, organization_id, created_at, updated_at FROM admin_users WHERE email = ?',
             [$email],
         );
 
@@ -24,19 +24,13 @@ final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterf
             return null;
         }
 
-        return new AdminUser(
-            email: (string) $row['email'],
-            passwordHash: (string) $row['password_hash'],
-            id: (int) $row['id'],
-            createdAt: (string) $row['created_at'],
-            updatedAt: (string) $row['updated_at'],
-        );
+        return $this->mapRow($row);
     }
 
     public function findById(int $id): ?AdminUser
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, created_at, updated_at FROM admin_users WHERE id = ?',
+            'SELECT id, email, password_hash, role, organization_id, created_at, updated_at FROM admin_users WHERE id = ?',
             [$id],
         );
 
@@ -44,10 +38,21 @@ final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterf
             return null;
         }
 
+        return $this->mapRow($row);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): AdminUser
+    {
+        $rawOrgId = $row['organization_id'] ?? null;
+        $orgId = is_numeric($rawOrgId) && (int) $rawOrgId !== 0 ? (int) $rawOrgId : null;
+
         return new AdminUser(
             email: (string) $row['email'],
             passwordHash: (string) $row['password_hash'],
             id: (int) $row['id'],
+            role: (string) ($row['role'] ?? 'admin'),
+            organizationId: $orgId,
             createdAt: (string) $row['created_at'],
             updatedAt: (string) $row['updated_at'],
         );

--- a/src/AdminAuth/Role.php
+++ b/src/AdminAuth/Role.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+enum Role: string
+{
+    case Admin = 'admin';
+    case Superadmin = 'superadmin';
+
+    public function isSuperadmin(): bool
+    {
+        return $this === self::Superadmin;
+    }
+}

--- a/src/AdminAuth/SuperadminMiddleware.php
+++ b/src/AdminAuth/SuperadminMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\AdminAuth;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Restricts access to /admin/superadmin/* routes to users with role = 'superadmin'.
+ *
+ * Must be applied after AdminBearerTokenMiddleware has set the JWT claims
+ * in the request attribute 'nene2.auth.claims'.
+ */
+final readonly class SuperadminMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $path = $request->getUri()->getPath() ?: '/';
+
+        if (!str_starts_with($path, '/admin/superadmin/')) {
+            return $handler->handle($request);
+        }
+
+        /** @var array<string, mixed>|null $claims */
+        $claims = $request->getAttribute('nene2.auth.claims');
+
+        if (!is_array($claims)) {
+            return $this->problemDetails->create($request, 'unauthorized', 'Unauthorized', 401);
+        }
+
+        $role = (string) ($claims['role'] ?? '');
+
+        if ($role !== Role::Superadmin->value) {
+            return $this->problemDetails->create(
+                $request,
+                'forbidden',
+                'Forbidden',
+                403,
+                'Superadmin role is required for this endpoint.',
+            );
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -40,6 +40,8 @@ use NeneCorpus\Llm\LlmServiceProvider;
 use NeneCorpus\Message\MessageServiceProvider;
 use NeneCorpus\Notification\NotificationRouteRegistrar;
 use NeneCorpus\Notification\NotificationServiceProvider;
+use NeneCorpus\Organization\OrganizationRouteRegistrar;
+use NeneCorpus\Organization\OrganizationServiceProvider;
 use NeneCorpus\RateLimit\RateLimitServiceProvider;
 use NeneCorpus\Search\SearchServiceProvider;
 use NeneCorpus\Session\AdminChatRouteRegistrar;
@@ -49,6 +51,9 @@ use NeneCorpus\Settings\SettingsServiceProvider;
 use NeneCorpus\Source\SourceNotFoundExceptionHandler;
 use NeneCorpus\Source\SourceRouteRegistrar;
 use NeneCorpus\Source\SourceServiceProvider;
+use NeneCorpus\SystemConfig\SystemConfigRouteRegistrar;
+use NeneCorpus\SystemConfig\SystemConfigServiceProvider;
+use NeneCorpus\Tenancy\Context\TenancyServiceProvider;
 use Psr\Container\ContainerInterface;
 
 final readonly class ApplicationServiceProvider implements ServiceProviderInterface
@@ -78,6 +83,9 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new NotificationServiceProvider())
             ->addProvider(new AnalyticsServiceProvider())
             ->addProvider(new InstallServiceProvider())
+            ->addProvider(new OrganizationServiceProvider())
+            ->addProvider(new SystemConfigServiceProvider())
+            ->addProvider(new TenancyServiceProvider())
             ->set(
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {
@@ -94,6 +102,8 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                     $notification = $container->get(NotificationServiceProvider::ROUTE_REGISTRAR);
                     $analytics = $container->get(AnalyticsServiceProvider::ROUTE_REGISTRAR);
                     $install = $container->get(InstallServiceProvider::ROUTE_REGISTRAR);
+                    $organization = $container->get(OrganizationServiceProvider::ROUTE_REGISTRAR);
+                    $systemConfig = $container->get(SystemConfigServiceProvider::ROUTE_REGISTRAR);
 
                     if (!$adminAuth instanceof AdminAuthRouteRegistrar) {
                         throw new LogicException('Admin auth route registrar service is invalid.');
@@ -147,7 +157,15 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
                         throw new LogicException('Install route registrar service is invalid.');
                     }
 
-                    return [$install, $adminAuth, $chat, $ingestion, $source, $document, $adminChat, $appearance, $settings, $chatSettings, $chatLimits, $notification, $analytics];
+                    if (!$organization instanceof OrganizationRouteRegistrar) {
+                        throw new LogicException('Organization route registrar service is invalid.');
+                    }
+
+                    if (!$systemConfig instanceof SystemConfigRouteRegistrar) {
+                        throw new LogicException('System config route registrar service is invalid.');
+                    }
+
+                    return [$install, $adminAuth, $chat, $ingestion, $source, $document, $adminChat, $appearance, $settings, $chatSettings, $chatLimits, $notification, $analytics, $organization, $systemConfig];
                 },
             )
             ->set(

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -24,10 +24,12 @@ use Nene2\Log\RequestIdHolder;
 use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
 use NeneCorpus\AdminAuth\AdminBearerTokenMiddleware;
 use NeneCorpus\AdminAuth\AdminLoginRateLimitMiddleware;
+use NeneCorpus\AdminAuth\SuperadminMiddleware;
 use NeneCorpus\ApplicationServiceProvider;
 use NeneCorpus\Install\InstallServiceProvider;
 use NeneCorpus\RateLimit\ConsumerChatRateLimitMiddleware;
 use NeneCorpus\RateLimit\RateLimitServiceProvider;
+use NeneCorpus\Tenancy\Resolution\OrgResolverMiddleware;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -220,8 +222,10 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 
                     $authMiddleware      = $container->get(AdminAuthServiceProvider::AUTH_MIDDLEWARE);
                     $loginRateLimit      = $container->get(AdminAuthServiceProvider::LOGIN_RATE_LIMIT_MIDDLEWARE);
+                    $superadminMiddleware = $container->get(AdminAuthServiceProvider::SUPERADMIN_MIDDLEWARE);
                     $chatRateLimit       = $container->get(RateLimitServiceProvider::CHAT_RATE_LIMIT_MIDDLEWARE);
                     $basePathMiddleware  = $container->get(InstallServiceProvider::BASE_PATH_MIDDLEWARE);
+                    $orgResolver         = $container->get(OrgResolverMiddleware::class);
 
                     if ($authMiddleware !== null && !$authMiddleware instanceof AdminBearerTokenMiddleware) {
                         throw new LogicException('Admin auth middleware service is invalid.');
@@ -229,6 +233,10 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
 
                     if (!$loginRateLimit instanceof AdminLoginRateLimitMiddleware) {
                         throw new LogicException('Admin login rate limit middleware service is invalid.');
+                    }
+
+                    if (!$superadminMiddleware instanceof SuperadminMiddleware) {
+                        throw new LogicException('Superadmin middleware service is invalid.');
                     }
 
                     if (!$chatRateLimit instanceof ConsumerChatRateLimitMiddleware) {
@@ -239,11 +247,17 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Base path middleware service is invalid.');
                     }
 
+                    if (!$orgResolver instanceof OrgResolverMiddleware) {
+                        throw new LogicException('Org resolver middleware service is invalid.');
+                    }
+
                     /** @var list<\Psr\Http\Server\MiddlewareInterface> $requestMiddleware */
                     $requestMiddleware = array_values(array_filter([
                         $basePathMiddleware,
                         $loginRateLimit,
                         $authMiddleware,
+                        $superadminMiddleware,
+                        $orgResolver,
                         $chatRateLimit,
                     ]));
 

--- a/src/Organization/CreateOrganizationHandler.php
+++ b/src/Organization/CreateOrganizationHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class CreateOrganizationHandler
+{
+    public function __construct(
+        private CreateOrganizationUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $name = trim((string) ($body['name'] ?? ''));
+        $slug = trim((string) ($body['slug'] ?? ''));
+        $plan = trim((string) ($body['plan'] ?? 'free'));
+        $customDomain = isset($body['custom_domain']) ? trim((string) $body['custom_domain']) : null;
+        $externalId   = isset($body['external_id']) ? trim((string) $body['external_id']) : null;
+
+        $errors = [];
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if ($slug === '') {
+            $errors[] = new ValidationError('slug', 'Slug is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new CreateOrganizationInput(
+            name: $name,
+            slug: $slug,
+            plan: $plan,
+            customDomain: $customDomain !== '' ? $customDomain : null,
+            externalId: $externalId !== '' ? $externalId : null,
+        ));
+
+        return $this->response->create(['id' => $output->id], 201);
+    }
+}

--- a/src/Organization/CreateOrganizationInput.php
+++ b/src/Organization/CreateOrganizationInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class CreateOrganizationInput
+{
+    public function __construct(
+        public string $name,
+        public string $slug,
+        public string $plan = 'free',
+        public ?string $customDomain = null,
+        public ?string $externalId = null,
+    ) {
+    }
+}

--- a/src/Organization/CreateOrganizationOutput.php
+++ b/src/Organization/CreateOrganizationOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class CreateOrganizationOutput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Organization/CreateOrganizationUseCase.php
+++ b/src/Organization/CreateOrganizationUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class CreateOrganizationUseCase implements CreateOrganizationUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(CreateOrganizationInput $input): CreateOrganizationOutput
+    {
+        $org = new Organization(
+            name: $input->name,
+            slug: $input->slug,
+            plan: $input->plan,
+            isActive: true,
+            customDomain: $input->customDomain,
+            externalId: $input->externalId,
+        );
+
+        $id = $this->organizations->save($org);
+
+        return new CreateOrganizationOutput(id: $id);
+    }
+}

--- a/src/Organization/CreateOrganizationUseCaseInterface.php
+++ b/src/Organization/CreateOrganizationUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+interface CreateOrganizationUseCaseInterface
+{
+    /** @throws OrganizationSlugConflictException */
+    public function execute(CreateOrganizationInput $input): CreateOrganizationOutput;
+}

--- a/src/Organization/DeleteOrganizationHandler.php
+++ b/src/Organization/DeleteOrganizationHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class DeleteOrganizationHandler
+{
+    public function __construct(
+        private DeleteOrganizationUseCaseInterface $useCase,
+        private ResponseFactoryInterface $responseFactory,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $id = (int) ($request->getAttribute('id') ?? 0);
+
+        $this->useCase->execute(new DeleteOrganizationInput(id: $id));
+
+        return $this->responseFactory->createResponse(204);
+    }
+}

--- a/src/Organization/DeleteOrganizationInput.php
+++ b/src/Organization/DeleteOrganizationInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class DeleteOrganizationInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Organization/DeleteOrganizationUseCase.php
+++ b/src/Organization/DeleteOrganizationUseCase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class DeleteOrganizationUseCase implements DeleteOrganizationUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(DeleteOrganizationInput $input): void
+    {
+        $this->organizations->delete($input->id);
+    }
+}

--- a/src/Organization/DeleteOrganizationUseCaseInterface.php
+++ b/src/Organization/DeleteOrganizationUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+interface DeleteOrganizationUseCaseInterface
+{
+    /** @throws OrganizationNotFoundException */
+    public function execute(DeleteOrganizationInput $input): void;
+}

--- a/src/Organization/GetOrganizationByIdHandler.php
+++ b/src/Organization/GetOrganizationByIdHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetOrganizationByIdHandler
+{
+    public function __construct(
+        private GetOrganizationByIdUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $id = (int) ($request->getAttribute('id') ?? 0);
+
+        $output = $this->useCase->execute(new GetOrganizationByIdInput(id: $id));
+        $org = $output->organization;
+
+        return $this->response->create([
+            'id'            => $org->id,
+            'name'          => $org->name,
+            'slug'          => $org->slug,
+            'custom_domain' => $org->customDomain,
+            'external_id'   => $org->externalId,
+            'plan'          => $org->plan,
+            'is_active'     => $org->isActive,
+            'created_at'    => $org->createdAt,
+            'updated_at'    => $org->updatedAt,
+        ]);
+    }
+}

--- a/src/Organization/GetOrganizationByIdInput.php
+++ b/src/Organization/GetOrganizationByIdInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class GetOrganizationByIdInput
+{
+    public function __construct(
+        public int $id,
+    ) {
+    }
+}

--- a/src/Organization/GetOrganizationByIdOutput.php
+++ b/src/Organization/GetOrganizationByIdOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class GetOrganizationByIdOutput
+{
+    public function __construct(
+        public Organization $organization,
+    ) {
+    }
+}

--- a/src/Organization/GetOrganizationByIdUseCase.php
+++ b/src/Organization/GetOrganizationByIdUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class GetOrganizationByIdUseCase implements GetOrganizationByIdUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(GetOrganizationByIdInput $input): GetOrganizationByIdOutput
+    {
+        $org = $this->organizations->findById($input->id);
+
+        if ($org === null) {
+            throw new OrganizationNotFoundException($input->id);
+        }
+
+        return new GetOrganizationByIdOutput(organization: $org);
+    }
+}

--- a/src/Organization/GetOrganizationByIdUseCaseInterface.php
+++ b/src/Organization/GetOrganizationByIdUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+interface GetOrganizationByIdUseCaseInterface
+{
+    /** @throws OrganizationNotFoundException */
+    public function execute(GetOrganizationByIdInput $input): GetOrganizationByIdOutput;
+}

--- a/src/Organization/ListOrganizationsHandler.php
+++ b/src/Organization/ListOrganizationsHandler.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class ListOrganizationsHandler
+{
+    public function __construct(
+        private ListOrganizationsUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $output = $this->useCase->execute(new ListOrganizationsInput());
+
+        return $this->response->create([
+            'organizations' => array_map(
+                static fn (Organization $org) => self::serialize($org),
+                $output->organizations,
+            ),
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private static function serialize(Organization $org): array
+    {
+        return [
+            'id'            => $org->id,
+            'name'          => $org->name,
+            'slug'          => $org->slug,
+            'custom_domain' => $org->customDomain,
+            'external_id'   => $org->externalId,
+            'plan'          => $org->plan,
+            'is_active'     => $org->isActive,
+            'created_at'    => $org->createdAt,
+            'updated_at'    => $org->updatedAt,
+        ];
+    }
+}

--- a/src/Organization/ListOrganizationsInput.php
+++ b/src/Organization/ListOrganizationsInput.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class ListOrganizationsInput
+{
+}

--- a/src/Organization/ListOrganizationsOutput.php
+++ b/src/Organization/ListOrganizationsOutput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class ListOrganizationsOutput
+{
+    /**
+     * @param list<Organization> $organizations
+     */
+    public function __construct(
+        public array $organizations,
+    ) {
+    }
+}

--- a/src/Organization/ListOrganizationsUseCase.php
+++ b/src/Organization/ListOrganizationsUseCase.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class ListOrganizationsUseCase implements ListOrganizationsUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(ListOrganizationsInput $input): ListOrganizationsOutput
+    {
+        return new ListOrganizationsOutput(
+            organizations: $this->organizations->listAll(),
+        );
+    }
+}

--- a/src/Organization/ListOrganizationsUseCaseInterface.php
+++ b/src/Organization/ListOrganizationsUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+interface ListOrganizationsUseCaseInterface
+{
+    public function execute(ListOrganizationsInput $input): ListOrganizationsOutput;
+}

--- a/src/Organization/Organization.php
+++ b/src/Organization/Organization.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class Organization
+{
+    public function __construct(
+        public string $name,
+        public string $slug,
+        public string $plan,
+        public bool $isActive,
+        public ?int $id = null,
+        public ?string $customDomain = null,
+        public ?string $externalId = null,
+        public ?string $createdAt = null,
+        public ?string $updatedAt = null,
+    ) {
+    }
+}

--- a/src/Organization/OrganizationNotFoundException.php
+++ b/src/Organization/OrganizationNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use RuntimeException;
+
+final class OrganizationNotFoundException extends RuntimeException
+{
+    public function __construct(int $id)
+    {
+        parent::__construct("Organization with id={$id} not found.");
+    }
+}

--- a/src/Organization/OrganizationRepositoryInterface.php
+++ b/src/Organization/OrganizationRepositoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+interface OrganizationRepositoryInterface
+{
+    public function findById(int $id): ?Organization;
+
+    public function findBySlug(string $slug): ?Organization;
+
+    public function findByCustomDomain(string $domain): ?Organization;
+
+    /** @return list<Organization> */
+    public function listAll(): array;
+
+    /** @throws OrganizationSlugConflictException */
+    public function save(Organization $organization): int;
+
+    /** @throws OrganizationNotFoundException */
+    public function update(Organization $organization): void;
+
+    /** @throws OrganizationNotFoundException */
+    public function delete(int $id): void;
+}

--- a/src/Organization/OrganizationRouteRegistrar.php
+++ b/src/Organization/OrganizationRouteRegistrar.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class OrganizationRouteRegistrar
+{
+    public function __construct(
+        private ListOrganizationsHandler $listHandler,
+        private GetOrganizationByIdHandler $getHandler,
+        private CreateOrganizationHandler $createHandler,
+        private UpdateOrganizationHandler $updateHandler,
+        private DeleteOrganizationHandler $deleteHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $list   = $this->listHandler;
+        $get    = $this->getHandler;
+        $create = $this->createHandler;
+        $update = $this->updateHandler;
+        $delete = $this->deleteHandler;
+
+        $router->get(
+            '/admin/superadmin/organizations',
+            static fn (ServerRequestInterface $request) => $list->handle($request),
+        );
+
+        $router->get(
+            '/admin/superadmin/organizations/{id}',
+            static fn (ServerRequestInterface $request) => $get->handle($request),
+        );
+
+        $router->post(
+            '/admin/superadmin/organizations',
+            static fn (ServerRequestInterface $request) => $create->handle($request),
+        );
+
+        $router->put(
+            '/admin/superadmin/organizations/{id}',
+            static fn (ServerRequestInterface $request) => $update->handle($request),
+        );
+
+        $router->delete(
+            '/admin/superadmin/organizations/{id}',
+            static fn (ServerRequestInterface $request) => $delete->handle($request),
+        );
+    }
+}

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+final readonly class OrganizationServiceProvider implements ServiceProviderInterface
+{
+    public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.organization';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                OrganizationRepositoryInterface::class,
+                static function (ContainerInterface $c): OrganizationRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoOrganizationRepository($query);
+                },
+            )
+            ->set(
+                ListOrganizationsUseCaseInterface::class,
+                static function (ContainerInterface $c): ListOrganizationsUseCaseInterface {
+                    $repo = $c->get(OrganizationRepositoryInterface::class);
+
+                    if (!$repo instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    return new ListOrganizationsUseCase($repo);
+                },
+            )
+            ->set(
+                GetOrganizationByIdUseCaseInterface::class,
+                static function (ContainerInterface $c): GetOrganizationByIdUseCaseInterface {
+                    $repo = $c->get(OrganizationRepositoryInterface::class);
+
+                    if (!$repo instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    return new GetOrganizationByIdUseCase($repo);
+                },
+            )
+            ->set(
+                CreateOrganizationUseCaseInterface::class,
+                static function (ContainerInterface $c): CreateOrganizationUseCaseInterface {
+                    $repo = $c->get(OrganizationRepositoryInterface::class);
+
+                    if (!$repo instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    return new CreateOrganizationUseCase($repo);
+                },
+            )
+            ->set(
+                UpdateOrganizationUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateOrganizationUseCaseInterface {
+                    $repo = $c->get(OrganizationRepositoryInterface::class);
+
+                    if (!$repo instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    return new UpdateOrganizationUseCase($repo);
+                },
+            )
+            ->set(
+                DeleteOrganizationUseCaseInterface::class,
+                static function (ContainerInterface $c): DeleteOrganizationUseCaseInterface {
+                    $repo = $c->get(OrganizationRepositoryInterface::class);
+
+                    if (!$repo instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    return new DeleteOrganizationUseCase($repo);
+                },
+            )
+            ->set(
+                ListOrganizationsHandler::class,
+                static function (ContainerInterface $c): ListOrganizationsHandler {
+                    $uc   = $c->get(ListOrganizationsUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof ListOrganizationsUseCaseInterface) {
+                        throw new LogicException('ListOrganizations use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new ListOrganizationsHandler($uc, $json);
+                },
+            )
+            ->set(
+                GetOrganizationByIdHandler::class,
+                static function (ContainerInterface $c): GetOrganizationByIdHandler {
+                    $uc   = $c->get(GetOrganizationByIdUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof GetOrganizationByIdUseCaseInterface) {
+                        throw new LogicException('GetOrganizationById use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetOrganizationByIdHandler($uc, $json);
+                },
+            )
+            ->set(
+                CreateOrganizationHandler::class,
+                static function (ContainerInterface $c): CreateOrganizationHandler {
+                    $uc   = $c->get(CreateOrganizationUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof CreateOrganizationUseCaseInterface) {
+                        throw new LogicException('CreateOrganization use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new CreateOrganizationHandler($uc, $json);
+                },
+            )
+            ->set(
+                UpdateOrganizationHandler::class,
+                static function (ContainerInterface $c): UpdateOrganizationHandler {
+                    $uc   = $c->get(UpdateOrganizationUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof UpdateOrganizationUseCaseInterface) {
+                        throw new LogicException('UpdateOrganization use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateOrganizationHandler($uc, $json);
+                },
+            )
+            ->set(
+                DeleteOrganizationHandler::class,
+                static function (ContainerInterface $c): DeleteOrganizationHandler {
+                    $uc              = $c->get(DeleteOrganizationUseCaseInterface::class);
+                    $responseFactory = $c->get(ResponseFactoryInterface::class);
+
+                    if (!$uc instanceof DeleteOrganizationUseCaseInterface) {
+                        throw new LogicException('DeleteOrganization use case service is invalid.');
+                    }
+
+                    if (!$responseFactory instanceof ResponseFactoryInterface) {
+                        throw new LogicException('Response factory service is invalid.');
+                    }
+
+                    return new DeleteOrganizationHandler($uc, $responseFactory);
+                },
+            )
+            ->set(
+                self::ROUTE_REGISTRAR,
+                static function (ContainerInterface $c): OrganizationRouteRegistrar {
+                    $list   = $c->get(ListOrganizationsHandler::class);
+                    $get    = $c->get(GetOrganizationByIdHandler::class);
+                    $create = $c->get(CreateOrganizationHandler::class);
+                    $update = $c->get(UpdateOrganizationHandler::class);
+                    $delete = $c->get(DeleteOrganizationHandler::class);
+
+                    if (!$list instanceof ListOrganizationsHandler) {
+                        throw new LogicException('ListOrganizations handler service is invalid.');
+                    }
+
+                    if (!$get instanceof GetOrganizationByIdHandler) {
+                        throw new LogicException('GetOrganizationById handler service is invalid.');
+                    }
+
+                    if (!$create instanceof CreateOrganizationHandler) {
+                        throw new LogicException('CreateOrganization handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateOrganizationHandler) {
+                        throw new LogicException('UpdateOrganization handler service is invalid.');
+                    }
+
+                    if (!$delete instanceof DeleteOrganizationHandler) {
+                        throw new LogicException('DeleteOrganization handler service is invalid.');
+                    }
+
+                    return new OrganizationRouteRegistrar($list, $get, $create, $update, $delete);
+                },
+            );
+    }
+}

--- a/src/Organization/OrganizationSlugConflictException.php
+++ b/src/Organization/OrganizationSlugConflictException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use RuntimeException;
+
+final class OrganizationSlugConflictException extends RuntimeException
+{
+    public function __construct(string $slug)
+    {
+        parent::__construct("Organization slug '{$slug}' is already taken.");
+    }
+}

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use Nene2\Database\DatabaseConstraintException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoOrganizationRepository implements OrganizationRepositoryInterface
+{
+    private const COLUMNS = 'id, name, slug, custom_domain, external_id, plan, is_active, created_at, updated_at';
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function findById(int $id): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE id = ?',
+            [$id],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findBySlug(string $slug): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE slug = ?',
+            [$slug],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    public function findByCustomDomain(string $domain): ?Organization
+    {
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::COLUMNS . ' FROM organizations WHERE custom_domain = ?',
+            [$domain],
+        );
+
+        return $row !== null ? $this->mapRow($row) : null;
+    }
+
+    /** @return list<Organization> */
+    public function listAll(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::COLUMNS . ' FROM organizations ORDER BY id ASC',
+            [],
+        );
+
+        return array_map(fn (array $row) => $this->mapRow($row), $rows);
+    }
+
+    public function save(Organization $organization): int
+    {
+        $now = date('Y-m-d H:i:s');
+
+        try {
+            $this->query->execute(
+                'INSERT INTO organizations (name, slug, custom_domain, external_id, plan, is_active, created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                [
+                    $organization->name,
+                    $organization->slug,
+                    $organization->customDomain,
+                    $organization->externalId,
+                    $organization->plan,
+                    $organization->isActive ? 1 : 0,
+                    $now,
+                    $now,
+                ],
+            );
+        } catch (DatabaseConstraintException $e) {
+            throw new OrganizationSlugConflictException($organization->slug);
+        }
+
+        return $this->query->lastInsertId();
+    }
+
+    public function update(Organization $organization): void
+    {
+        if ($organization->id === null) {
+            throw new OrganizationNotFoundException(0);
+        }
+
+        $now = date('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'UPDATE organizations SET name = ?, slug = ?, custom_domain = ?, external_id = ?, plan = ?, is_active = ?, updated_at = ? WHERE id = ?',
+            [
+                $organization->name,
+                $organization->slug,
+                $organization->customDomain,
+                $organization->externalId,
+                $organization->plan,
+                $organization->isActive ? 1 : 0,
+                $now,
+                $organization->id,
+            ],
+        );
+    }
+
+    public function delete(int $id): void
+    {
+        $org = $this->findById($id);
+
+        if ($org === null) {
+            throw new OrganizationNotFoundException($id);
+        }
+
+        $this->query->execute('DELETE FROM organizations WHERE id = ?', [$id]);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): Organization
+    {
+        return new Organization(
+            name: (string) $row['name'],
+            slug: (string) $row['slug'],
+            plan: (string) $row['plan'],
+            isActive: (bool) $row['is_active'],
+            id: (int) $row['id'],
+            customDomain: isset($row['custom_domain']) && $row['custom_domain'] !== '' ? (string) $row['custom_domain'] : null,
+            externalId: isset($row['external_id']) && $row['external_id'] !== '' ? (string) $row['external_id'] : null,
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Organization/UpdateOrganizationHandler.php
+++ b/src/Organization/UpdateOrganizationHandler.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateOrganizationHandler
+{
+    public function __construct(
+        private UpdateOrganizationUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $id   = (int) ($request->getAttribute('id') ?? 0);
+        $body = JsonRequestBodyParser::parse($request);
+
+        $name         = trim((string) ($body['name'] ?? ''));
+        $slug         = trim((string) ($body['slug'] ?? ''));
+        $plan         = trim((string) ($body['plan'] ?? 'free'));
+        $isActive     = isset($body['is_active']) ? (bool) $body['is_active'] : true;
+        $customDomain = isset($body['custom_domain']) ? trim((string) $body['custom_domain']) : null;
+        $externalId   = isset($body['external_id']) ? trim((string) $body['external_id']) : null;
+
+        $errors = [];
+
+        if ($name === '') {
+            $errors[] = new ValidationError('name', 'Name is required.', 'required');
+        }
+
+        if ($slug === '') {
+            $errors[] = new ValidationError('slug', 'Slug is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new UpdateOrganizationInput(
+            id: $id,
+            name: $name,
+            slug: $slug,
+            plan: $plan,
+            isActive: $isActive,
+            customDomain: $customDomain !== '' ? $customDomain : null,
+            externalId: $externalId !== '' ? $externalId : null,
+        ));
+
+        $org = $output->organization;
+
+        return $this->response->create([
+            'id'            => $org->id,
+            'name'          => $org->name,
+            'slug'          => $org->slug,
+            'custom_domain' => $org->customDomain,
+            'external_id'   => $org->externalId,
+            'plan'          => $org->plan,
+            'is_active'     => $org->isActive,
+            'created_at'    => $org->createdAt,
+            'updated_at'    => $org->updatedAt,
+        ]);
+    }
+}

--- a/src/Organization/UpdateOrganizationInput.php
+++ b/src/Organization/UpdateOrganizationInput.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class UpdateOrganizationInput
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $slug,
+        public string $plan,
+        public bool $isActive,
+        public ?string $customDomain = null,
+        public ?string $externalId = null,
+    ) {
+    }
+}

--- a/src/Organization/UpdateOrganizationOutput.php
+++ b/src/Organization/UpdateOrganizationOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class UpdateOrganizationOutput
+{
+    public function __construct(
+        public Organization $organization,
+    ) {
+    }
+}

--- a/src/Organization/UpdateOrganizationUseCase.php
+++ b/src/Organization/UpdateOrganizationUseCase.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+final readonly class UpdateOrganizationUseCase implements UpdateOrganizationUseCaseInterface
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    public function execute(UpdateOrganizationInput $input): UpdateOrganizationOutput
+    {
+        $existing = $this->organizations->findById($input->id);
+
+        if ($existing === null) {
+            throw new OrganizationNotFoundException($input->id);
+        }
+
+        $updated = new Organization(
+            name: $input->name,
+            slug: $input->slug,
+            plan: $input->plan,
+            isActive: $input->isActive,
+            id: $input->id,
+            customDomain: $input->customDomain,
+            externalId: $input->externalId,
+            createdAt: $existing->createdAt,
+        );
+
+        $this->organizations->update($updated);
+
+        $fresh = $this->organizations->findById($input->id);
+
+        if ($fresh === null) {
+            throw new OrganizationNotFoundException($input->id);
+        }
+
+        return new UpdateOrganizationOutput(organization: $fresh);
+    }
+}

--- a/src/Organization/UpdateOrganizationUseCaseInterface.php
+++ b/src/Organization/UpdateOrganizationUseCaseInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Organization;
+
+interface UpdateOrganizationUseCaseInterface
+{
+    /**
+     * @throws OrganizationNotFoundException
+     * @throws OrganizationSlugConflictException
+     */
+    public function execute(UpdateOrganizationInput $input): UpdateOrganizationOutput;
+}

--- a/src/SystemConfig/GetSystemConfigHandler.php
+++ b/src/SystemConfig/GetSystemConfigHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+use Nene2\Http\JsonResponseFactory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class GetSystemConfigHandler
+{
+    public function __construct(
+        private GetSystemConfigUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $config = $this->useCase->execute();
+
+        return $this->response->create([
+            'tenant_resolution_mode' => $config->tenantResolutionMode,
+            'tenant_org_slug'        => $config->tenantOrgSlug,
+            'tenant_base_domain'     => $config->tenantBaseDomain,
+        ]);
+    }
+}

--- a/src/SystemConfig/GetSystemConfigUseCase.php
+++ b/src/SystemConfig/GetSystemConfigUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+final readonly class GetSystemConfigUseCase implements GetSystemConfigUseCaseInterface
+{
+    public function __construct(
+        private SystemConfigRepositoryInterface $config,
+    ) {
+    }
+
+    public function execute(): SystemConfig
+    {
+        return new SystemConfig(
+            tenantResolutionMode: $this->config->get('tenant_resolution_mode') ?? 'single',
+            tenantOrgSlug: $this->config->get('tenant_org_slug') ?? 'default',
+            tenantBaseDomain: $this->config->get('tenant_base_domain') ?? 'localhost',
+        );
+    }
+}

--- a/src/SystemConfig/GetSystemConfigUseCaseInterface.php
+++ b/src/SystemConfig/GetSystemConfigUseCaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+interface GetSystemConfigUseCaseInterface
+{
+    public function execute(): SystemConfig;
+}

--- a/src/SystemConfig/InvalidTenantResolutionModeException.php
+++ b/src/SystemConfig/InvalidTenantResolutionModeException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+use InvalidArgumentException;
+
+final class InvalidTenantResolutionModeException extends InvalidArgumentException
+{
+    public function __construct(string $mode)
+    {
+        parent::__construct("Invalid tenant resolution mode: '{$mode}'. Valid modes are: single, subdomain, path.");
+    }
+}

--- a/src/SystemConfig/PdoSystemConfigRepository.php
+++ b/src/SystemConfig/PdoSystemConfigRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+
+final readonly class PdoSystemConfigRepository implements SystemConfigRepositoryInterface
+{
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+    ) {
+    }
+
+    public function get(string $key): ?string
+    {
+        $row = $this->query->fetchOne(
+            'SELECT `value` FROM system_config WHERE `key` = ?',
+            [$key],
+        );
+
+        return $row !== null ? (string) $row['value'] : null;
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $now = date('Y-m-d H:i:s');
+
+        // Use REPLACE INTO for broad DB compatibility (MySQL and SQLite both support it).
+        // MySQL: REPLACE = DELETE + INSERT on PK conflict.
+        // SQLite: REPLACE = INSERT OR REPLACE.
+        $this->query->execute(
+            'REPLACE INTO system_config (`key`, `value`, `updated_at`) VALUES (?, ?, ?)',
+            [$key, $value, $now],
+        );
+    }
+
+    /** @return array<string, string> */
+    public function all(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT `key`, `value` FROM system_config ORDER BY `key` ASC',
+            [],
+        );
+
+        $result = [];
+
+        foreach ($rows as $row) {
+            $result[(string) $row['key']] = (string) $row['value'];
+        }
+
+        return $result;
+    }
+}

--- a/src/SystemConfig/SystemConfig.php
+++ b/src/SystemConfig/SystemConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+final readonly class SystemConfig
+{
+    public function __construct(
+        public string $tenantResolutionMode,
+        public string $tenantOrgSlug,
+        public string $tenantBaseDomain,
+    ) {
+    }
+}

--- a/src/SystemConfig/SystemConfigRepositoryInterface.php
+++ b/src/SystemConfig/SystemConfigRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+interface SystemConfigRepositoryInterface
+{
+    public function get(string $key): ?string;
+
+    public function set(string $key, string $value): void;
+
+    /** @return array<string, string> */
+    public function all(): array;
+}

--- a/src/SystemConfig/SystemConfigRouteRegistrar.php
+++ b/src/SystemConfig/SystemConfigRouteRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+use Nene2\Routing\Router;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class SystemConfigRouteRegistrar
+{
+    public function __construct(
+        private GetSystemConfigHandler $getHandler,
+        private UpdateSystemConfigHandler $updateHandler,
+    ) {
+    }
+
+    public function __invoke(Router $router): void
+    {
+        $get    = $this->getHandler;
+        $update = $this->updateHandler;
+
+        $router->get(
+            '/admin/superadmin/system-config',
+            static fn (ServerRequestInterface $request) => $get->handle($request),
+        );
+
+        $router->patch(
+            '/admin/superadmin/system-config',
+            static fn (ServerRequestInterface $request) => $update->handle($request),
+        );
+    }
+}

--- a/src/SystemConfig/SystemConfigServiceProvider.php
+++ b/src/SystemConfig/SystemConfigServiceProvider.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\JsonResponseFactory;
+use Psr\Container\ContainerInterface;
+
+final readonly class SystemConfigServiceProvider implements ServiceProviderInterface
+{
+    public const ROUTE_REGISTRAR = 'nene-corpus.route_registrar.system_config';
+
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                SystemConfigRepositoryInterface::class,
+                static function (ContainerInterface $c): SystemConfigRepositoryInterface {
+                    $query = $c->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoSystemConfigRepository($query);
+                },
+            )
+            ->set(
+                GetSystemConfigUseCaseInterface::class,
+                static function (ContainerInterface $c): GetSystemConfigUseCaseInterface {
+                    $repo = $c->get(SystemConfigRepositoryInterface::class);
+
+                    if (!$repo instanceof SystemConfigRepositoryInterface) {
+                        throw new LogicException('System config repository service is invalid.');
+                    }
+
+                    return new GetSystemConfigUseCase($repo);
+                },
+            )
+            ->set(
+                UpdateSystemConfigUseCaseInterface::class,
+                static function (ContainerInterface $c): UpdateSystemConfigUseCaseInterface {
+                    $repo = $c->get(SystemConfigRepositoryInterface::class);
+
+                    if (!$repo instanceof SystemConfigRepositoryInterface) {
+                        throw new LogicException('System config repository service is invalid.');
+                    }
+
+                    return new UpdateSystemConfigUseCase($repo);
+                },
+            )
+            ->set(
+                GetSystemConfigHandler::class,
+                static function (ContainerInterface $c): GetSystemConfigHandler {
+                    $uc   = $c->get(GetSystemConfigUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof GetSystemConfigUseCaseInterface) {
+                        throw new LogicException('GetSystemConfig use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new GetSystemConfigHandler($uc, $json);
+                },
+            )
+            ->set(
+                UpdateSystemConfigHandler::class,
+                static function (ContainerInterface $c): UpdateSystemConfigHandler {
+                    $uc   = $c->get(UpdateSystemConfigUseCaseInterface::class);
+                    $json = $c->get(JsonResponseFactory::class);
+
+                    if (!$uc instanceof UpdateSystemConfigUseCaseInterface) {
+                        throw new LogicException('UpdateSystemConfig use case service is invalid.');
+                    }
+
+                    if (!$json instanceof JsonResponseFactory) {
+                        throw new LogicException('JSON response factory service is invalid.');
+                    }
+
+                    return new UpdateSystemConfigHandler($uc, $json);
+                },
+            )
+            ->set(
+                self::ROUTE_REGISTRAR,
+                static function (ContainerInterface $c): SystemConfigRouteRegistrar {
+                    $get    = $c->get(GetSystemConfigHandler::class);
+                    $update = $c->get(UpdateSystemConfigHandler::class);
+
+                    if (!$get instanceof GetSystemConfigHandler) {
+                        throw new LogicException('GetSystemConfig handler service is invalid.');
+                    }
+
+                    if (!$update instanceof UpdateSystemConfigHandler) {
+                        throw new LogicException('UpdateSystemConfig handler service is invalid.');
+                    }
+
+                    return new SystemConfigRouteRegistrar($get, $update);
+                },
+            );
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigHandler.php
+++ b/src/SystemConfig/UpdateSystemConfigHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+use Nene2\Http\JsonRequestBodyParser;
+use Nene2\Http\JsonResponseFactory;
+use Nene2\Validation\ValidationError;
+use Nene2\Validation\ValidationException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final readonly class UpdateSystemConfigHandler
+{
+    public function __construct(
+        private UpdateSystemConfigUseCaseInterface $useCase,
+        private JsonResponseFactory $response,
+    ) {
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $body = JsonRequestBodyParser::parse($request);
+
+        $mode       = trim((string) ($body['tenant_resolution_mode'] ?? ''));
+        $orgSlug    = trim((string) ($body['tenant_org_slug'] ?? ''));
+        $baseDomain = trim((string) ($body['tenant_base_domain'] ?? ''));
+
+        $errors = [];
+
+        if ($mode === '') {
+            $errors[] = new ValidationError('tenant_resolution_mode', 'Tenant resolution mode is required.', 'required');
+        }
+
+        if ($errors !== []) {
+            throw new ValidationException($errors);
+        }
+
+        $output = $this->useCase->execute(new UpdateSystemConfigInput(
+            tenantResolutionMode: $mode,
+            tenantOrgSlug: $orgSlug,
+            tenantBaseDomain: $baseDomain,
+        ));
+
+        $config = $output->config;
+
+        return $this->response->create([
+            'tenant_resolution_mode' => $config->tenantResolutionMode,
+            'tenant_org_slug'        => $config->tenantOrgSlug,
+            'tenant_base_domain'     => $config->tenantBaseDomain,
+        ]);
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigInput.php
+++ b/src/SystemConfig/UpdateSystemConfigInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+final readonly class UpdateSystemConfigInput
+{
+    public function __construct(
+        public string $tenantResolutionMode,
+        public string $tenantOrgSlug,
+        public string $tenantBaseDomain,
+    ) {
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigOutput.php
+++ b/src/SystemConfig/UpdateSystemConfigOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+final readonly class UpdateSystemConfigOutput
+{
+    public function __construct(
+        public SystemConfig $config,
+    ) {
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigUseCase.php
+++ b/src/SystemConfig/UpdateSystemConfigUseCase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+final readonly class UpdateSystemConfigUseCase implements UpdateSystemConfigUseCaseInterface
+{
+    /** @var list<string> */
+    public const VALID_MODES = ['single', 'subdomain', 'path'];
+
+    public function __construct(
+        private SystemConfigRepositoryInterface $config,
+    ) {
+    }
+
+    public function execute(UpdateSystemConfigInput $input): UpdateSystemConfigOutput
+    {
+        if (!in_array($input->tenantResolutionMode, self::VALID_MODES, true)) {
+            throw new InvalidTenantResolutionModeException($input->tenantResolutionMode);
+        }
+
+        $this->config->set('tenant_resolution_mode', $input->tenantResolutionMode);
+        $this->config->set('tenant_org_slug', $input->tenantOrgSlug);
+        $this->config->set('tenant_base_domain', $input->tenantBaseDomain);
+
+        return new UpdateSystemConfigOutput(
+            config: new SystemConfig(
+                tenantResolutionMode: $input->tenantResolutionMode,
+                tenantOrgSlug: $input->tenantOrgSlug,
+                tenantBaseDomain: $input->tenantBaseDomain,
+            ),
+        );
+    }
+}

--- a/src/SystemConfig/UpdateSystemConfigUseCaseInterface.php
+++ b/src/SystemConfig/UpdateSystemConfigUseCaseInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\SystemConfig;
+
+interface UpdateSystemConfigUseCaseInterface
+{
+    /** @throws InvalidTenantResolutionModeException */
+    public function execute(UpdateSystemConfigInput $input): UpdateSystemConfigOutput;
+}

--- a/src/Tenancy/Context/RequestScopedOrgIdHolder.php
+++ b/src/Tenancy/Context/RequestScopedOrgIdHolder.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tenancy\Context;
+
+/**
+ * Holds the resolved organization ID for the current request.
+ *
+ * This is set by OrgResolverMiddleware after successfully resolving the organization.
+ * Repositories should not call getId() on bypass paths (superadmin / health / auth).
+ */
+final class RequestScopedOrgIdHolder
+{
+    private ?int $id = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function clear(): void
+    {
+        $this->id = null;
+    }
+}

--- a/src/Tenancy/Context/TenancyServiceProvider.php
+++ b/src/Tenancy/Context/TenancyServiceProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tenancy\Context;
+
+use LogicException;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneCorpus\Organization\OrganizationRepositoryInterface;
+use NeneCorpus\SystemConfig\SystemConfigRepositoryInterface;
+use NeneCorpus\Tenancy\Resolution\OrgResolverMiddleware;
+use Psr\Container\ContainerInterface;
+
+final readonly class TenancyServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        // RequestScopedOrgIdHolder は singleton として登録
+        // OrgResolverMiddleware がリクエスト毎に setId() / clear() する
+        $builder
+            ->set(
+                RequestScopedOrgIdHolder::class,
+                static fn (ContainerInterface $c): RequestScopedOrgIdHolder => new RequestScopedOrgIdHolder(),
+            )
+            ->set(
+                OrgResolverMiddleware::class,
+                static function (ContainerInterface $c): OrgResolverMiddleware {
+                    $holder       = $c->get(RequestScopedOrgIdHolder::class);
+                    $organizations = $c->get(OrganizationRepositoryInterface::class);
+                    $systemConfig  = $c->get(SystemConfigRepositoryInterface::class);
+                    $problemDetails = $c->get(ProblemDetailsResponseFactory::class);
+
+                    if (!$holder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    if (!$organizations instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    if (!$systemConfig instanceof SystemConfigRepositoryInterface) {
+                        throw new LogicException('System config repository service is invalid.');
+                    }
+
+                    if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
+                        throw new LogicException('Problem details response factory service is invalid.');
+                    }
+
+                    return new OrgResolverMiddleware($holder, $organizations, $systemConfig, $problemDetails);
+                },
+            );
+    }
+}

--- a/src/Tenancy/Resolution/OrgResolutionStrategyInterface.php
+++ b/src/Tenancy/Resolution/OrgResolutionStrategyInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tenancy\Resolution;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Resolves the organization identifier (slug or custom domain) from an incoming HTTP request.
+ *
+ * Implementations:
+ *  - SingleResolutionStrategy    — returns the configured default slug from system_config
+ *  - SubdomainResolutionStrategy — stub (see TODO comment, implemented in a follow-up Issue)
+ *  - PathPrefixResolutionStrategy — stub (see TODO comment, implemented in a follow-up Issue)
+ */
+interface OrgResolutionStrategyInterface
+{
+    /**
+     * Returns the org slug or custom domain identifier.
+     * Returns null when this strategy cannot determine an org from the request.
+     */
+    public function resolve(ServerRequestInterface $request): ?string;
+}

--- a/src/Tenancy/Resolution/OrgResolverMiddleware.php
+++ b/src/Tenancy/Resolution/OrgResolverMiddleware.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tenancy\Resolution;
+
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneCorpus\Organization\OrganizationRepositoryInterface;
+use NeneCorpus\SystemConfig\SystemConfigRepositoryInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Resolves the current organization from the request and stores its ID
+ * in RequestScopedOrgIdHolder for downstream handlers to read.
+ *
+ * Bypass paths (superadmin org management, health, auth) skip resolution
+ * and pass through with org ID unset. Handlers on those routes must
+ * not rely on the org context.
+ *
+ * Resolution order:
+ *  1. Read tenant_resolution_mode from system_config
+ *  2. Instantiate matching OrgResolutionStrategy
+ *  3. strategy->resolve() → slug identifier
+ *  4. OrganizationRepository::findBySlug() → Organization
+ *  5. If not found by slug, try findByCustomDomain()
+ *  6. 404 if still not found
+ *  7. 403 if org is inactive
+ *  8. Set org ID in holder + request attributes
+ */
+final readonly class OrgResolverMiddleware implements MiddlewareInterface
+{
+    /**
+     * Paths that bypass org resolution entirely.
+     * Superadmin routes, health checks, and auth do not need an org context.
+     *
+     * @var list<string>
+     */
+    private const BYPASS_PREFIXES = [
+        '/health',
+        '/machine/health',
+        '/admin/auth/',
+        '/admin/superadmin/',
+        '/install',
+    ];
+
+    public function __construct(
+        private RequestScopedOrgIdHolder $orgIdHolder,
+        private OrganizationRepositoryInterface $organizations,
+        private SystemConfigRepositoryInterface $systemConfig,
+        private ProblemDetailsResponseFactory $problemDetails,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $path = $request->getUri()->getPath();
+
+        // Bypass: superadmin / health / auth / install routes don't need org context
+        foreach (self::BYPASS_PREFIXES as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return $handler->handle($request);
+            }
+        }
+
+        $mode = $this->systemConfig->get('tenant_resolution_mode') ?? 'single';
+
+        $strategy = match ($mode) {
+            'subdomain' => new SubdomainResolutionStrategy(),
+            'path'      => new PathPrefixResolutionStrategy(),
+            default     => new SingleResolutionStrategy($this->systemConfig),
+        };
+
+        $identifier = $strategy->resolve($request);
+
+        if ($identifier === null) {
+            return $this->problemDetails->create(
+                $request,
+                'org-not-resolved',
+                'Organization Not Resolved',
+                404,
+                'Could not determine the organization for this request. Check your tenant_resolution_mode configuration.',
+            );
+        }
+
+        // Try by slug first, then by custom domain
+        $org = $this->organizations->findBySlug($identifier)
+            ?? $this->organizations->findByCustomDomain($identifier);
+
+        if ($org === null) {
+            return $this->problemDetails->create(
+                $request,
+                'org-not-found',
+                'Organization Not Found',
+                404,
+                "No organization found for '{$identifier}'.",
+            );
+        }
+
+        if (!$org->isActive) {
+            return $this->problemDetails->create(
+                $request,
+                'org-inactive',
+                'Organization Inactive',
+                403,
+                'This organization is currently inactive.',
+            );
+        }
+
+        $orgId = $org->id ?? 1;
+        $this->orgIdHolder->setId($orgId);
+
+        return $handler->handle(
+            $request->withAttribute('nene-corpus.org.id', $orgId)
+                     ->withAttribute('nene-corpus.org.slug', $org->slug),
+        );
+    }
+}

--- a/src/Tenancy/Resolution/PathPrefixResolutionStrategy.php
+++ b/src/Tenancy/Resolution/PathPrefixResolutionStrategy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tenancy\Resolution;
+
+use LogicException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * TODO: Path prefix resolution strategy stub.
+ *
+ * This strategy will resolve the organization slug from the URL path prefix.
+ * Example: /org1/admin/... → slug = "org1"
+ *
+ * Implementation is deferred to a follow-up Issue.
+ * Configuring tenant_resolution_mode = 'path' in system_config will throw
+ * until this strategy is fully implemented.
+ */
+final readonly class PathPrefixResolutionStrategy implements OrgResolutionStrategyInterface
+{
+    public function resolve(ServerRequestInterface $request): ?string
+    {
+        // TODO: Implement path prefix org resolution (follow-up Issue)
+        throw new LogicException('PathPrefixResolutionStrategy is not yet implemented. Use SingleResolutionStrategy instead.');
+    }
+}

--- a/src/Tenancy/Resolution/SingleResolutionStrategy.php
+++ b/src/Tenancy/Resolution/SingleResolutionStrategy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tenancy\Resolution;
+
+use NeneCorpus\SystemConfig\SystemConfigRepositoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Returns the configured default org slug from system_config.
+ *
+ * This is the default strategy for single-tenant deployments (tenant_resolution_mode = 'single').
+ * The slug is read from system_config key 'tenant_org_slug'; falls back to 'default'.
+ */
+final readonly class SingleResolutionStrategy implements OrgResolutionStrategyInterface
+{
+    public function __construct(
+        private SystemConfigRepositoryInterface $config,
+    ) {
+    }
+
+    public function resolve(ServerRequestInterface $request): string
+    {
+        return $this->config->get('tenant_org_slug') ?? 'default';
+    }
+}

--- a/src/Tenancy/Resolution/SubdomainResolutionStrategy.php
+++ b/src/Tenancy/Resolution/SubdomainResolutionStrategy.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tenancy\Resolution;
+
+use LogicException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * TODO: Subdomain resolution strategy stub.
+ *
+ * This strategy will resolve the organization slug from the request subdomain.
+ * Example: org1.nene-corpus.com → slug = "org1"
+ *
+ * Implementation is deferred to a follow-up Issue.
+ * Configuring tenant_resolution_mode = 'subdomain' in system_config will throw
+ * until this strategy is fully implemented.
+ */
+final readonly class SubdomainResolutionStrategy implements OrgResolutionStrategyInterface
+{
+    public function resolve(ServerRequestInterface $request): ?string
+    {
+        // TODO: Implement subdomain org resolution (follow-up Issue)
+        throw new LogicException('SubdomainResolutionStrategy is not yet implemented. Use SingleResolutionStrategy instead.');
+    }
+}

--- a/tests/Organization/PdoOrganizationRepositoryTest.php
+++ b/tests/Organization/PdoOrganizationRepositoryTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Organization;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Organization\Organization;
+use NeneCorpus\Organization\OrganizationNotFoundException;
+use NeneCorpus\Organization\OrganizationSlugConflictException;
+use NeneCorpus\Organization\PdoOrganizationRepository;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoOrganizationRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private PdoOrganizationRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        TenancySchemaSetup::createOrganizations($this->executor);
+        TenancySchemaSetup::seedDefaultOrganization($this->executor);
+
+        $this->repository = new PdoOrganizationRepository($this->executor);
+    }
+
+    public function test_findById_returns_organization(): void
+    {
+        $org = $this->repository->findById(1);
+
+        self::assertNotNull($org);
+        self::assertSame(1, $org->id);
+        self::assertSame('Default Organization', $org->name);
+        self::assertSame('default', $org->slug);
+        self::assertTrue($org->isActive);
+    }
+
+    public function test_findById_returns_null_for_unknown_id(): void
+    {
+        $org = $this->repository->findById(999);
+
+        self::assertNull($org);
+    }
+
+    public function test_findBySlug_returns_organization(): void
+    {
+        $org = $this->repository->findBySlug('default');
+
+        self::assertNotNull($org);
+        self::assertSame('default', $org->slug);
+    }
+
+    public function test_findBySlug_returns_null_for_unknown_slug(): void
+    {
+        $org = $this->repository->findBySlug('unknown');
+
+        self::assertNull($org);
+    }
+
+    public function test_findByCustomDomain_returns_null_when_no_match(): void
+    {
+        $org = $this->repository->findByCustomDomain('example.com');
+
+        self::assertNull($org);
+    }
+
+    public function test_listAll_returns_all_organizations(): void
+    {
+        $orgs = $this->repository->listAll();
+
+        self::assertCount(1, $orgs);
+        self::assertSame('default', $orgs[0]->slug);
+    }
+
+    public function test_save_creates_new_organization_and_returns_id(): void
+    {
+        $org = new Organization(
+            name: 'Test Org',
+            slug: 'test-org',
+            plan: 'free',
+            isActive: true,
+        );
+
+        $id = $this->repository->save($org);
+
+        self::assertGreaterThan(0, $id);
+
+        $found = $this->repository->findById($id);
+        self::assertNotNull($found);
+        self::assertSame('test-org', $found->slug);
+        self::assertSame('Test Org', $found->name);
+    }
+
+    public function test_save_throws_on_duplicate_slug(): void
+    {
+        $org = new Organization(
+            name: 'Duplicate',
+            slug: 'default',
+            plan: 'free',
+            isActive: true,
+        );
+
+        $this->expectException(OrganizationSlugConflictException::class);
+        $this->repository->save($org);
+    }
+
+    public function test_update_modifies_organization(): void
+    {
+        $org = new Organization(
+            name: 'Updated Name',
+            slug: 'default',
+            plan: 'pro',
+            isActive: true,
+            id: 1,
+        );
+
+        $this->repository->update($org);
+
+        $found = $this->repository->findById(1);
+        self::assertNotNull($found);
+        self::assertSame('Updated Name', $found->name);
+        self::assertSame('pro', $found->plan);
+    }
+
+    public function test_delete_removes_organization(): void
+    {
+        $newOrg = new Organization(
+            name: 'To Delete',
+            slug: 'to-delete',
+            plan: 'free',
+            isActive: true,
+        );
+
+        $id = $this->repository->save($newOrg);
+        $this->repository->delete($id);
+
+        $found = $this->repository->findById($id);
+        self::assertNull($found);
+    }
+
+    public function test_delete_throws_for_unknown_id(): void
+    {
+        $this->expectException(OrganizationNotFoundException::class);
+        $this->repository->delete(999);
+    }
+}

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -76,6 +76,8 @@ final class CorpusSchemaSetup
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     email TEXT NOT NULL,
                     password_hash TEXT NOT NULL,
+                    role TEXT NOT NULL DEFAULT 'admin',
+                    organization_id INTEGER NULL DEFAULT NULL,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 )

--- a/tests/Support/TenancySchemaSetup.php
+++ b/tests/Support/TenancySchemaSetup.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use Nene2\Database\PdoDatabaseQueryExecutor;
+
+final class TenancySchemaSetup
+{
+    public static function createOrganizations(PdoDatabaseQueryExecutor $executor): void
+    {
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE organizations (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL,
+                    slug TEXT NOT NULL,
+                    custom_domain TEXT NULL,
+                    plan TEXT NOT NULL DEFAULT 'free',
+                    is_active INTEGER NOT NULL DEFAULT 1,
+                    external_id TEXT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                SQL,
+        );
+
+        $executor->execute('CREATE UNIQUE INDEX uq_organizations_slug ON organizations (slug)');
+        $executor->execute('CREATE UNIQUE INDEX uq_organizations_custom_domain ON organizations (custom_domain)');
+        $executor->execute('CREATE UNIQUE INDEX uq_organizations_external_id ON organizations (external_id)');
+    }
+
+    public static function createSystemConfig(PdoDatabaseQueryExecutor $executor): void
+    {
+        $executor->execute(
+            <<<'SQL'
+                CREATE TABLE system_config (
+                    `key` TEXT NOT NULL,
+                    `value` TEXT NOT NULL DEFAULT '',
+                    `updated_at` TEXT NOT NULL,
+                    PRIMARY KEY (`key`)
+                )
+                SQL,
+        );
+    }
+
+    public static function seedDefaultOrganization(PdoDatabaseQueryExecutor $executor): void
+    {
+        $now = gmdate('Y-m-d H:i:s');
+        $executor->execute(
+            "INSERT INTO organizations (id, name, slug, plan, is_active, created_at, updated_at)
+             VALUES (1, 'Default Organization', 'default', 'free', 1, ?, ?)",
+            [$now, $now],
+        );
+    }
+
+    public static function seedSystemConfig(PdoDatabaseQueryExecutor $executor): void
+    {
+        $now = gmdate('Y-m-d H:i:s');
+        $executor->execute(
+            "INSERT INTO system_config (`key`, `value`, `updated_at`) VALUES ('tenant_resolution_mode', 'single', ?)",
+            [$now],
+        );
+        $executor->execute(
+            "INSERT INTO system_config (`key`, `value`, `updated_at`) VALUES ('tenant_org_slug', 'default', ?)",
+            [$now],
+        );
+        $executor->execute(
+            "INSERT INTO system_config (`key`, `value`, `updated_at`) VALUES ('tenant_base_domain', 'localhost', ?)",
+            [$now],
+        );
+    }
+}

--- a/tests/SystemConfig/SystemConfigUseCaseTest.php
+++ b/tests/SystemConfig/SystemConfigUseCaseTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\SystemConfig;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\SystemConfig\GetSystemConfigUseCase;
+use NeneCorpus\SystemConfig\InvalidTenantResolutionModeException;
+use NeneCorpus\SystemConfig\PdoSystemConfigRepository;
+use NeneCorpus\SystemConfig\UpdateSystemConfigInput;
+use NeneCorpus\SystemConfig\UpdateSystemConfigUseCase;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class SystemConfigUseCaseTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private PdoSystemConfigRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        TenancySchemaSetup::createSystemConfig($this->executor);
+        TenancySchemaSetup::seedSystemConfig($this->executor);
+
+        $this->repository = new PdoSystemConfigRepository($this->executor);
+    }
+
+    public function test_get_returns_default_config(): void
+    {
+        $useCase = new GetSystemConfigUseCase($this->repository);
+        $config = $useCase->execute();
+
+        self::assertSame('single', $config->tenantResolutionMode);
+        self::assertSame('default', $config->tenantOrgSlug);
+        self::assertSame('localhost', $config->tenantBaseDomain);
+    }
+
+    public function test_update_persists_valid_config(): void
+    {
+        $updateUseCase = new UpdateSystemConfigUseCase($this->repository);
+        $output = $updateUseCase->execute(new UpdateSystemConfigInput(
+            tenantResolutionMode: 'single',
+            tenantOrgSlug: 'my-org',
+            tenantBaseDomain: 'example.com',
+        ));
+
+        self::assertSame('single', $output->config->tenantResolutionMode);
+        self::assertSame('my-org', $output->config->tenantOrgSlug);
+        self::assertSame('example.com', $output->config->tenantBaseDomain);
+
+        // Verify persisted
+        $getUseCase = new GetSystemConfigUseCase($this->repository);
+        $config = $getUseCase->execute();
+        self::assertSame('my-org', $config->tenantOrgSlug);
+    }
+
+    public function test_update_throws_for_invalid_mode(): void
+    {
+        $updateUseCase = new UpdateSystemConfigUseCase($this->repository);
+
+        $this->expectException(InvalidTenantResolutionModeException::class);
+
+        $updateUseCase->execute(new UpdateSystemConfigInput(
+            tenantResolutionMode: 'invalid-mode',
+            tenantOrgSlug: 'default',
+            tenantBaseDomain: 'localhost',
+        ));
+    }
+
+    public function test_valid_modes_are_single_subdomain_path(): void
+    {
+        self::assertSame(['single', 'subdomain', 'path'], UpdateSystemConfigUseCase::VALID_MODES);
+    }
+}

--- a/tests/Tenancy/OrgResolverMiddlewareTest.php
+++ b/tests/Tenancy/OrgResolverMiddlewareTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Tenancy;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Error\ProblemDetailsResponseFactory;
+use NeneCorpus\Organization\PdoOrganizationRepository;
+use NeneCorpus\SystemConfig\PdoSystemConfigRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tenancy\Resolution\OrgResolverMiddleware;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class OrgResolverMiddlewareTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $holder;
+
+    private OrgResolverMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        TenancySchemaSetup::createOrganizations($this->executor);
+        TenancySchemaSetup::createSystemConfig($this->executor);
+        TenancySchemaSetup::seedDefaultOrganization($this->executor);
+        TenancySchemaSetup::seedSystemConfig($this->executor);
+
+        $psr17 = new Psr17Factory();
+
+        $this->holder = new RequestScopedOrgIdHolder();
+        $this->middleware = new OrgResolverMiddleware(
+            $this->holder,
+            new PdoOrganizationRepository($this->executor),
+            new PdoSystemConfigRepository($this->executor),
+            new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-corpus.example'),
+        );
+    }
+
+    public function test_single_mode_resolves_default_org(): void
+    {
+        $request = new ServerRequest('GET', 'http://localhost/admin/sources');
+
+        $handler = $this->createPassThroughHandler();
+        $response = $this->middleware->process($request, $handler);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(1, $this->holder->getId());
+    }
+
+    public function test_bypass_path_health_skips_resolution(): void
+    {
+        $request = new ServerRequest('GET', 'http://localhost/health');
+
+        $handler = $this->createPassThroughHandler();
+        $this->middleware->process($request, $handler);
+
+        // holder should not be set for bypass paths
+        self::assertNull($this->holder->getId());
+    }
+
+    public function test_bypass_path_admin_auth_skips_resolution(): void
+    {
+        $request = new ServerRequest('POST', 'http://localhost/admin/auth/login');
+
+        $handler = $this->createPassThroughHandler();
+        $this->middleware->process($request, $handler);
+
+        self::assertNull($this->holder->getId());
+    }
+
+    public function test_bypass_path_superadmin_skips_resolution(): void
+    {
+        $request = new ServerRequest('GET', 'http://localhost/admin/superadmin/organizations');
+
+        $handler = $this->createPassThroughHandler();
+        $this->middleware->process($request, $handler);
+
+        self::assertNull($this->holder->getId());
+    }
+
+    public function test_resolved_org_attributes_are_set_on_request(): void
+    {
+        $handler = new class () implements RequestHandlerInterface {
+            public ?ServerRequestInterface $captured = null;
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->captured = $request;
+
+                return (new Psr17Factory())->createResponse(200);
+            }
+        };
+
+        $request = new ServerRequest('GET', 'http://localhost/admin/sources');
+        $this->middleware->process($request, $handler);
+
+        self::assertNotNull($handler->captured);
+        self::assertSame(1, $handler->captured->getAttribute('nene-corpus.org.id'));
+        self::assertSame('default', $handler->captured->getAttribute('nene-corpus.org.slug'));
+    }
+
+    public function test_inactive_org_returns_403(): void
+    {
+        // Deactivate the default org
+        $this->executor->execute('UPDATE organizations SET is_active = 0 WHERE id = 1', []);
+
+        $request = new ServerRequest('GET', 'http://localhost/admin/sources');
+        $handler = $this->createPassThroughHandler();
+
+        $response = $this->middleware->process($request, $handler);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    private function createPassThroughHandler(): RequestHandlerInterface
+    {
+        return new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return (new Psr17Factory())->createResponse(200);
+            }
+        };
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,16 @@
 
 declare(strict_types=1);
 
-require dirname(__DIR__) . '/vendor/autoload.php';
+$loader = require dirname(__DIR__) . '/vendor/autoload.php';
+
+// When running in a git worktree, the symlinked vendor autoloader resolves src/tests
+// to the main repo path. Add the worktree paths so new modules are found.
+$worktreeRoot = dirname(__DIR__);
+$mainRepoRoot = realpath(dirname($worktreeRoot, 4)); // nene-corpus/.claude/worktrees/agent-X -> nene-corpus
+if ($mainRepoRoot !== false && $mainRepoRoot !== $worktreeRoot) {
+    $loader->addPsr4('NeneCorpus\\', [$worktreeRoot . '/src']);
+    $loader->addPsr4('NeneCorpus\\Tests\\', [$worktreeRoot . '/tests']);
+}
 
 if (!isset($_ENV['NENE2_LOCAL_JWT_SECRET']) && !isset($_SERVER['NENE2_LOCAL_JWT_SECRET'])) {
     $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';


### PR DESCRIPTION
Closes #274

## 内容（要約）

- `organizations` / `system_config` テーブル新設 + 全 11 既存テーブルへの `organization_id` 追加（DEFAULT 1 = default org）
- `src/Organization/` モジュール（Entity + Repository + 5 UseCase + 5 Handler + RouteRegistrar + ServiceProvider）
- `src/SystemConfig/` モジュール（Entity + Repository + Get/Update UseCase + 2 Handler + RouteRegistrar + ServiceProvider）
- `src/Tenancy/Resolution/` — OrgResolverMiddleware + SingleResolutionStrategy（実装済み）+ subdomain/path stub
- `src/Tenancy/Context/` — RequestScopedOrgIdHolder + TenancyServiceProvider
- `src/AdminAuth/Role.php` enum（Admin / Superadmin）、SuperadminMiddleware
- JWT claim に `role` / `org_id` を追加、AdminBearerTokenMiddleware で `nene-corpus.auth.role` / `nene-corpus.auth.org_id` 属性を set
- Migration で既存の最初の admin_user を superadmin に自動昇格

## チェックリスト
- [x] docs/review/database.md
- [x] docs/review/middleware-security.md
- [x] docs/review/backend-api.md

## 品質チェック結果
- PHPUnit: 350/351 pass（`InstallHttpTest::test_install_flow_with_sqlite` は本 PR 前から既存失敗）
- PHPStan level8: No errors
- PHP CS Fixer: No violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)