### PR TITLE
feat(tenancy): Appearance / LlmSettings / ChatSettings / ChatLimits / Notifications を org スコープに対応する (#277)

### DIFF
--- a/src/Appearance/AppearanceServiceProvider.php
+++ b/src/Appearance/AppearanceServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Http\RuntimeServiceProvider;
 use NeneCorpus\Ingestion\UploadFilenameSanitizer;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
@@ -27,12 +28,17 @@ final readonly class AppearanceServiceProvider implements ServiceProviderInterfa
                 AppearanceSettingsRepositoryInterface::class,
                 static function (ContainerInterface $container): AppearanceSettingsRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoAppearanceSettingsRepository($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoAppearanceSettingsRepository($query, $orgIdHolder);
                 },
             )
             ->set(

--- a/src/Appearance/PdoAppearanceSettingsRepository.php
+++ b/src/Appearance/PdoAppearanceSettingsRepository.php
@@ -5,18 +5,23 @@ declare(strict_types=1);
 namespace NeneCorpus\Appearance;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoAppearanceSettingsRepository implements AppearanceSettingsRepositoryInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
     public function get(): AppearanceSettings
     {
+        $orgId = $this->orgIdHolder->getId() ?? 1;
+
         $row = $this->query->fetchOne(
-            'SELECT widget_locale, theme_json, hero_json, chat_json, layout_json, custom_css FROM appearance_settings ORDER BY id ASC LIMIT 1',
+            'SELECT widget_locale, theme_json, hero_json, chat_json, layout_json, custom_css FROM appearance_settings WHERE organization_id = ? ORDER BY id ASC LIMIT 1',
+            [$orgId],
         );
 
         if ($row === null) {
@@ -40,25 +45,26 @@ final readonly class PdoAppearanceSettingsRepository implements AppearanceSettin
 
     public function save(AppearanceSettings $settings): void
     {
+        $orgId = $this->orgIdHolder->getId() ?? 1;
         $now = gmdate('Y-m-d H:i:s');
         $themeJson = json_encode($settings->theme->toArray(), JSON_THROW_ON_ERROR);
         $heroJson = json_encode($settings->hero->toArray(), JSON_THROW_ON_ERROR);
         $chatJson = json_encode($settings->chat->toArray(), JSON_THROW_ON_ERROR);
         $layoutJson = json_encode($settings->layout->toArray(), JSON_THROW_ON_ERROR);
-        $existing = $this->query->fetchOne('SELECT id FROM appearance_settings ORDER BY id ASC LIMIT 1');
+        $existing = $this->query->fetchOne('SELECT id FROM appearance_settings WHERE organization_id = ? ORDER BY id ASC LIMIT 1', [$orgId]);
 
         if ($existing === null) {
             $this->query->execute(
-                'INSERT INTO appearance_settings (widget_locale, theme_json, hero_json, chat_json, layout_json, custom_css, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-                [$settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $settings->customCss, $now, $now],
+                'INSERT INTO appearance_settings (organization_id, widget_locale, theme_json, hero_json, chat_json, layout_json, custom_css, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                [$orgId, $settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $settings->customCss, $now, $now],
             );
 
             return;
         }
 
         $this->query->execute(
-            'UPDATE appearance_settings SET widget_locale = ?, theme_json = ?, hero_json = ?, chat_json = ?, layout_json = ?, custom_css = ?, updated_at = ? WHERE id = ?',
-            [$settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $settings->customCss, $now, (int) $existing['id']],
+            'UPDATE appearance_settings SET widget_locale = ?, theme_json = ?, hero_json = ?, chat_json = ?, layout_json = ?, custom_css = ?, updated_at = ? WHERE id = ? AND organization_id = ?',
+            [$settings->widgetLocale, $themeJson, $heroJson, $chatJson, $layoutJson, $settings->customCss, $now, (int) $existing['id'], $orgId],
         );
     }
 }

--- a/src/ChatLimits/ChatLimitsServiceProvider.php
+++ b/src/ChatLimits/ChatLimitsServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\JsonResponseFactory;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class ChatLimitsServiceProvider implements ServiceProviderInterface
@@ -22,24 +23,34 @@ final readonly class ChatLimitsServiceProvider implements ServiceProviderInterfa
                 ChatLimitsRepositoryInterface::class,
                 static function (ContainerInterface $container): ChatLimitsRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoChatLimitsRepository($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoChatLimitsRepository($query, $orgIdHolder);
                 },
             )
             ->set(
                 ChatTokenTrackerInterface::class,
                 static function (ContainerInterface $container): ChatTokenTrackerInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoChatTokenTracker($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoChatTokenTracker($query, $orgIdHolder);
                 },
             )
             ->set(

--- a/src/ChatLimits/PdoChatLimitsRepository.php
+++ b/src/ChatLimits/PdoChatLimitsRepository.php
@@ -5,21 +5,26 @@ declare(strict_types=1);
 namespace NeneCorpus\ChatLimits;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoChatLimitsRepository implements ChatLimitsRepositoryInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
     public function get(): ChatLimitsSettings
     {
+        $orgId = $this->orgIdHolder->getId() ?? 1;
+
         $row = $this->query->fetchOne(
             'SELECT max_message_chars, message_interval_seconds, session_requests_per_hour,
                     ip_requests_per_hour, daily_requests_per_ip, daily_requests_global,
                     daily_tokens_per_ip, daily_tokens_global
-             FROM chat_limits_settings ORDER BY id ASC LIMIT 1',
+             FROM chat_limits_settings WHERE organization_id = ? ORDER BY id ASC LIMIT 1',
+            [$orgId],
         );
 
         if ($row === null) {
@@ -40,18 +45,20 @@ final readonly class PdoChatLimitsRepository implements ChatLimitsRepositoryInte
 
     public function save(ChatLimitsSettings $settings): void
     {
+        $orgId = $this->orgIdHolder->getId() ?? 1;
         $now = gmdate('Y-m-d H:i:s');
-        $existing = $this->query->fetchOne('SELECT id FROM chat_limits_settings ORDER BY id ASC LIMIT 1');
+        $existing = $this->query->fetchOne('SELECT id FROM chat_limits_settings WHERE organization_id = ? ORDER BY id ASC LIMIT 1', [$orgId]);
 
         if ($existing === null) {
             $this->query->execute(
                 'INSERT INTO chat_limits_settings
-                 (max_message_chars, message_interval_seconds, session_requests_per_hour,
+                 (organization_id, max_message_chars, message_interval_seconds, session_requests_per_hour,
                   ip_requests_per_hour, daily_requests_per_ip, daily_requests_global,
                   daily_tokens_per_ip, daily_tokens_global,
                   created_at, updated_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                 [
+                    $orgId,
                     $settings->maxMessageChars,
                     $settings->messageIntervalSeconds,
                     $settings->sessionRequestsPerHour,
@@ -74,7 +81,7 @@ final readonly class PdoChatLimitsRepository implements ChatLimitsRepositoryInte
                  ip_requests_per_hour = ?, daily_requests_per_ip = ?, daily_requests_global = ?,
                  daily_tokens_per_ip = ?, daily_tokens_global = ?,
                  updated_at = ?
-             WHERE id = ?',
+             WHERE id = ? AND organization_id = ?',
             [
                 $settings->maxMessageChars,
                 $settings->messageIntervalSeconds,
@@ -86,6 +93,7 @@ final readonly class PdoChatLimitsRepository implements ChatLimitsRepositoryInte
                 $settings->dailyTokensGlobal,
                 $now,
                 (int) $existing['id'],
+                $orgId,
             ],
         );
     }

--- a/src/ChatLimits/PdoChatTokenTracker.php
+++ b/src/ChatLimits/PdoChatTokenTracker.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace NeneCorpus\ChatLimits;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 /**
  * Tracks daily token usage (input + output) in rate_limit_buckets.
  *
  * Uses a 24-hour rolling window, keyed as:
- *   chat:tokens:ip:{ip}    — per-IP daily total
- *   chat:tokens:global     — global daily total
+ *   chat:tokens:{orgId}:ip:{ip}    — per-IP daily total (org-scoped)
+ *   chat:tokens:{orgId}:global     — global daily total (org-scoped)
  *
  * hit_count stores the sum of (inputTokens + outputTokens) for each call.
  */
@@ -21,6 +22,7 @@ final readonly class PdoChatTokenTracker implements ChatTokenTrackerInterface
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
@@ -32,18 +34,24 @@ final readonly class PdoChatTokenTracker implements ChatTokenTrackerInterface
             return;
         }
 
-        $this->addToWindow('chat:tokens:ip:' . $ip, $total);
-        $this->addToWindow('chat:tokens:global', $total);
+        $orgId = $this->orgIdHolder->getId() ?? 1;
+
+        $this->addToWindow('chat:tokens:' . $orgId . ':ip:' . $ip, $total);
+        $this->addToWindow('chat:tokens:' . $orgId . ':global', $total);
     }
 
     public function dailyTokensForIp(string $ip): int
     {
-        return $this->peekWindow('chat:tokens:ip:' . $ip);
+        $orgId = $this->orgIdHolder->getId() ?? 1;
+
+        return $this->peekWindow('chat:tokens:' . $orgId . ':ip:' . $ip);
     }
 
     public function dailyTokensGlobal(): int
     {
-        return $this->peekWindow('chat:tokens:global');
+        $orgId = $this->orgIdHolder->getId() ?? 1;
+
+        return $this->peekWindow('chat:tokens:' . $orgId . ':global');
     }
 
     private function addToWindow(string $key, int $amount): void

--- a/src/ChatSettings/ChatSettingsServiceProvider.php
+++ b/src/ChatSettings/ChatSettingsServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\JsonResponseFactory;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class ChatSettingsServiceProvider implements ServiceProviderInterface
@@ -22,12 +23,17 @@ final readonly class ChatSettingsServiceProvider implements ServiceProviderInter
                 ChatSettingsRepositoryInterface::class,
                 static function (ContainerInterface $container): ChatSettingsRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoChatSettingsRepository($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoChatSettingsRepository($query, $orgIdHolder);
                 },
             )
             ->set(

--- a/src/ChatSettings/PdoChatSettingsRepository.php
+++ b/src/ChatSettings/PdoChatSettingsRepository.php
@@ -5,18 +5,23 @@ declare(strict_types=1);
 namespace NeneCorpus\ChatSettings;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoChatSettingsRepository implements ChatSettingsRepositoryInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
     public function get(): ChatSettings
     {
+        $orgId = $this->orgIdHolder->getId() ?? 1;
+
         $row = $this->query->fetchOne(
-            'SELECT system_prompt, fallback_message FROM corpus_chat_settings ORDER BY id ASC LIMIT 1',
+            'SELECT system_prompt, fallback_message FROM corpus_chat_settings WHERE organization_id = ? ORDER BY id ASC LIMIT 1',
+            [$orgId],
         );
 
         if ($row === null) {
@@ -31,21 +36,22 @@ final readonly class PdoChatSettingsRepository implements ChatSettingsRepository
 
     public function save(ChatSettings $settings): void
     {
+        $orgId = $this->orgIdHolder->getId() ?? 1;
         $now = gmdate('Y-m-d H:i:s');
-        $existing = $this->query->fetchOne('SELECT id FROM corpus_chat_settings ORDER BY id ASC LIMIT 1');
+        $existing = $this->query->fetchOne('SELECT id FROM corpus_chat_settings WHERE organization_id = ? ORDER BY id ASC LIMIT 1', [$orgId]);
 
         if ($existing === null) {
             $this->query->execute(
-                'INSERT INTO corpus_chat_settings (system_prompt, fallback_message, created_at, updated_at) VALUES (?, ?, ?, ?)',
-                [$settings->systemPrompt, $settings->fallbackMessage, $now, $now],
+                'INSERT INTO corpus_chat_settings (organization_id, system_prompt, fallback_message, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+                [$orgId, $settings->systemPrompt, $settings->fallbackMessage, $now, $now],
             );
 
             return;
         }
 
         $this->query->execute(
-            'UPDATE corpus_chat_settings SET system_prompt = ?, fallback_message = ?, updated_at = ? WHERE id = ?',
-            [$settings->systemPrompt, $settings->fallbackMessage, $now, (int) $existing['id']],
+            'UPDATE corpus_chat_settings SET system_prompt = ?, fallback_message = ?, updated_at = ? WHERE id = ? AND organization_id = ?',
+            [$settings->systemPrompt, $settings->fallbackMessage, $now, (int) $existing['id'], $orgId],
         );
     }
 }

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -17,6 +17,7 @@ use NeneCorpus\Mail\MailerInterface;
 use NeneCorpus\Mail\NullMailer;
 use NeneCorpus\Mail\SmtpConfig;
 use NeneCorpus\Mail\SmtpMailer;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class NotificationServiceProvider implements ServiceProviderInterface
@@ -38,12 +39,17 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                 DailyReportRepositoryInterface::class,
                 static function (ContainerInterface $container): DailyReportRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoDailyReportRepository($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoDailyReportRepository($query, $orgIdHolder);
                 },
             )
             ->set(
@@ -104,8 +110,9 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
             ->set(
                 RateLimitNotifier::class,
                 static function (ContainerInterface $container): RateLimitNotifier {
-                    $mailer  = $container->get(MailerInterface::class);
-                    $storage = $container->get(RateLimitStorageInterface::class);
+                    $mailer      = $container->get(MailerInterface::class);
+                    $storage     = $container->get(RateLimitStorageInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$mailer instanceof MailerInterface) {
                         throw new LogicException('Mailer service is invalid.');
@@ -115,7 +122,11 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                         throw new LogicException('RateLimitStorage service is invalid.');
                     }
 
-                    return new RateLimitNotifier($mailer, $storage);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new RateLimitNotifier($mailer, $storage, $orgIdHolder);
                 },
             )
             ->set(

--- a/src/Notification/PdoDailyReportRepository.php
+++ b/src/Notification/PdoDailyReportRepository.php
@@ -5,44 +5,49 @@ declare(strict_types=1);
 namespace NeneCorpus\Notification;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoDailyReportRepository implements DailyReportRepositoryInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
     public function getStats(string $date): DailyReportStats
     {
+        $orgId = $this->orgIdHolder->getId() ?? 1;
         $dateStart = $date . ' 00:00:00';
         $dateEnd   = $date . ' 23:59:59';
 
-        // Sessions created today
+        // Sessions created today (org-scoped)
         $sessionRow = $this->query->fetchOne(
-            'SELECT COUNT(*) AS cnt FROM chat_sessions WHERE created_at BETWEEN ? AND ?',
-            [$dateStart, $dateEnd],
+            'SELECT COUNT(*) AS cnt FROM chat_sessions WHERE organization_id = ? AND created_at BETWEEN ? AND ?',
+            [$orgId, $dateStart, $dateEnd],
         );
         $totalSessions = (int) ($sessionRow['cnt'] ?? 0);
 
-        // Messages created today
+        // Messages created today (org-scoped via session join)
         $messageRow = $this->query->fetchOne(
-            'SELECT COUNT(*) AS cnt FROM chat_messages WHERE created_at BETWEEN ? AND ?',
-            [$dateStart, $dateEnd],
+            'SELECT COUNT(*) AS cnt FROM chat_messages cm
+             JOIN chat_sessions cs ON cs.id = cm.session_id
+             WHERE cs.organization_id = ? AND cm.created_at BETWEEN ? AND ?',
+            [$orgId, $dateStart, $dateEnd],
         );
         $totalMessages = (int) ($messageRow['cnt'] ?? 0);
 
-        // Unique IPs today
+        // Unique IPs today (org-scoped)
         $ipRow = $this->query->fetchOne(
-            'SELECT COUNT(DISTINCT client_ip) AS cnt FROM chat_sessions WHERE created_at BETWEEN ? AND ?',
-            [$dateStart, $dateEnd],
+            'SELECT COUNT(DISTINCT client_ip) AS cnt FROM chat_sessions WHERE organization_id = ? AND created_at BETWEEN ? AND ?',
+            [$orgId, $dateStart, $dateEnd],
         );
         $uniqueIps = (int) ($ipRow['cnt'] ?? 0);
 
-        // Rate limit hits today: reuse bucket keys with pattern notify:ratelimit:hits:{date}
+        // Rate limit hits today: bucket key is org-prefixed
         $rateLimitRow = $this->query->fetchOne(
             'SELECT COALESCE(SUM(hit_count), 0) AS cnt FROM rate_limit_buckets WHERE bucket_key = ?',
-            ['notify:ratelimit:hits:' . $date],
+            ['notify:ratelimit:hits:' . $orgId . ':' . $date],
         );
         $rateLimitHits = (int) ($rateLimitRow['cnt'] ?? 0);
 

--- a/src/Notification/RateLimitNotifier.php
+++ b/src/Notification/RateLimitNotifier.php
@@ -7,19 +7,21 @@ namespace NeneCorpus\Notification;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Mail\MailerInterface;
 use NeneCorpus\Mail\MailMessage;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 /**
  * Fires a rate-limit-exceeded email to the operator, with cooldown to suppress burst notifications.
  */
 final readonly class RateLimitNotifier
 {
-    private const COOLDOWN_KEY = 'notify:ratelimit:cooldown';
-
     private const HITS_KEY_PREFIX = 'notify:ratelimit:hits:';
+
+    private const COOLDOWN_KEY_PREFIX = 'notify:ratelimit:cooldown:';
 
     public function __construct(
         private MailerInterface $mailer,
         private RateLimitStorageInterface $storage,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
     }
 
@@ -37,13 +39,15 @@ final readonly class RateLimitNotifier
             return;
         }
 
-        // Track daily hits regardless of cooldown
-        $today = date('Y-m-d');
-        $this->storage->hit(self::HITS_KEY_PREFIX . $today, 86400);
+        $orgId = $this->orgIdHolder->getId() ?? 1;
 
-        // Cooldown check — use 1 hit-per-window as the gate
+        // Track daily hits regardless of cooldown (org-scoped)
+        $today = date('Y-m-d');
+        $this->storage->hit(self::HITS_KEY_PREFIX . $orgId . ':' . $today, 86400);
+
+        // Cooldown check — use 1 hit-per-window as the gate (org-scoped)
         $cooldownSeconds = $config->rateLimitCooldownMinutes * 60;
-        $result = $this->storage->hit(self::COOLDOWN_KEY, $cooldownSeconds);
+        $result = $this->storage->hit(self::COOLDOWN_KEY_PREFIX . $orgId, $cooldownSeconds);
 
         if ($result['count'] > 1) {
             // Still inside cooldown window; don't send again

--- a/tests/Appearance/AppearanceHttpTest.php
+++ b/tests/Appearance/AppearanceHttpTest.php
@@ -10,6 +10,7 @@ use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use NeneCorpus\Tests\Support\SampleHeroImage;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -36,6 +37,10 @@ final class AppearanceHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        TenancySchemaSetup::createOrganizations($executor);
+        TenancySchemaSetup::createSystemConfig($executor);
+        TenancySchemaSetup::seedDefaultOrganization($executor);
+        TenancySchemaSetup::seedSystemConfig($executor);
         CorpusSchemaSetup::createAdminUsers($executor);
         RateLimitSchemaSetup::create($executor);
         CorpusSchemaSetup::createAppearanceSettings($executor);
@@ -43,8 +48,8 @@ final class AppearanceHttpTest extends TestCase
         $hash = password_hash('secret-password', PASSWORD_ARGON2ID);
         $now = gmdate('Y-m-d H:i:s');
         $executor->execute(
-            'INSERT INTO admin_users (email, password_hash, created_at, updated_at) VALUES (?, ?, ?, ?)',
-            ['admin@example.com', $hash, $now, $now],
+            'INSERT INTO admin_users (email, password_hash, role, organization_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+            ['admin@example.com', $hash, 'admin', 1, $now, $now],
         );
     }
 

--- a/tests/Appearance/PdoAppearanceSettingsRepositoryOrgIsolationTest.php
+++ b/tests/Appearance/PdoAppearanceSettingsRepositoryOrgIsolationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Appearance;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Appearance\AppearanceSettings;
+use NeneCorpus\Appearance\PdoAppearanceSettingsRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that appearance settings stored for org A are not visible to org B
+ * and vice-versa.
+ */
+final class PdoAppearanceSettingsRepositoryOrgIsolationTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private RequestScopedOrgIdHolder $orgIdHolder;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::createAppearanceSettings($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+    }
+
+    private function repoFor(int $orgId): PdoAppearanceSettingsRepository
+    {
+        $this->orgIdHolder->setId($orgId);
+
+        return new PdoAppearanceSettingsRepository($this->executor, $this->orgIdHolder);
+    }
+
+    private function settingsWithLocale(?string $locale): AppearanceSettings
+    {
+        $defaults = AppearanceSettings::defaults();
+
+        return new AppearanceSettings(
+            widgetLocale: $locale,
+            theme: $defaults->theme,
+            hero: $defaults->hero,
+            chat: $defaults->chat,
+            layout: $defaults->layout,
+            customCss: null,
+        );
+    }
+
+    public function test_save_for_org1_does_not_appear_for_org2(): void
+    {
+        $this->repoFor(1)->save($this->settingsWithLocale('ja'));
+
+        // org 2 はまだ保存していないのでデフォルト値が返る
+        $settingsOrg2 = $this->repoFor(2)->get();
+
+        self::assertNull($settingsOrg2->widgetLocale, 'org 2 は org 1 の設定を参照してはいけない');
+    }
+
+    public function test_orgs_have_independent_appearance_settings(): void
+    {
+        $this->repoFor(1)->save($this->settingsWithLocale('ja'));
+        $this->repoFor(2)->save($this->settingsWithLocale('en'));
+
+        // 再読み込みして独立していることを確認
+        self::assertSame('ja', $this->repoFor(1)->get()->widgetLocale);
+        self::assertSame('en', $this->repoFor(2)->get()->widgetLocale);
+    }
+
+    public function test_update_for_org1_does_not_affect_org2(): void
+    {
+        // 両 org に同じ設定を保存
+        $this->repoFor(1)->save($this->settingsWithLocale('en'));
+        $this->repoFor(2)->save($this->settingsWithLocale('en'));
+
+        // org 1 だけ 'ja' に更新
+        $this->repoFor(1)->save($this->settingsWithLocale('ja'));
+
+        // org 2 は 'en' のまま
+        self::assertSame('ja', $this->repoFor(1)->get()->widgetLocale);
+        self::assertSame('en', $this->repoFor(2)->get()->widgetLocale);
+    }
+}

--- a/tests/ChatLimits/PdoChatLimitsRepositoryOrgIsolationTest.php
+++ b/tests/ChatLimits/PdoChatLimitsRepositoryOrgIsolationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\ChatLimits;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\ChatLimits\ChatLimitsSettings;
+use NeneCorpus\ChatLimits\PdoChatLimitsRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\ChatLimitsSchemaSetup;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that chat-limits settings are isolated per organization.
+ */
+final class PdoChatLimitsRepositoryOrgIsolationTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+    private RequestScopedOrgIdHolder $orgIdHolder;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        ChatLimitsSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+    }
+
+    private function repoFor(int $orgId): PdoChatLimitsRepository
+    {
+        $this->orgIdHolder->setId($orgId);
+
+        return new PdoChatLimitsRepository($this->executor, $this->orgIdHolder);
+    }
+
+    private function settingsWithMaxChars(int $maxChars): ChatLimitsSettings
+    {
+        return new ChatLimitsSettings(
+            maxMessageChars: $maxChars,
+            messageIntervalSeconds: 10,
+            sessionRequestsPerHour: 20,
+            ipRequestsPerHour: 60,
+            dailyRequestsPerIp: 200,
+            dailyRequestsGlobal: 2000,
+            dailyTokensPerIp: 0,
+            dailyTokensGlobal: 0,
+        );
+    }
+
+    public function test_save_for_org1_does_not_appear_for_org2(): void
+    {
+        $this->repoFor(1)->save($this->settingsWithMaxChars(500));
+
+        // org 2 はまだ保存していないのでデフォルト値が返る
+        $defaults = ChatLimitsSettings::defaults();
+        $settingsOrg2 = $this->repoFor(2)->get();
+
+        self::assertSame($defaults->maxMessageChars, $settingsOrg2->maxMessageChars, 'org 2 は org 1 の設定を参照してはいけない');
+    }
+
+    public function test_orgs_have_independent_chat_limits(): void
+    {
+        $this->repoFor(1)->save($this->settingsWithMaxChars(300));
+        $this->repoFor(2)->save($this->settingsWithMaxChars(800));
+
+        self::assertSame(300, $this->repoFor(1)->get()->maxMessageChars);
+        self::assertSame(800, $this->repoFor(2)->get()->maxMessageChars);
+    }
+
+    public function test_update_for_org1_does_not_affect_org2(): void
+    {
+        // 両 org に同じ設定を保存
+        $this->repoFor(1)->save($this->settingsWithMaxChars(600));
+        $this->repoFor(2)->save($this->settingsWithMaxChars(600));
+
+        // org 1 だけ更新
+        $this->repoFor(1)->save($this->settingsWithMaxChars(400));
+
+        self::assertSame(400, $this->repoFor(1)->get()->maxMessageChars);
+        self::assertSame(600, $this->repoFor(2)->get()->maxMessageChars);
+    }
+}

--- a/tests/ChatLimits/PdoChatTokenTrackerTest.php
+++ b/tests/ChatLimits/PdoChatTokenTrackerTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\ChatLimits\PdoChatTokenTracker;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -25,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 final class PdoChatTokenTrackerTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+    private RequestScopedOrgIdHolder $orgIdHolder;
     private PdoChatTokenTracker $tracker;
 
     protected function setUp(): void
@@ -43,7 +45,9 @@ final class PdoChatTokenTrackerTest extends TestCase
 
         RateLimitSchemaSetup::create($this->executor);
 
-        $this->tracker = new PdoChatTokenTracker($this->executor);
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
+        $this->tracker = new PdoChatTokenTracker($this->executor, $this->orgIdHolder);
     }
 
     // ── ゼロトークン ──────────────────────────────────────────────────

--- a/tests/Notification/PdoDailyReportRepositoryTest.php
+++ b/tests/Notification/PdoDailyReportRepositoryTest.php
@@ -8,6 +8,7 @@ use Nene2\Config\DatabaseConfig;
 use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Notification\PdoDailyReportRepository;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 final class PdoDailyReportRepositoryTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+    private RequestScopedOrgIdHolder $orgIdHolder;
     private PdoDailyReportRepository $repo;
 
     protected function setUp(): void
@@ -34,7 +36,9 @@ final class PdoDailyReportRepositoryTest extends TestCase
         ChatSchemaSetup::create($this->executor);
         RateLimitSchemaSetup::create($this->executor);
 
-        $this->repo = new PdoDailyReportRepository($this->executor);
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
+        $this->repo = new PdoDailyReportRepository($this->executor, $this->orgIdHolder);
     }
 
     public function test_returns_zeros_for_empty_database(): void
@@ -107,9 +111,10 @@ final class PdoDailyReportRepositoryTest extends TestCase
     public function test_counts_rate_limit_hits_from_bucket(): void
     {
         $today = '2026-01-15';
+        $orgId = 1;
         $this->executor->execute(
             'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
-            ["notify:ratelimit:hits:{$today}", 17, time() + 86400, '2026-01-15 10:00:00'],
+            ["notify:ratelimit:hits:{$orgId}:{$today}", 17, time() + 86400, '2026-01-15 10:00:00'],
         );
 
         $stats = $this->repo->getStats($today);
@@ -128,7 +133,7 @@ final class PdoDailyReportRepositoryTest extends TestCase
     {
         $this->executor->execute(
             'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
-            ['notify:ratelimit:hits:2026-01-14', 99, time() + 86400, '2026-01-14 00:00:00'],
+            ['notify:ratelimit:hits:1:2026-01-14', 99, time() + 86400, '2026-01-14 00:00:00'],
         );
 
         $stats = $this->repo->getStats('2026-01-15');

--- a/tests/Notification/RateLimitNotifierTest.php
+++ b/tests/Notification/RateLimitNotifierTest.php
@@ -9,6 +9,7 @@ use NeneCorpus\Mail\MailerInterface;
 use NeneCorpus\Mail\MailSendException;
 use NeneCorpus\Notification\NotificationConfig;
 use NeneCorpus\Notification\RateLimitNotifier;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use PHPUnit\Framework\TestCase;
 
 final class RateLimitNotifierTest extends TestCase
@@ -24,6 +25,14 @@ final class RateLimitNotifierTest extends TestCase
         );
     }
 
+    private function makeHolder(int $orgId = 1): RequestScopedOrgIdHolder
+    {
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId($orgId);
+
+        return $holder;
+    }
+
     public function test_does_nothing_when_rate_limit_notify_disabled(): void
     {
         $mailer  = $this->createMock(MailerInterface::class);
@@ -32,7 +41,7 @@ final class RateLimitNotifierTest extends TestCase
         $mailer->expects(self::never())->method('send');
         $storage->expects(self::never())->method('hit');
 
-        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
             $this->makeConfig(enabled: false),
             'ops@example.com',
             '1.2.3.4',
@@ -48,7 +57,7 @@ final class RateLimitNotifierTest extends TestCase
         $mailer->expects(self::once())->method('isConfigured')->willReturn(false);
         $mailer->expects(self::never())->method('send');
 
-        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
             $this->makeConfig(enabled: true),
             'ops@example.com',
             '1.2.3.4',
@@ -67,7 +76,7 @@ final class RateLimitNotifierTest extends TestCase
         // Both calls: daily hits tracking + cooldown gate
         $storage->method('hit')->willReturn(['count' => 1, 'reset_at' => time() + 3600]);
 
-        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '1.2.3.4',
@@ -94,7 +103,7 @@ final class RateLimitNotifierTest extends TestCase
             },
         );
 
-        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '192.168.0.1',
@@ -112,7 +121,7 @@ final class RateLimitNotifierTest extends TestCase
         $storage->method('hit')->willReturn(['count' => 1, 'reset_at' => time() + 3600]);
 
         // Must not throw
-        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '10.0.0.1',
@@ -130,18 +139,19 @@ final class RateLimitNotifierTest extends TestCase
         $mailer->method('isConfigured')->willReturn(true);
 
         $today = date('Y-m-d');
-        $hitsKeyPrefix = 'notify:ratelimit:hits:' . $today;
+        $orgId = 1;
+        $hitsKeyPrefix = 'notify:ratelimit:hits:' . $orgId . ':' . $today;
 
         // hit() must be called for the daily hits key
         $storage->expects(self::atLeastOnce())
             ->method('hit')
             ->with(self::logicalOr(
                 self::stringStartsWith($hitsKeyPrefix),
-                self::stringStartsWith('notify:ratelimit:cooldown'),
+                self::stringStartsWith('notify:ratelimit:cooldown:'),
             ))
             ->willReturn(['count' => 2, 'reset_at' => time() + 86400]);
 
-        (new RateLimitNotifier($mailer, $storage))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder($orgId)))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '1.2.3.4',

--- a/tests/Support/ChatLimitsSchemaSetup.php
+++ b/tests/Support/ChatLimitsSchemaSetup.php
@@ -14,6 +14,7 @@ final class ChatLimitsSchemaSetup
             <<<'SQL'
                 CREATE TABLE chat_limits_settings (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     max_message_chars INTEGER NOT NULL DEFAULT 800,
                     message_interval_seconds INTEGER NOT NULL DEFAULT 10,
                     session_requests_per_hour INTEGER NOT NULL DEFAULT 20,

--- a/tests/Support/ChatSchemaSetup.php
+++ b/tests/Support/ChatSchemaSetup.php
@@ -14,6 +14,7 @@ final class ChatSchemaSetup
             <<<'SQL'
                 CREATE TABLE chat_sessions (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     public_token TEXT NOT NULL,
                     client_ip TEXT NULL,
                     user_agent TEXT NULL,
@@ -49,6 +50,7 @@ final class ChatSchemaSetup
             <<<'SQL'
                 CREATE TABLE corpus_chat_settings (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     system_prompt TEXT NULL,
                     fallback_message TEXT NULL,
                     created_at TEXT NOT NULL,

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -111,6 +111,7 @@ final class CorpusSchemaSetup
             <<<'SQL'
                 CREATE TABLE corpus_chat_settings (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     system_prompt TEXT NULL,
                     fallback_message TEXT NULL,
                     created_at TEXT NOT NULL,
@@ -126,6 +127,7 @@ final class CorpusSchemaSetup
             <<<'SQL'
                 CREATE TABLE appearance_settings (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     widget_locale TEXT NULL,
                     theme_json TEXT NOT NULL,
                     hero_json TEXT NULL,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,8 +9,10 @@ $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 $worktreeRoot = dirname(__DIR__);
 $mainRepoRoot = realpath(dirname($worktreeRoot, 4)); // nene-corpus/.claude/worktrees/agent-X -> nene-corpus
 if ($mainRepoRoot !== false && $mainRepoRoot !== $worktreeRoot) {
-    $loader->addPsr4('NeneCorpus\\', [$worktreeRoot . '/src']);
-    $loader->addPsr4('NeneCorpus\\Tests\\', [$worktreeRoot . '/tests']);
+    // Use prepend=true so worktree classes shadow the main-repo classes when both share
+    // the NeneCorpus\ namespace via the symlinked vendor autoloader.
+    $loader->addPsr4('NeneCorpus\\', [$worktreeRoot . '/src'], true);
+    $loader->addPsr4('NeneCorpus\\Tests\\', [$worktreeRoot . '/tests'], true);
 }
 
 if (!isset($_ENV['NENE2_LOCAL_JWT_SECRET']) && !isset($_SERVER['NENE2_LOCAL_JWT_SECRET'])) {


### PR DESCRIPTION
Closes #277

## 内容

- **5 Repository + RateLimitNotifier** に `RequestScopedOrgIdHolder` を注入し、全 SQL を org スコープに変更
  - `PdoAppearanceSettingsRepository` — `appearance_settings WHERE organization_id = ?`
  - `PdoChatSettingsRepository` — `corpus_chat_settings WHERE organization_id = ?`
  - `PdoChatLimitsRepository` — `chat_limits_settings WHERE organization_id = ?`
  - `PdoChatTokenTracker` — bucket_key を `chat:tokens:{orgId}:ip/{global}` 形式に変更
  - `PdoDailyReportRepository` — chat_sessions に org フィルタ、rate_limit bucket_key を `notify:ratelimit:hits:{orgId}:{date}` に変更
  - `RateLimitNotifier` — hits/cooldown bucket_key を org プレフィックス付きに変更

- **5 ServiceProvider** を更新（Holder 注入追加）

- **テストスキーマ更新**: `appearance_settings` / `corpus_chat_settings` / `chat_limits_settings` / `chat_sessions` に `organization_id` カラム追加

- **AppearanceHttpTest 修正**: B1 で導入された `OrgResolverMiddleware` が `system_config` テーブルを要求するため `TenancySchemaSetup` を追加（base branch 起因の既存失敗を修正）

- **データ分離テスト追加**（計 6 件）
  - `PdoAppearanceSettingsRepositoryOrgIsolationTest`（3 件）
  - `PdoChatLimitsRepositoryOrgIsolationTest`（3 件）

- **bootstrap.php 修正**: `addPsr4(..., true)` でワークツリーのクラスがメインリポジトリのクラスより優先されるよう修正

## LLM 設定（`.env` ベース）について

`src/Settings/` の LLM 設定（API キー・モデル）は現在 `.env` ファイルに保存されており、DB テーブルが存在しない。マルチテナント対応には `llm_settings` テーブルの新設が必要。**次 Issue 候補として報告**（本 Issue 範囲外）。

## スキーマ制約について

`appearance_settings` / `corpus_chat_settings` / `chat_limits_settings` の `organization_id` に compound unique constraint はなし（`(organization_id, id)` の unique は不要、1 org 1 行の UPSERT は WHERE で実現）。現行の migration （B1 #274）は `organization_id` の INDEX のみ追加済み。追加の constraint は不要と判断。

## チェックリスト

- [x] docs/review/database.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)