### PR TITLE
feat(tenancy): RateLimit / Analytics / AdminAuth を org スコープに対応する (#278)

### DIFF
--- a/src/AdminAuth/AdminAuthServiceProvider.php
+++ b/src/AdminAuth/AdminAuthServiceProvider.php
@@ -16,6 +16,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Mail\MailerInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class AdminAuthServiceProvider implements ServiceProviderInterface
@@ -42,6 +43,9 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
+                    // PdoAdminUserRepository does not scope findByEmail/findById by org
+                    // (those methods are called from bypass-path use cases: login, password-reset).
+                    // listByOrganization and create do use the org argument explicitly.
                     return new PdoAdminUserRepository($query);
                 },
             )

--- a/src/AdminAuth/AdminUserRepositoryInterface.php
+++ b/src/AdminAuth/AdminUserRepositoryInterface.php
@@ -13,4 +13,18 @@ interface AdminUserRepositoryInterface
     public function updatePassword(int $id, string $newPasswordHash): void;
 
     public function updateEmail(int $id, string $newEmail): void;
+
+    /**
+     * List admin users belonging to the given organization.
+     * Pass null to list all organizations (superadmin scope).
+     *
+     * @return list<AdminUser>
+     */
+    public function listByOrganization(?int $organizationId): array;
+
+    /**
+     * Create a new admin user in the specified organization.
+     * Returns the newly created user (with id populated).
+     */
+    public function create(string $email, string $passwordHash, string $role, int $organizationId): AdminUser;
 }

--- a/src/AdminAuth/PdoAdminUserRepository.php
+++ b/src/AdminAuth/PdoAdminUserRepository.php
@@ -8,15 +8,21 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 
 final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterface
 {
+    private const SELECT_COLUMNS = 'id, email, password_hash, role, organization_id, created_at, updated_at';
+
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
     ) {
     }
 
+    /**
+     * Global lookup by email — used by login and password-reset paths
+     * that are bypassed from org resolution.
+     */
     public function findByEmail(string $email): ?AdminUser
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, role, organization_id, created_at, updated_at FROM admin_users WHERE email = ?',
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM admin_users WHERE email = ?',
             [$email],
         );
 
@@ -27,10 +33,14 @@ final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterf
         return $this->mapRow($row);
     }
 
+    /**
+     * Global lookup by id — used by change-password / change-email paths
+     * where the caller already owns the id from their JWT.
+     */
     public function findById(int $id): ?AdminUser
     {
         $row = $this->query->fetchOne(
-            'SELECT id, email, password_hash, role, organization_id, created_at, updated_at FROM admin_users WHERE id = ?',
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM admin_users WHERE id = ?',
             [$id],
         );
 
@@ -39,23 +49,6 @@ final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterf
         }
 
         return $this->mapRow($row);
-    }
-
-    /** @param array<string, mixed> $row */
-    private function mapRow(array $row): AdminUser
-    {
-        $rawOrgId = $row['organization_id'] ?? null;
-        $orgId = is_numeric($rawOrgId) && (int) $rawOrgId !== 0 ? (int) $rawOrgId : null;
-
-        return new AdminUser(
-            email: (string) $row['email'],
-            passwordHash: (string) $row['password_hash'],
-            id: (int) $row['id'],
-            role: (string) ($row['role'] ?? 'admin'),
-            organizationId: $orgId,
-            createdAt: (string) $row['created_at'],
-            updatedAt: (string) $row['updated_at'],
-        );
     }
 
     public function updatePassword(int $id, string $newPasswordHash): void
@@ -71,6 +64,69 @@ final readonly class PdoAdminUserRepository implements AdminUserRepositoryInterf
         $this->query->execute(
             'UPDATE admin_users SET email = ?, updated_at = ? WHERE id = ?',
             [$newEmail, gmdate('Y-m-d H:i:s'), $id],
+        );
+    }
+
+    /**
+     * List admins scoped to the given organization.
+     * Passing null returns all admins across all organizations (superadmin scope).
+     *
+     * @return list<AdminUser>
+     */
+    public function listByOrganization(?int $organizationId): array
+    {
+        if ($organizationId === null) {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::SELECT_COLUMNS . ' FROM admin_users ORDER BY id ASC',
+                [],
+            );
+        } else {
+            $rows = $this->query->fetchAll(
+                'SELECT ' . self::SELECT_COLUMNS . ' FROM admin_users WHERE organization_id = ? ORDER BY id ASC',
+                [$organizationId],
+            );
+        }
+
+        return array_values(array_map(fn (array $row): AdminUser => $this->mapRow($row), $rows));
+    }
+
+    /**
+     * Create a new admin user assigned to the given organization.
+     * Returns the created AdminUser with id populated.
+     */
+    public function create(string $email, string $passwordHash, string $role, int $organizationId): AdminUser
+    {
+        $now = gmdate('Y-m-d H:i:s');
+
+        $this->query->execute(
+            'INSERT INTO admin_users (email, password_hash, role, organization_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+            [$email, $passwordHash, $role, $organizationId, $now, $now],
+        );
+
+        $row = $this->query->fetchOne(
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM admin_users WHERE email = ?',
+            [$email],
+        );
+
+        assert($row !== null);
+
+        return $this->mapRow($row);
+    }
+
+    /** @param array<string, mixed> $row */
+    private function mapRow(array $row): AdminUser
+    {
+        $rawOrgId = $row['organization_id'] ?? null;
+        $orgId    = is_numeric($rawOrgId) && (int) $rawOrgId !== 0 ? (int) $rawOrgId : null;
+
+        return new AdminUser(
+            email: (string) $row['email'],
+            passwordHash: (string) $row['password_hash'],
+            id: (int) $row['id'],
+            role: (string) ($row['role'] ?? 'admin'),
+            organizationId: $orgId,
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
         );
     }
 }

--- a/src/Analytics/AnalyticsServiceProvider.php
+++ b/src/Analytics/AnalyticsServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\JsonResponseFactory;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -23,13 +24,18 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
             ->set(
                 AnalyticsRepositoryInterface::class,
                 static function (ContainerInterface $container): AnalyticsRepositoryInterface {
-                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $query  = $container->get(DatabaseQueryExecutorInterface::class);
+                    $holder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoAnalyticsRepository($query);
+                    if (!$holder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoAnalyticsRepository($query, $holder);
                 },
             )
             ->set(

--- a/src/Analytics/PdoAnalyticsRepository.php
+++ b/src/Analytics/PdoAnalyticsRepository.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Analytics;
 
+use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
@@ -18,8 +21,8 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
     public function countSessionsToday(): int
     {
         $rows = $this->query->fetchAll(
-            "SELECT COUNT(*) AS cnt FROM chat_sessions WHERE DATE(created_at) = DATE('now')",
-            [],
+            "SELECT COUNT(*) AS cnt FROM chat_sessions WHERE organization_id = ? AND DATE(created_at) = DATE('now')",
+            [$this->orgId()],
         );
 
         return (int) ($rows[0]['cnt'] ?? 0);
@@ -28,8 +31,8 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
     public function countSessionsThisWeek(): int
     {
         $rows = $this->query->fetchAll(
-            "SELECT COUNT(*) AS cnt FROM chat_sessions WHERE created_at >= DATE('now', '-7 days')",
-            [],
+            "SELECT COUNT(*) AS cnt FROM chat_sessions WHERE organization_id = ? AND created_at >= DATE('now', '-7 days')",
+            [$this->orgId()],
         );
 
         return (int) ($rows[0]['cnt'] ?? 0);
@@ -37,7 +40,10 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
 
     public function countSessionsTotal(): int
     {
-        $rows = $this->query->fetchAll('SELECT COUNT(*) AS cnt FROM chat_sessions', []);
+        $rows = $this->query->fetchAll(
+            'SELECT COUNT(*) AS cnt FROM chat_sessions WHERE organization_id = ?',
+            [$this->orgId()],
+        );
 
         return (int) ($rows[0]['cnt'] ?? 0);
     }
@@ -45,8 +51,8 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
     public function countMessagesByRole(string $role): int
     {
         $rows = $this->query->fetchAll(
-            'SELECT COUNT(*) AS cnt FROM chat_messages WHERE role = ?',
-            [$role],
+            'SELECT COUNT(*) AS cnt FROM chat_messages WHERE organization_id = ? AND role = ?',
+            [$this->orgId(), $role],
         );
 
         return (int) ($rows[0]['cnt'] ?? 0);
@@ -61,8 +67,8 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
         }
 
         $rows = $this->query->fetchAll(
-            "SELECT COALESCE(SUM({$column}), 0) AS total FROM chat_messages",
-            [],
+            "SELECT COALESCE(SUM({$column}), 0) AS total FROM chat_messages WHERE organization_id = ?",
+            [$this->orgId()],
         );
 
         return (int) ($rows[0]['total'] ?? 0);
@@ -77,8 +83,9 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
                          ELSE CAST(COUNT(*) AS REAL) / COUNT(DISTINCT session_id)
                     END AS avg_msg
                 FROM chat_messages
+                WHERE organization_id = ?
                 SQL,
-            [],
+            [$this->orgId()],
         );
 
         return round((float) ($rows[0]['avg_msg'] ?? 0.0), 2);
@@ -94,9 +101,10 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
                         AS REAL
                     ) / NULLIF(COUNT(*), 0) AS rate
                 FROM chat_messages
-                WHERE role = 'assistant'
+                WHERE organization_id = ?
+                  AND role = 'assistant'
                 SQL,
-            [],
+            [$this->orgId()],
         );
 
         $raw = $rows[0]['rate'] ?? null;
@@ -116,11 +124,12 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
                     COUNT(m.id) AS messages
                 FROM chat_sessions s
                 LEFT JOIN chat_messages m ON m.session_id = s.id
-                WHERE s.created_at >= DATE('now', '-{$days} days')
+                WHERE s.organization_id = ?
+                  AND s.created_at >= DATE('now', '-{$days} days')
                 GROUP BY DATE(s.created_at)
                 ORDER BY date ASC
                 SQL,
-            [],
+            [$this->orgId()],
         );
 
         return array_map(
@@ -141,10 +150,11 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
                     CAST(strftime('%H', created_at) AS INTEGER) AS hour,
                     COUNT(*) AS sessions
                 FROM chat_sessions
+                WHERE organization_id = ?
                 GROUP BY strftime('%H', created_at)
                 ORDER BY hour ASC
                 SQL,
-            [],
+            [$this->orgId()],
         );
 
         return array_map(
@@ -160,8 +170,8 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
 
     public function topQuestions(int $limit, ?string $from, ?string $to): array
     {
-        $params = [];
-        $where  = ["role = 'user'"];
+        $params = [$this->orgId()];
+        $where  = ['organization_id = ?', "role = 'user'"];
 
         if ($from !== null) {
             $where[]  = 'created_at >= ?';
@@ -205,8 +215,8 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
 
     public function exportSessions(?string $from, ?string $to): array
     {
-        $params = [];
-        $where  = ['1=1'];
+        $params = [$this->orgId()];
+        $where  = ['s.organization_id = ?'];
 
         if ($from !== null) {
             $where[]  = 's.created_at >= ?';
@@ -246,8 +256,8 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
 
     public function exportConversations(?string $from, ?string $to): array
     {
-        $params = [];
-        $where  = ['1=1'];
+        $params = [$this->orgId()];
+        $where  = ['s.organization_id = ?'];
 
         if ($from !== null) {
             $where[]  = 's.created_at >= ?';
@@ -284,5 +294,16 @@ final readonly class PdoAnalyticsRepository implements AnalyticsRepositoryInterf
         );
 
         return $rows;
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
     }
 }

--- a/src/RateLimit/PdoRateLimitStorage.php
+++ b/src/RateLimit/PdoRateLimitStorage.php
@@ -4,30 +4,34 @@ declare(strict_types=1);
 
 namespace NeneCorpus\RateLimit;
 
+use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoRateLimitStorage implements RateLimitStorageInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
     public function hit(string $key, int $windowSeconds): array
     {
-        $now = time();
-        $row = $this->query->fetchOne(
-            'SELECT hit_count, reset_at FROM rate_limit_buckets WHERE bucket_key = ?',
-            [$key],
+        $orgId = $this->orgId();
+        $now   = time();
+        $row   = $this->query->fetchOne(
+            'SELECT hit_count, reset_at FROM rate_limit_buckets WHERE organization_id = ? AND bucket_key = ?',
+            [$orgId, $key],
         );
 
         if ($row === null) {
             $resetAt = $now + $windowSeconds;
 
             $this->query->execute(
-                'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
-                [$key, 1, $resetAt, $this->now()],
+                'INSERT INTO rate_limit_buckets (organization_id, bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+                [$orgId, $key, 1, $resetAt, $this->now()],
             );
 
             return ['count' => 1, 'reset_at' => $resetAt];
@@ -39,8 +43,8 @@ final readonly class PdoRateLimitStorage implements RateLimitStorageInterface
             $resetAt = $now + $windowSeconds;
 
             $this->query->execute(
-                'UPDATE rate_limit_buckets SET hit_count = ?, reset_at = ?, updated_at = ? WHERE bucket_key = ?',
-                [1, $resetAt, $this->now(), $key],
+                'UPDATE rate_limit_buckets SET hit_count = ?, reset_at = ?, updated_at = ? WHERE organization_id = ? AND bucket_key = ?',
+                [1, $resetAt, $this->now(), $orgId, $key],
             );
 
             return ['count' => 1, 'reset_at' => $resetAt];
@@ -49,11 +53,22 @@ final readonly class PdoRateLimitStorage implements RateLimitStorageInterface
         $count = (int) $row['hit_count'] + 1;
 
         $this->query->execute(
-            'UPDATE rate_limit_buckets SET hit_count = ?, updated_at = ? WHERE bucket_key = ?',
-            [$count, $this->now(), $key],
+            'UPDATE rate_limit_buckets SET hit_count = ?, updated_at = ? WHERE organization_id = ? AND bucket_key = ?',
+            [$count, $this->now(), $orgId, $key],
         );
 
         return ['count' => $count, 'reset_at' => $resetAt];
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
     }
 
     private function now(): string

--- a/src/RateLimit/RateLimitServiceProvider.php
+++ b/src/RateLimit/RateLimitServiceProvider.php
@@ -13,6 +13,7 @@ use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\ChatLimits\ChatLimitsRepositoryInterface;
 use NeneCorpus\ChatLimits\ChatTokenTrackerInterface;
 use NeneCorpus\Notification\RateLimitNotifier;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class RateLimitServiceProvider implements ServiceProviderInterface
@@ -25,13 +26,18 @@ final readonly class RateLimitServiceProvider implements ServiceProviderInterfac
             ->set(
                 RateLimitStorageInterface::class,
                 static function (ContainerInterface $container): RateLimitStorageInterface {
-                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $query  = $container->get(DatabaseQueryExecutorInterface::class);
+                    $holder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoRateLimitStorage($query);
+                    if (!$holder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoRateLimitStorage($query, $holder);
                 },
             )
             ->set(

--- a/tests/AdminAuth/PdoAdminUserRepositoryOrgScopeTest.php
+++ b/tests/AdminAuth/PdoAdminUserRepositoryOrgScopeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\AdminAuth;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\AdminAuth\PdoAdminUserRepository;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * PdoAdminUserRepository の org スコープ動作を検証する。
+ *
+ * - listByOrganization($orgId) は該当 org の admin のみ返す
+ * - listByOrganization(null) は全 org の admin を返す（superadmin 特例）
+ * - create() は指定 org に admin を作成する
+ * - findByEmail / findById はバイパスパス用につき org フィルタを持たない
+ */
+final class PdoAdminUserRepositoryOrgScopeTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private PdoAdminUserRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::createAdminUsers($this->executor);
+        $this->repository = new PdoAdminUserRepository($this->executor);
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    public function test_create_assigns_organization_id(): void
+    {
+        $hash = password_hash('pass', PASSWORD_BCRYPT);
+        $user = $this->repository->create('org1admin@example.com', $hash, 'admin', 1);
+
+        self::assertSame(1, $user->organizationId);
+        self::assertSame('org1admin@example.com', $user->email);
+        self::assertSame('admin', $user->role);
+        self::assertNotNull($user->id);
+    }
+
+    // ── listByOrganization ────────────────────────────────────────────────────
+
+    public function test_listByOrganization_returns_only_org_admins(): void
+    {
+        $hash = password_hash('pass', PASSWORD_BCRYPT);
+        $this->repository->create('org1a@example.com', $hash, 'admin', 1);
+        $this->repository->create('org1b@example.com', $hash, 'admin', 1);
+        $this->repository->create('org2a@example.com', $hash, 'admin', 2);
+
+        $org1Users = $this->repository->listByOrganization(1);
+
+        self::assertCount(2, $org1Users);
+        $emails = array_map(fn ($u) => $u->email, $org1Users);
+        self::assertContains('org1a@example.com', $emails);
+        self::assertContains('org1b@example.com', $emails);
+    }
+
+    public function test_listByOrganization_null_returns_all_orgs_superadmin_scope(): void
+    {
+        $hash = password_hash('pass', PASSWORD_BCRYPT);
+
+        // Insert a superadmin (organization_id IS NULL via raw SQL to simulate the migration pattern)
+        $now = gmdate('Y-m-d H:i:s');
+        $this->executor->execute(
+            'INSERT INTO admin_users (email, password_hash, role, organization_id, created_at, updated_at) VALUES (?, ?, ?, NULL, ?, ?)',
+            ['super@example.com', $hash, 'superadmin', $now, $now],
+        );
+        $this->repository->create('org1@example.com', $hash, 'admin', 1);
+        $this->repository->create('org2@example.com', $hash, 'admin', 2);
+
+        $all = $this->repository->listByOrganization(null);
+
+        self::assertCount(3, $all);
+    }
+
+    public function test_listByOrganization_empty_when_no_admins_in_org(): void
+    {
+        $hash = password_hash('pass', PASSWORD_BCRYPT);
+        $this->repository->create('org1@example.com', $hash, 'admin', 1);
+
+        $org2Users = $this->repository->listByOrganization(2);
+
+        self::assertCount(0, $org2Users);
+    }
+
+    // ── データ分離テスト ──────────────────────────────────────────────────────
+
+    public function test_org1_admins_not_visible_in_org2_listing(): void
+    {
+        $hash = password_hash('pass', PASSWORD_BCRYPT);
+        $this->repository->create('only-org1@example.com', $hash, 'admin', 1);
+
+        $org2 = $this->repository->listByOrganization(2);
+
+        self::assertCount(0, $org2);
+    }
+
+    // ── findByEmail / findById はグローバル（バイパスパス用） ─────────────────
+
+    public function test_findByEmail_finds_across_orgs(): void
+    {
+        $hash = password_hash('pass', PASSWORD_BCRYPT);
+        $this->repository->create('cross-org@example.com', $hash, 'admin', 2);
+
+        // Even when called with "org 1 context", the global lookup works
+        $user = $this->repository->findByEmail('cross-org@example.com');
+
+        self::assertNotNull($user);
+        self::assertSame(2, $user->organizationId);
+    }
+}

--- a/tests/Analytics/PdoAnalyticsRepositoryTest.php
+++ b/tests/Analytics/PdoAnalyticsRepositoryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Analytics;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Analytics\PdoAnalyticsRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+final class PdoAnalyticsRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private RequestScopedOrgIdHolder $holder;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        ChatSchemaSetup::create($this->executor);
+
+        $this->holder = new RequestScopedOrgIdHolder();
+        $this->holder->setId(1);
+    }
+
+    // ── ヘルパー ──────────────────────────────────────────────────────────────
+
+    private function repo(?int $orgId = 1): PdoAnalyticsRepository
+    {
+        $holder = new RequestScopedOrgIdHolder();
+
+        if ($orgId !== null) {
+            $holder->setId($orgId);
+        }
+
+        return new PdoAnalyticsRepository($this->executor, $holder);
+    }
+
+    private function insertSession(int $orgId, string $token, string $createdAt = '2026-05-01 10:00:00'): int
+    {
+        $this->executor->execute(
+            'INSERT INTO chat_sessions (organization_id, public_token, created_at, updated_at) VALUES (?, ?, ?, ?)',
+            [$orgId, $token, $createdAt, $createdAt],
+        );
+
+        $row = $this->executor->fetchOne('SELECT last_insert_rowid() AS id');
+        assert($row !== null);
+
+        return (int) $row['id'];
+    }
+
+    private function insertMessage(int $orgId, int $sessionId, string $role, string $content = 'hello', ?string $citationsJson = null, ?int $inputTokens = null, ?int $outputTokens = null, string $createdAt = '2026-05-01 10:01:00'): void
+    {
+        $this->executor->execute(
+            'INSERT INTO chat_messages (organization_id, session_id, role, content, citations_json, input_tokens, output_tokens, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [$orgId, $sessionId, $role, $content, $citationsJson, $inputTokens, $outputTokens, $createdAt, $createdAt],
+        );
+    }
+
+    // ── countSessionsTotal ────────────────────────────────────────────────────
+
+    public function test_countSessionsTotal_returns_count_for_own_org(): void
+    {
+        $this->insertSession(1, 'tok-org1-a');
+        $this->insertSession(1, 'tok-org1-b');
+        $this->insertSession(2, 'tok-org2-a');
+
+        self::assertSame(2, $this->repo(1)->countSessionsTotal());
+        self::assertSame(1, $this->repo(2)->countSessionsTotal());
+    }
+
+    // ── countMessagesByRole ───────────────────────────────────────────────────
+
+    public function test_countMessagesByRole_is_scoped_to_org(): void
+    {
+        $s1 = $this->insertSession(1, 'tok-msg-org1');
+        $s2 = $this->insertSession(2, 'tok-msg-org2');
+
+        $this->insertMessage(1, $s1, 'user');
+        $this->insertMessage(1, $s1, 'assistant');
+        $this->insertMessage(2, $s2, 'user');
+
+        self::assertSame(1, $this->repo(1)->countMessagesByRole('user'));
+        self::assertSame(1, $this->repo(1)->countMessagesByRole('assistant'));
+        // Org 2 only sees its own message
+        self::assertSame(1, $this->repo(2)->countMessagesByRole('user'));
+        self::assertSame(0, $this->repo(2)->countMessagesByRole('assistant'));
+    }
+
+    // ── sumTokens ─────────────────────────────────────────────────────────────
+
+    public function test_sumTokens_is_scoped_to_org(): void
+    {
+        $s1 = $this->insertSession(1, 'tok-token-org1');
+        $s2 = $this->insertSession(2, 'tok-token-org2');
+
+        $this->insertMessage(1, $s1, 'assistant', 'reply', null, 100, 50);
+        $this->insertMessage(2, $s2, 'assistant', 'reply', null, 200, 80);
+
+        self::assertSame(100, $this->repo(1)->sumTokens('input_tokens'));
+        self::assertSame(50, $this->repo(1)->sumTokens('output_tokens'));
+        self::assertSame(200, $this->repo(2)->sumTokens('input_tokens'));
+    }
+
+    // ── citationRate ──────────────────────────────────────────────────────────
+
+    public function test_citationRate_is_scoped_to_org(): void
+    {
+        $s1 = $this->insertSession(1, 'tok-cite-org1');
+        $s2 = $this->insertSession(2, 'tok-cite-org2');
+
+        // Org 1: 1 cited out of 2 assistant messages = 0.5
+        $this->insertMessage(1, $s1, 'assistant', 'reply', '[{"chunk_id":1}]');
+        $this->insertMessage(1, $s1, 'assistant', 'reply', '[]');
+        // Org 2: 1 cited out of 1 = 1.0
+        $this->insertMessage(2, $s2, 'assistant', 'reply', '[{"chunk_id":2}]');
+
+        self::assertSame(0.5, $this->repo(1)->citationRate());
+        self::assertSame(1.0, $this->repo(2)->citationRate());
+    }
+
+    // ── avgMessagesPerSession ─────────────────────────────────────────────────
+
+    public function test_avgMessagesPerSession_is_scoped_to_org(): void
+    {
+        $s1 = $this->insertSession(1, 'tok-avg-org1');
+        $s2 = $this->insertSession(2, 'tok-avg-org2');
+
+        // Org 1: 4 messages in 1 session = avg 4.0
+        for ($i = 0; $i < 4; $i++) {
+            $this->insertMessage(1, $s1, 'user', "q{$i}");
+        }
+
+        // Org 2: 2 messages in 1 session = avg 2.0
+        $this->insertMessage(2, $s2, 'user', 'q1');
+        $this->insertMessage(2, $s2, 'user', 'q2');
+
+        self::assertSame(4.0, $this->repo(1)->avgMessagesPerSession());
+        self::assertSame(2.0, $this->repo(2)->avgMessagesPerSession());
+    }
+
+    // ── topQuestions ──────────────────────────────────────────────────────────
+
+    public function test_topQuestions_is_scoped_to_org(): void
+    {
+        $s1 = $this->insertSession(1, 'tok-tq-org1');
+        $s2 = $this->insertSession(2, 'tok-tq-org2');
+
+        $this->insertMessage(1, $s1, 'user', 'what is X?');
+        $this->insertMessage(2, $s2, 'user', 'org2 question?');
+
+        $questions = $this->repo(1)->topQuestions(10, null, null);
+
+        self::assertCount(1, $questions);
+        self::assertSame('what is X?', $questions[0]['content']);
+    }
+
+    // ── exportSessions ────────────────────────────────────────────────────────
+
+    public function test_exportSessions_is_scoped_to_org(): void
+    {
+        $s1 = $this->insertSession(1, 'tok-exp-org1');
+        $this->insertSession(2, 'tok-exp-org2');
+
+        $this->insertMessage(1, $s1, 'user');
+
+        $rows = $this->repo(1)->exportSessions(null, null);
+
+        self::assertCount(1, $rows);
+        self::assertSame($s1, (int) $rows[0]['session_id']);
+    }
+
+    // ── exportConversations ───────────────────────────────────────────────────
+
+    public function test_exportConversations_is_scoped_to_org(): void
+    {
+        $s1 = $this->insertSession(1, 'tok-conv-org1');
+        $s2 = $this->insertSession(2, 'tok-conv-org2');
+
+        $this->insertMessage(1, $s1, 'user', 'hello org1');
+        $this->insertMessage(2, $s2, 'user', 'hello org2');
+
+        $rows = $this->repo(1)->exportConversations(null, null);
+
+        self::assertCount(1, $rows);
+        self::assertSame('hello org1', (string) $rows[0]['content']);
+    }
+
+    // ── データ分離テスト ──────────────────────────────────────────────────────
+
+    public function test_org1_data_does_not_leak_into_org2(): void
+    {
+        // Insert sessions for org 1 only
+        $this->insertSession(1, 'tok-iso-org1-a');
+        $this->insertSession(1, 'tok-iso-org1-b');
+
+        // Org 2 must see zero sessions
+        self::assertSame(0, $this->repo(2)->countSessionsTotal());
+        self::assertSame(0.0, $this->repo(2)->citationRate());
+        self::assertCount(0, $this->repo(2)->exportSessions(null, null));
+    }
+}

--- a/tests/RateLimit/PdoRateLimitStorageTest.php
+++ b/tests/RateLimit/PdoRateLimitStorageTest.php
@@ -8,12 +8,14 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\RateLimit\PdoRateLimitStorage;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
 final class PdoRateLimitStorageTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+    private RequestScopedOrgIdHolder $holder;
 
     protected function setUp(): void
     {
@@ -30,13 +32,16 @@ final class PdoRateLimitStorageTest extends TestCase
         )));
 
         RateLimitSchemaSetup::create($this->executor);
+
+        $this->holder = new RequestScopedOrgIdHolder();
+        $this->holder->setId(1);
     }
 
     public function test_hit_increments_count_within_window(): void
     {
-        $storage = new PdoRateLimitStorage($this->executor);
+        $storage = new PdoRateLimitStorage($this->executor, $this->holder);
 
-        $first = $storage->hit('chat:session:abc', 60);
+        $first  = $storage->hit('chat:session:abc', 60);
         $second = $storage->hit('chat:session:abc', 60);
 
         self::assertSame(1, $first['count']);
@@ -46,16 +51,35 @@ final class PdoRateLimitStorageTest extends TestCase
 
     public function test_hit_resets_count_after_window_expires(): void
     {
-        $storage = new PdoRateLimitStorage($this->executor);
+        $storage = new PdoRateLimitStorage($this->executor, $this->holder);
         $storage->hit('chat:ip:127.0.0.1', 60);
 
         $this->executor->execute(
-            'UPDATE rate_limit_buckets SET reset_at = ? WHERE bucket_key = ?',
-            [time() - 1, 'chat:ip:127.0.0.1'],
+            'UPDATE rate_limit_buckets SET reset_at = ? WHERE organization_id = ? AND bucket_key = ?',
+            [time() - 1, 1, 'chat:ip:127.0.0.1'],
         );
 
         $result = $storage->hit('chat:ip:127.0.0.1', 60);
 
         self::assertSame(1, $result['count']);
+    }
+
+    public function test_hit_is_isolated_per_organization(): void
+    {
+        $holderOrg1 = new RequestScopedOrgIdHolder();
+        $holderOrg1->setId(1);
+        $storageOrg1 = new PdoRateLimitStorage($this->executor, $holderOrg1);
+
+        $holderOrg2 = new RequestScopedOrgIdHolder();
+        $holderOrg2->setId(2);
+        $storageOrg2 = new PdoRateLimitStorage($this->executor, $holderOrg2);
+
+        // Org 1 hits twice, org 2 hits once with the same key
+        $storageOrg1->hit('chat:session:xyz', 60);
+        $storageOrg1->hit('chat:session:xyz', 60);
+        $resultOrg2 = $storageOrg2->hit('chat:session:xyz', 60);
+
+        // Org 2 must start at 1 — not influenced by org 1's count
+        self::assertSame(1, $resultOrg2['count']);
     }
 }

--- a/tests/Support/ChatSchemaSetup.php
+++ b/tests/Support/ChatSchemaSetup.php
@@ -14,6 +14,7 @@ final class ChatSchemaSetup
             <<<'SQL'
                 CREATE TABLE chat_sessions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     public_token TEXT NOT NULL,
                     client_ip TEXT NULL,
                     user_agent TEXT NULL,
@@ -30,6 +31,7 @@ final class ChatSchemaSetup
             <<<'SQL'
                 CREATE TABLE chat_messages (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     session_id INTEGER NOT NULL,
                     role TEXT NOT NULL,
                     content TEXT NOT NULL,

--- a/tests/Support/RateLimitSchemaSetup.php
+++ b/tests/Support/RateLimitSchemaSetup.php
@@ -14,6 +14,7 @@ final class RateLimitSchemaSetup
             <<<'SQL'
                 CREATE TABLE rate_limit_buckets (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     bucket_key TEXT NOT NULL,
                     hit_count INTEGER NOT NULL DEFAULT 0,
                     reset_at INTEGER NOT NULL,
@@ -22,6 +23,6 @@ final class RateLimitSchemaSetup
                 SQL,
         );
 
-        $executor->execute('CREATE UNIQUE INDEX uniq_rate_limit_buckets_bucket_key ON rate_limit_buckets (bucket_key)');
+        $executor->execute('CREATE UNIQUE INDEX uniq_rate_limit_buckets_org_key ON rate_limit_buckets (organization_id, bucket_key)');
     }
 }


### PR DESCRIPTION
Closes #278

## 内容

- **RateLimit**: `PdoRateLimitStorage` の bucket を org 毎に分離。SELECT/INSERT/UPDATE に `organization_id` 追加、UNIQUE 制約を `(organization_id, bucket_key)` に変更
- **Analytics**: `PdoAnalyticsRepository` の全集計クエリに org filter を追加（sessions / messages / citation_rate / avg_messages / daily_trend / hourly_distribution / top_questions / export_sessions / export_conversations）
- **AdminAuth**: `PdoAdminUserRepository` に `listByOrganization` / `create` を追加。`findByEmail` / `findById` はバイパスパス用（login / password-reset）につき org フィルタなし

## AdminAuth の superadmin 設計判断

`findByEmail` と `findById` は `/admin/auth/*` バイパスパスから呼ばれるため org フィルタを持たない（OrgResolverMiddleware がこれらのパスをスキップするため org ID が未セット）。

superadmin のクロスオーグ参照は新設の `listByOrganization(null)` で対応。null を渡すと全テナントの admin を返し、int を渡すと自 org のみを返す。呼び出し側 UseCase がどちらの引数を渡すかで権限を制御する（今後の Phase C で UI を実装）。

## テスト

- `tests/RateLimit/PdoRateLimitStorageTest` — org 分離テスト追加
- `tests/Analytics/PdoAnalyticsRepositoryTest` — 全メソッドの org scope + データ漏洩テスト（新規）
- `tests/AdminAuth/PdoAdminUserRepositoryOrgScopeTest` — listByOrganization / create / superadmin 特例（新規）

## チェックリスト

- docs/review/database.md
- docs/review/middleware-security.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)