### PR TITLE
feat(tenancy): Session / Message / Chat / Llm を org スコープに対応する (#276)

### DIFF
--- a/src/Message/MessageServiceProvider.php
+++ b/src/Message/MessageServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class MessageServiceProvider implements ServiceProviderInterface
@@ -18,12 +19,17 @@ final readonly class MessageServiceProvider implements ServiceProviderInterface
             ChatMessageRepositoryInterface::class,
             static function (ContainerInterface $container): ChatMessageRepositoryInterface {
                 $query = $container->get(DatabaseQueryExecutorInterface::class);
+                $holder = $container->get(RequestScopedOrgIdHolder::class);
 
                 if (!$query instanceof DatabaseQueryExecutorInterface) {
                     throw new LogicException('Database query executor service is invalid.');
                 }
 
-                return new PdoChatMessageRepository($query);
+                if (!$holder instanceof RequestScopedOrgIdHolder) {
+                    throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                }
+
+                return new PdoChatMessageRepository($query, $holder);
             },
         );
     }

--- a/src/Message/PdoChatMessageRepository.php
+++ b/src/Message/PdoChatMessageRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\Message;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoChatMessageRepository implements ChatMessageRepositoryInterface
 {
@@ -14,14 +15,15 @@ final readonly class PdoChatMessageRepository implements ChatMessageRepositoryIn
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
     public function findById(int $id): ?ChatMessage
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_messages WHERE id = ?',
-            [$id],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_messages WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId()],
         );
 
         return $row === null ? null : $this->mapRow($row);
@@ -31,8 +33,8 @@ final readonly class PdoChatMessageRepository implements ChatMessageRepositoryIn
     public function findBySessionId(int $sessionId, int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_messages WHERE session_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
-            [$sessionId, $limit, $offset],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_messages WHERE session_id = ? AND organization_id = ? ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$sessionId, $this->orgId(), $limit, $offset],
         );
 
         return array_map(fn (array $row): ChatMessage => $this->mapRow($row), $rows);
@@ -45,10 +47,11 @@ final readonly class PdoChatMessageRepository implements ChatMessageRepositoryIn
         $this->query->execute(
             <<<'SQL'
                 INSERT INTO chat_messages (
-                    session_id, role, content, citations_json, input_tokens, output_tokens, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    organization_id, session_id, role, content, citations_json, input_tokens, output_tokens, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 SQL,
             [
+                $this->orgId(),
                 $message->sessionId,
                 $message->role->value,
                 $message->content,
@@ -61,6 +64,17 @@ final readonly class PdoChatMessageRepository implements ChatMessageRepositoryIn
         );
 
         return $this->query->lastInsertId();
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new \LogicException('Organization ID is not resolved.');
+        }
+
+        return $id;
     }
 
     /**

--- a/src/Session/PdoChatSessionRepository.php
+++ b/src/Session/PdoChatSessionRepository.php
@@ -6,6 +6,7 @@ namespace NeneCorpus\Session;
 
 use InvalidArgumentException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoChatSessionRepository implements ChatSessionRepositoryInterface
 {
@@ -15,14 +16,15 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
     public function findById(int $id): ?ChatSession
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_sessions WHERE id = ?',
-            [$id],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_sessions WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId()],
         );
 
         return $row === null ? null : $this->mapRow($row);
@@ -31,8 +33,8 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
     public function findByPublicToken(string $publicToken): ?ChatSession
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_sessions WHERE public_token = ?',
-            [$publicToken],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chat_sessions WHERE public_token = ? AND organization_id = ?',
+            [$publicToken, $this->orgId()],
         );
 
         return $row === null ? null : $this->mapRow($row);
@@ -43,8 +45,8 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
         $now = $this->now();
 
         $this->query->execute(
-            'INSERT INTO chat_sessions (public_token, client_ip, user_agent, referer, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
-            [$session->publicToken, $session->clientIp, $session->userAgent, $session->referer, $now, $now],
+            'INSERT INTO chat_sessions (organization_id, public_token, client_ip, user_agent, referer, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [$this->orgId(), $session->publicToken, $session->clientIp, $session->userAgent, $session->referer, $now, $now],
         );
 
         return $this->query->lastInsertId();
@@ -57,8 +59,8 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
         }
 
         $this->query->execute(
-            'UPDATE chat_sessions SET public_token = ?, updated_at = ? WHERE id = ?',
-            [$session->publicToken, $this->now(), $session->id],
+            'UPDATE chat_sessions SET public_token = ?, updated_at = ? WHERE id = ? AND organization_id = ?',
+            [$session->publicToken, $this->now(), $session->id, $this->orgId()],
         );
     }
 
@@ -80,10 +82,11 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
                         WHERE m.session_id = s.id
                     ) AS last_message_at
                 FROM chat_sessions s
+                WHERE s.organization_id = ?
                 ORDER BY s.id DESC
                 LIMIT ? OFFSET ?
                 SQL,
-            [$limit, $offset],
+            [$this->orgId(), $limit, $offset],
         );
 
         return array_map(
@@ -98,7 +101,7 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
 
     public function countAll(): int
     {
-        $rows = $this->query->fetchAll('SELECT COUNT(*) AS cnt FROM chat_sessions', []);
+        $rows = $this->query->fetchAll('SELECT COUNT(*) AS cnt FROM chat_sessions WHERE organization_id = ?', [$this->orgId()]);
 
         return (int) ($rows[0]['cnt'] ?? 0);
     }
@@ -108,9 +111,20 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
         $cutoff = gmdate('Y-m-d H:i:s', time() - $days * 86400);
 
         $before = $this->countAll();
-        $this->query->execute('DELETE FROM chat_sessions WHERE created_at < ?', [$cutoff]);
+        $this->query->execute('DELETE FROM chat_sessions WHERE created_at < ? AND organization_id = ?', [$cutoff, $this->orgId()]);
 
         return max(0, $before - $this->countAll());
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new \LogicException('Organization ID is not resolved.');
+        }
+
+        return $id;
     }
 
     /**

--- a/src/Session/SessionServiceProvider.php
+++ b/src/Session/SessionServiceProvider.php
@@ -13,6 +13,7 @@ use NeneCorpus\Message\ChatMessageRepositoryInterface;
 use NeneCorpus\Message\ListChatSessionMessagesHandler;
 use NeneCorpus\Message\ListChatSessionMessagesUseCase;
 use NeneCorpus\Message\ListChatSessionMessagesUseCaseInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class SessionServiceProvider implements ServiceProviderInterface
@@ -26,12 +27,17 @@ final readonly class SessionServiceProvider implements ServiceProviderInterface
                 ChatSessionRepositoryInterface::class,
                 static function (ContainerInterface $container): ChatSessionRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $holder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoChatSessionRepository($query);
+                    if (!$holder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoChatSessionRepository($query, $holder);
                 },
             )
             ->set(

--- a/tests/Appearance/AppearanceHttpTest.php
+++ b/tests/Appearance/AppearanceHttpTest.php
@@ -7,6 +7,7 @@ namespace NeneCorpus\Tests\Appearance;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use NeneCorpus\Tests\Support\SampleHeroImage;
@@ -36,6 +37,7 @@ final class AppearanceHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         CorpusSchemaSetup::createAdminUsers($executor);
         RateLimitSchemaSetup::create($executor);
         CorpusSchemaSetup::createAppearanceSettings($executor);

--- a/tests/Chat/AdminChatHttpTest.php
+++ b/tests/Chat/AdminChatHttpTest.php
@@ -49,6 +49,7 @@ final class AdminChatHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         CorpusSchemaSetup::create($executor);
         ChatSchemaSetup::create($executor);
         RateLimitSchemaSetup::create($executor);

--- a/tests/Chat/ChatHttpTest.php
+++ b/tests/Chat/ChatHttpTest.php
@@ -15,6 +15,7 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
 use NeneCorpus\Tests\Support\ChatLimitsSchemaSetup;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
@@ -43,6 +44,7 @@ final class ChatHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         CorpusSchemaSetup::create($executor);
         ChatSchemaSetup::create($executor);
         RateLimitSchemaSetup::create($executor);

--- a/tests/Chat/SendChatMessageUseCaseEdgeCaseTest.php
+++ b/tests/Chat/SendChatMessageUseCaseEdgeCaseTest.php
@@ -21,6 +21,7 @@ use NeneCorpus\Llm\GenerateChatReplyUseCaseInterface;
 use NeneCorpus\Message\PdoChatMessageRepository;
 use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -57,8 +58,11 @@ final class SendChatMessageUseCaseEdgeCaseTest extends TestCase
 
         ChatSchemaSetup::create($this->executor);
 
-        $this->sessions = new PdoChatSessionRepository($this->executor);
-        $this->messages = new PdoChatMessageRepository($this->executor);
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId(1);
+
+        $this->sessions = new PdoChatSessionRepository($this->executor, $holder);
+        $this->messages = new PdoChatMessageRepository($this->executor, $holder);
     }
 
     // ── セッションエラー ───────────────────────────────────────────────

--- a/tests/Chat/SendChatMessageUseCaseTest.php
+++ b/tests/Chat/SendChatMessageUseCaseTest.php
@@ -19,6 +19,7 @@ use NeneCorpus\Message\MessageRole;
 use NeneCorpus\Message\PdoChatMessageRepository;
 use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -40,7 +41,10 @@ final class SendChatMessageUseCaseTest extends TestCase
 
         ChatSchemaSetup::create($executor);
 
-        $sessions = new PdoChatSessionRepository($executor);
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId(1);
+
+        $sessions = new PdoChatSessionRepository($executor, $holder);
         $sessionId = $sessions->save(new ChatSession(publicToken: 'token-abc'));
         $session = $sessions->findById($sessionId);
         self::assertNotNull($session);
@@ -75,7 +79,7 @@ final class SendChatMessageUseCaseTest extends TestCase
 
         $output = (new SendChatMessageUseCase(
             $sessions,
-            new PdoChatMessageRepository($executor),
+            new PdoChatMessageRepository($executor, $holder),
             $generateReply,
             $limitsRepository,
             $tokenTracker,
@@ -88,7 +92,7 @@ final class SendChatMessageUseCaseTest extends TestCase
         self::assertSame('Assistant answer.', $output->content);
         self::assertCount(1, $output->citations);
 
-        $messages = (new PdoChatMessageRepository($executor))->findBySessionId($sessionId, 10, 0);
+        $messages = (new PdoChatMessageRepository($executor, $holder))->findBySessionId($sessionId, 10, 0);
         self::assertCount(2, $messages);
         self::assertSame(MessageRole::User, $messages[0]->role);
         self::assertSame(MessageRole::Assistant, $messages[1]->role);

--- a/tests/ChatSettings/ChatSettingsHttpTest.php
+++ b/tests/ChatSettings/ChatSettingsHttpTest.php
@@ -7,6 +7,7 @@ namespace NeneCorpus\Tests\ChatSettings;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -50,6 +51,7 @@ final class ChatSettingsHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         CorpusSchemaSetup::createAdminUsers($executor);
         RateLimitSchemaSetup::create($executor);
         CorpusSchemaSetup::createChatSettings($executor);

--- a/tests/Document/DocumentHttpTest.php
+++ b/tests/Document/DocumentHttpTest.php
@@ -37,6 +37,7 @@ final class DocumentHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         AdminHttpTestSupport::seedCorpusSchema($executor);
     }
 

--- a/tests/Ingestion/CsvIngestionHttpTest.php
+++ b/tests/Ingestion/CsvIngestionHttpTest.php
@@ -37,6 +37,7 @@ final class CsvIngestionHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         AdminHttpTestSupport::seedCorpusSchema($executor);
     }
 

--- a/tests/Ingestion/PdfIngestionHttpTest.php
+++ b/tests/Ingestion/PdfIngestionHttpTest.php
@@ -38,6 +38,7 @@ final class PdfIngestionHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         AdminHttpTestSupport::seedCorpusSchema($executor);
     }
 

--- a/tests/Ingestion/TextIngestionHttpTest.php
+++ b/tests/Ingestion/TextIngestionHttpTest.php
@@ -37,6 +37,7 @@ final class TextIngestionHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         AdminHttpTestSupport::seedCorpusSchema($executor);
     }
 

--- a/tests/Message/PdoChatMessageRepositoryTest.php
+++ b/tests/Message/PdoChatMessageRepositoryTest.php
@@ -12,6 +12,7 @@ use NeneCorpus\Message\MessageRole;
 use NeneCorpus\Message\PdoChatMessageRepository;
 use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -36,10 +37,26 @@ final class PdoChatMessageRepositoryTest extends TestCase
         ChatSchemaSetup::create($this->executor);
     }
 
+    private function makeSessions(int $orgId = 1): PdoChatSessionRepository
+    {
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId($orgId);
+
+        return new PdoChatSessionRepository($this->executor, $holder);
+    }
+
+    private function makeMessages(int $orgId = 1): PdoChatMessageRepository
+    {
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId($orgId);
+
+        return new PdoChatMessageRepository($this->executor, $holder);
+    }
+
     public function test_save_and_find_by_session_id(): void
     {
-        $sessions = new PdoChatSessionRepository($this->executor);
-        $messages = new PdoChatMessageRepository($this->executor);
+        $sessions = $this->makeSessions();
+        $messages = $this->makeMessages();
 
         $sessionId = $sessions->save(new ChatSession(publicToken: 'chat-token'));
 
@@ -65,5 +82,64 @@ final class PdoChatMessageRepositoryTest extends TestCase
         $byId = $messages->findById($messageId);
         self::assertNotNull($byId);
         self::assertStringContainsString('chunk_id', (string) $byId->citationsJson);
+    }
+
+    public function test_messages_are_isolated_by_organization(): void
+    {
+        $sessions1 = $this->makeSessions(1);
+        $sessions2 = $this->makeSessions(2);
+        $messages1 = $this->makeMessages(1);
+        $messages2 = $this->makeMessages(2);
+
+        $sessionId1 = $sessions1->save(new ChatSession(publicToken: 'isolation-org1-token'));
+        $sessionId2 = $sessions2->save(new ChatSession(publicToken: 'isolation-org2-token'));
+
+        $messages1->save(new ChatMessage(
+            sessionId: $sessionId1,
+            role: MessageRole::User,
+            content: 'org1 question',
+        ));
+
+        $messages2->save(new ChatMessage(
+            sessionId: $sessionId2,
+            role: MessageRole::User,
+            content: 'org2 question',
+        ));
+
+        // org1 repo finds its own message
+        $found1 = $messages1->findBySessionId($sessionId1, 10, 0);
+        self::assertCount(1, $found1);
+        self::assertSame('org1 question', $found1[0]->content);
+
+        // org2 repo finds its own message
+        $found2 = $messages2->findBySessionId($sessionId2, 10, 0);
+        self::assertCount(1, $found2);
+        self::assertSame('org2 question', $found2[0]->content);
+
+        // org1 cannot see org2's session messages
+        $cross = $messages1->findBySessionId($sessionId2, 10, 0);
+        self::assertCount(0, $cross);
+    }
+
+    public function test_find_by_id_does_not_cross_organization_boundary(): void
+    {
+        $sessions1 = $this->makeSessions(1);
+        $sessions2 = $this->makeSessions(2);
+        $messages1 = $this->makeMessages(1);
+        $messages2 = $this->makeMessages(2);
+
+        $sessionId1 = $sessions1->save(new ChatSession(publicToken: 'cross-msg-org1-token'));
+        $sessions2->save(new ChatSession(publicToken: 'cross-msg-org2-token'));
+
+        $msgId = $messages1->save(new ChatMessage(
+            sessionId: $sessionId1,
+            role: MessageRole::User,
+            content: 'cross org message',
+        ));
+
+        // org2 cannot find org1's message by id
+        self::assertNull($messages2->findById($msgId));
+        // org1 can find its own message
+        self::assertNotNull($messages1->findById($msgId));
     }
 }

--- a/tests/Session/CleanupChatSessionsHttpTest.php
+++ b/tests/Session/CleanupChatSessionsHttpTest.php
@@ -42,6 +42,7 @@ final class CleanupChatSessionsHttpTest extends TestCase
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
         $this->executor = $executor;
 
+        AdminHttpTestSupport::seedTenancy($executor);
         CorpusSchemaSetup::create($executor);
         ChatSchemaSetup::create($executor);
         RateLimitSchemaSetup::create($executor);
@@ -174,8 +175,8 @@ final class CleanupChatSessionsHttpTest extends TestCase
     {
         $createdAt = gmdate('Y-m-d H:i:s', time() - $daysAgo * 86400);
         $this->executor->execute(
-            'INSERT INTO chat_sessions (public_token, client_ip, user_agent, referer, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
-            [$token, null, null, null, $createdAt, $createdAt],
+            'INSERT INTO chat_sessions (organization_id, public_token, client_ip, user_agent, referer, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [1, $token, null, null, null, $createdAt, $createdAt],
         );
     }
 

--- a/tests/Session/PdoChatSessionRepositoryTest.php
+++ b/tests/Session/PdoChatSessionRepositoryTest.php
@@ -9,6 +9,7 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -33,9 +34,17 @@ final class PdoChatSessionRepositoryTest extends TestCase
         ChatSchemaSetup::create($this->executor);
     }
 
+    private function makeRepository(int $orgId = 1): PdoChatSessionRepository
+    {
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId($orgId);
+
+        return new PdoChatSessionRepository($this->executor, $holder);
+    }
+
     public function test_save_and_find_by_public_token(): void
     {
-        $repository = new PdoChatSessionRepository($this->executor);
+        $repository = $this->makeRepository();
         $id = $repository->save(new ChatSession(publicToken: 'abc123token'));
 
         $session = $repository->findByPublicToken('abc123token');
@@ -47,12 +56,74 @@ final class PdoChatSessionRepositoryTest extends TestCase
 
     public function test_find_by_id_returns_saved_session(): void
     {
-        $repository = new PdoChatSessionRepository($this->executor);
+        $repository = $this->makeRepository();
         $id = $repository->save(new ChatSession(publicToken: 'session-token'));
 
         $session = $repository->findById($id);
 
         self::assertNotNull($session);
         self::assertSame('session-token', $session->publicToken);
+    }
+
+    public function test_sessions_are_isolated_by_organization(): void
+    {
+        $repo1 = $this->makeRepository(1);
+        $repo2 = $this->makeRepository(2);
+
+        $repo1->save(new ChatSession(publicToken: 'org1-token'));
+        $repo2->save(new ChatSession(publicToken: 'org2-token'));
+
+        // org1 cannot see org2 session by public token
+        self::assertNull($repo1->findByPublicToken('org2-token'));
+        // org2 cannot see org1 session by public token
+        self::assertNull($repo2->findByPublicToken('org1-token'));
+
+        // each org sees only its own session
+        self::assertNotNull($repo1->findByPublicToken('org1-token'));
+        self::assertNotNull($repo2->findByPublicToken('org2-token'));
+    }
+
+    public function test_count_all_scoped_to_organization(): void
+    {
+        $repo1 = $this->makeRepository(1);
+        $repo2 = $this->makeRepository(2);
+
+        $repo1->save(new ChatSession(publicToken: 'org1-a'));
+        $repo1->save(new ChatSession(publicToken: 'org1-b'));
+        $repo2->save(new ChatSession(publicToken: 'org2-a'));
+
+        self::assertSame(2, $repo1->countAll());
+        self::assertSame(1, $repo2->countAll());
+    }
+
+    public function test_find_all_summaries_scoped_to_organization(): void
+    {
+        $repo1 = $this->makeRepository(1);
+        $repo2 = $this->makeRepository(2);
+
+        $repo1->save(new ChatSession(publicToken: 'org1-summary-token'));
+        $repo2->save(new ChatSession(publicToken: 'org2-summary-token'));
+
+        $summaries1 = $repo1->findAllSummaries(10, 0);
+        $summaries2 = $repo2->findAllSummaries(10, 0);
+
+        self::assertCount(1, $summaries1);
+        self::assertSame('org1-summary-token', $summaries1[0]->session->publicToken);
+
+        self::assertCount(1, $summaries2);
+        self::assertSame('org2-summary-token', $summaries2[0]->session->publicToken);
+    }
+
+    public function test_find_by_id_does_not_cross_organization_boundary(): void
+    {
+        $repo1 = $this->makeRepository(1);
+        $repo2 = $this->makeRepository(2);
+
+        $id = $repo1->save(new ChatSession(publicToken: 'cross-org-token'));
+
+        // org2 cannot access org1's session by id
+        self::assertNull($repo2->findById($id));
+        // org1 can access it
+        self::assertNotNull($repo1->findById($id));
     }
 }

--- a/tests/Settings/LlmSettingsHttpTest.php
+++ b/tests/Settings/LlmSettingsHttpTest.php
@@ -7,6 +7,7 @@ namespace NeneCorpus\Tests\Settings;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -55,6 +56,7 @@ final class LlmSettingsHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         CorpusSchemaSetup::createAdminUsers($executor);
         RateLimitSchemaSetup::create($executor);
 

--- a/tests/Source/SourceAdminHttpTest.php
+++ b/tests/Source/SourceAdminHttpTest.php
@@ -38,6 +38,7 @@ final class SourceAdminHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        AdminHttpTestSupport::seedTenancy($executor);
         AdminHttpTestSupport::seedCorpusSchema($executor);
     }
 

--- a/tests/Support/AdminHttpTestSupport.php
+++ b/tests/Support/AdminHttpTestSupport.php
@@ -27,4 +27,12 @@ final class AdminHttpTestSupport
             ['admin@example.com', $hash, $now, $now],
         );
     }
+
+    public static function seedTenancy(PdoDatabaseQueryExecutor $executor): void
+    {
+        TenancySchemaSetup::createOrganizations($executor);
+        TenancySchemaSetup::createSystemConfig($executor);
+        TenancySchemaSetup::seedDefaultOrganization($executor);
+        TenancySchemaSetup::seedSystemConfig($executor);
+    }
 }

--- a/tests/Support/ChatSchemaSetup.php
+++ b/tests/Support/ChatSchemaSetup.php
@@ -14,6 +14,7 @@ final class ChatSchemaSetup
             <<<'SQL'
                 CREATE TABLE chat_sessions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     public_token TEXT NOT NULL,
                     client_ip TEXT NULL,
                     user_agent TEXT NULL,
@@ -25,11 +26,13 @@ final class ChatSchemaSetup
         );
 
         $executor->execute('CREATE UNIQUE INDEX uniq_chat_sessions_public_token ON chat_sessions (public_token)');
+        $executor->execute('CREATE INDEX idx_chat_sessions_org_id ON chat_sessions (organization_id)');
 
         $executor->execute(
             <<<'SQL'
                 CREATE TABLE chat_messages (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     session_id INTEGER NOT NULL,
                     role TEXT NOT NULL,
                     content TEXT NOT NULL,
@@ -44,6 +47,7 @@ final class ChatSchemaSetup
         );
 
         $executor->execute('CREATE INDEX idx_chat_messages_session_id ON chat_messages (session_id)');
+        $executor->execute('CREATE INDEX idx_chat_messages_org_id ON chat_messages (organization_id)');
 
         $executor->execute(
             <<<'SQL'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,12 +5,33 @@ declare(strict_types=1);
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 
 // When running in a git worktree, the symlinked vendor autoloader resolves src/tests
-// to the main repo path. Add the worktree paths so new modules are found.
+// to the main repo path. Override classmap and PSR-4 paths so worktree files take priority.
 $worktreeRoot = dirname(__DIR__);
 $mainRepoRoot = realpath(dirname($worktreeRoot, 4)); // nene-corpus/.claude/worktrees/agent-X -> nene-corpus
 if ($mainRepoRoot !== false && $mainRepoRoot !== $worktreeRoot) {
-    $loader->addPsr4('NeneCorpus\\', [$worktreeRoot . '/src']);
-    $loader->addPsr4('NeneCorpus\\Tests\\', [$worktreeRoot . '/tests']);
+    $loader->addPsr4('NeneCorpus\\', [$worktreeRoot . '/src'], true);
+    $loader->addPsr4('NeneCorpus\\Tests\\', [$worktreeRoot . '/tests'], true);
+
+    // Override classmap entries for worktree files so they take priority over the main repo.
+    // The classmap is checked before PSR-4 in Composer's ClassLoader::findFile().
+    $worktreeClassMap = [];
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($worktreeRoot . '/src')) as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $relativePath = str_replace($worktreeRoot . '/src/', '', $file->getPathname());
+        $classNamespace = str_replace('/', '\\', substr($relativePath, 0, -4));
+        $worktreeClassMap['NeneCorpus\\' . $classNamespace] = $file->getPathname();
+    }
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($worktreeRoot . '/tests')) as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $relativePath = str_replace($worktreeRoot . '/tests/', '', $file->getPathname());
+        $classNamespace = str_replace('/', '\\', substr($relativePath, 0, -4));
+        $worktreeClassMap['NeneCorpus\\Tests\\' . $classNamespace] = $file->getPathname();
+    }
+    $loader->addClassMap($worktreeClassMap);
 }
 
 if (!isset($_ENV['NENE2_LOCAL_JWT_SECRET']) && !isset($_SERVER['NENE2_LOCAL_JWT_SECRET'])) {


### PR DESCRIPTION
Closes #276

## 内容

- `PdoChatSessionRepository` / `PdoChatMessageRepository` に `RequestScopedOrgIdHolder` 注入
- 全 SQL（SELECT / INSERT / UPDATE / DELETE / COUNT）を `WHERE organization_id = ?` でスコープ
- `SessionServiceProvider` / `MessageServiceProvider` の factory に Holder 注入を追加
- `ChatSchemaSetup`（テスト用 SQLite スキーマ）に `organization_id` カラム追加
- 既存テストに `Holder.setId(1)` 注入
- データ分離テスト追加（別 org のセッション・メッセージが listing で混ざらないこと）
- 全 HTTP テストに `AdminHttpTestSupport::seedTenancy` を追加（foundation の `OrgResolverMiddleware` 対応）
- `tests/bootstrap.php` の `addClassMap` prepend 修正（worktree src が main repo src より優先されるよう修正）

## UseCase 伝搬確認

- `CreateChatSessionUseCase` / `SendChatMessageUseCase` — Repository が Holder から org_id を取るため UseCase 変更不要
- `GenerateChatReplyUseCase` / `CorpusSearchTool` — B1（Search）の Repository 修正で吸収されるため変更不要

## チェックリスト

- docs/review/database.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)