### PR TITLE
feat(tenancy): Source / Document / Chunk / Search を org スコープに対応する (#275)

### DIFF
--- a/src/Chunk/ChunkServiceProvider.php
+++ b/src/Chunk/ChunkServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class ChunkServiceProvider implements ServiceProviderInterface
@@ -18,12 +19,17 @@ final readonly class ChunkServiceProvider implements ServiceProviderInterface
             ChunkRepositoryInterface::class,
             static function (ContainerInterface $container): ChunkRepositoryInterface {
                 $query = $container->get(DatabaseQueryExecutorInterface::class);
+                $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                 if (!$query instanceof DatabaseQueryExecutorInterface) {
                     throw new LogicException('Database query executor service is invalid.');
                 }
 
-                return new PdoChunkRepository($query);
+                if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                    throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                }
+
+                return new PdoChunkRepository($query, $orgIdHolder);
             },
         );
     }

--- a/src/Chunk/PdoChunkRepository.php
+++ b/src/Chunk/PdoChunkRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Chunk;
 
+use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoChunkRepository implements ChunkRepositoryInterface
 {
@@ -15,14 +17,26 @@ final readonly class PdoChunkRepository implements ChunkRepositoryInterface
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
     }
 
     public function findById(int $id): ?Chunk
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM chunks WHERE id = ?',
-            [$id],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chunks WHERE id = ? AND organization_id = ?',
+            [$id, $this->orgId()],
         );
 
         return $row === null ? null : $this->mapRow($row);
@@ -32,8 +46,8 @@ final readonly class PdoChunkRepository implements ChunkRepositoryInterface
     public function findByDocumentId(int $documentId): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM chunks WHERE document_id = ? ORDER BY chunk_index ASC, id ASC',
-            [$documentId],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM chunks WHERE document_id = ? AND organization_id = ? ORDER BY chunk_index ASC, id ASC',
+            [$documentId, $this->orgId()],
         );
 
         return array_map(fn (array $row): Chunk => $this->mapRow($row), $rows);
@@ -46,11 +60,12 @@ final readonly class PdoChunkRepository implements ChunkRepositoryInterface
         $this->query->execute(
             <<<'SQL'
                 INSERT INTO chunks (
-                    document_id, source_id, chunk_index, content, page_number,
+                    organization_id, document_id, source_id, chunk_index, content, page_number,
                     section_label, token_count, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 SQL,
             [
+                $this->orgId(),
                 $chunk->documentId,
                 $chunk->sourceId,
                 $chunk->chunkIndex,
@@ -68,12 +83,12 @@ final readonly class PdoChunkRepository implements ChunkRepositoryInterface
 
     public function deleteByDocumentId(int $documentId): void
     {
-        $this->query->execute('DELETE FROM chunks WHERE document_id = ?', [$documentId]);
+        $this->query->execute('DELETE FROM chunks WHERE document_id = ? AND organization_id = ?', [$documentId, $this->orgId()]);
     }
 
     public function deleteBySourceId(int $sourceId): void
     {
-        $this->query->execute('DELETE FROM chunks WHERE source_id = ?', [$sourceId]);
+        $this->query->execute('DELETE FROM chunks WHERE source_id = ? AND organization_id = ?', [$sourceId, $this->orgId()]);
     }
 
     /**

--- a/src/Document/DocumentServiceProvider.php
+++ b/src/Document/DocumentServiceProvider.php
@@ -14,6 +14,7 @@ use NeneCorpus\Chunk\ChunkRepositoryInterface;
 use NeneCorpus\Http\RuntimeServiceProvider;
 use NeneCorpus\Ingestion\StoredFileWriter;
 use NeneCorpus\Source\SourceRepositoryInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -28,12 +29,17 @@ final readonly class DocumentServiceProvider implements ServiceProviderInterface
                 DocumentRepositoryInterface::class,
                 static function (ContainerInterface $container): DocumentRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoDocumentRepository($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoDocumentRepository($query, $orgIdHolder);
                 },
             )
             ->set(

--- a/src/Document/PdoDocumentRepository.php
+++ b/src/Document/PdoDocumentRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Document;
 
+use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoDocumentRepository implements DocumentRepositoryInterface
 {
@@ -14,14 +16,26 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
     }
 
     public function findById(int $id): ?Document
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM documents WHERE id = ? AND is_deleted = 0',
-            [$id],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM documents WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [$id, $this->orgId()],
         );
 
         return $row === null ? null : $this->mapRow($row);
@@ -31,8 +45,8 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
     public function findBySourceId(int $sourceId, int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM documents WHERE source_id = ? AND is_deleted = 0 ORDER BY position ASC, id ASC LIMIT ? OFFSET ?',
-            [$sourceId, $limit, $offset],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM documents WHERE source_id = ? AND organization_id = ? AND is_deleted = 0 ORDER BY position ASC, id ASC LIMIT ? OFFSET ?',
+            [$sourceId, $this->orgId(), $limit, $offset],
         );
 
         return array_map(fn (array $row): Document => $this->mapRow($row), $rows);
@@ -41,7 +55,7 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
     /** @return list<DocumentSummary> */
     public function findSummariesBySourceId(int $sourceId, int $limit, int $offset, string $query = ''): array
     {
-        [$whereExtra, $params] = $this->buildQueryCondition($sourceId, $query);
+        [$whereExtra, $extraParams] = $this->buildQueryCondition($query);
 
         $rows = $this->query->fetchAll(
             <<<SQL
@@ -61,11 +75,11 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
                         LIMIT 1
                     ) AS first_chunk_content
                 FROM documents d
-                WHERE d.source_id = ? AND d.is_deleted = 0{$whereExtra}
+                WHERE d.source_id = ? AND d.organization_id = ? AND d.is_deleted = 0{$whereExtra}
                 ORDER BY d.position ASC, d.id ASC
                 LIMIT ? OFFSET ?
                 SQL,
-            [...$params, $limit, $offset],
+            [$sourceId, $this->orgId(), ...$extraParams, $limit, $offset],
         );
 
         return array_map(function (array $row): DocumentSummary {
@@ -86,11 +100,11 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
 
     public function countBySourceId(int $sourceId, string $query = ''): int
     {
-        [$whereExtra, $params] = $this->buildQueryCondition($sourceId, $query);
+        [$whereExtra, $extraParams] = $this->buildQueryCondition($query);
 
         $row = $this->query->fetchOne(
-            "SELECT COUNT(*) AS cnt FROM documents d WHERE d.source_id = ? AND d.is_deleted = 0{$whereExtra}",
-            $params,
+            "SELECT COUNT(*) AS cnt FROM documents d WHERE d.source_id = ? AND d.organization_id = ? AND d.is_deleted = 0{$whereExtra}",
+            [$sourceId, $this->orgId(), ...$extraParams],
         );
 
         return $row === null ? 0 : (int) $row['cnt'];
@@ -103,10 +117,11 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
         $this->query->execute(
             <<<'SQL'
                 INSERT INTO documents (
-                    source_id, title, position, metadata_json, created_at, updated_at, is_deleted, deleted_at
-                ) VALUES (?, ?, ?, ?, ?, ?, 0, NULL)
+                    organization_id, source_id, title, position, metadata_json, created_at, updated_at, is_deleted, deleted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL)
                 SQL,
             [
+                $this->orgId(),
                 $document->sourceId,
                 $document->title,
                 $document->position,
@@ -126,13 +141,14 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
         }
 
         $this->query->execute(
-            'UPDATE documents SET title = ?, position = ?, metadata_json = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
+            'UPDATE documents SET title = ?, position = ?, metadata_json = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
             [
                 $document->title,
                 $document->position,
                 $document->metadataJson,
                 $this->now(),
                 $document->id,
+                $this->orgId(),
             ],
         );
     }
@@ -140,8 +156,8 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
     public function softDelete(int $id, string $deletedAt): void
     {
         $this->query->execute(
-            'UPDATE documents SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
-            [$deletedAt, $this->now(), $id],
+            'UPDATE documents SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [$deletedAt, $this->now(), $id, $this->orgId()],
         );
     }
 
@@ -169,23 +185,23 @@ final readonly class PdoDocumentRepository implements DocumentRepositoryInterfac
     }
 
     /**
-     * Returns [whereExtra, params] for optional title LIKE filter.
-     * $params already contains $sourceId as the first element.
+     * Returns [whereExtra, extraParams] for optional title LIKE filter.
+     * Caller is responsible for prepending source_id and organization_id before these params.
      *
      * @return array{string, list<mixed>}
      */
-    private function buildQueryCondition(int $sourceId, string $query): array
+    private function buildQueryCondition(string $query): array
     {
-        $params = [$sourceId];
+        $extraParams = [];
         $whereExtra = '';
 
         $q = trim($query);
 
         if ($q !== '') {
             $whereExtra = ' AND d.title LIKE ? ESCAPE \'!\'';
-            $params[] = '%' . str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $q) . '%';
+            $extraParams[] = '%' . str_replace(['!', '%', '_'], ['!!', '!%', '!_'], $q) . '%';
         }
 
-        return [$whereExtra, $params];
+        return [$whereExtra, $extraParams];
     }
 }

--- a/src/Search/PdoChunkSearchRepository.php
+++ b/src/Search/PdoChunkSearchRepository.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Search;
 
+use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryInterface
 {
@@ -18,7 +20,19 @@ final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryIn
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
     }
 
     public function search(string $query, int $limit): array
@@ -46,6 +60,7 @@ final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryIn
             $params[] = '%' . $this->escapeLike($term) . '%';
         }
 
+        $params[] = $this->orgId();
         $params[] = $limit;
 
         $scoreExpression = implode(' + ', $scoreParts);
@@ -56,7 +71,7 @@ final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryIn
             . 'FROM chunks c '
             . 'INNER JOIN sources s ON s.id = c.source_id AND s.is_deleted = 0 '
             . 'INNER JOIN documents d ON d.id = c.document_id AND d.is_deleted = 0 '
-            . 'WHERE ' . $whereExpression . ' '
+            . 'WHERE (' . $whereExpression . ') AND c.organization_id = ? '
             . 'ORDER BY relevance_score DESC, c.id ASC '
             . 'LIMIT ?',
             $params,

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class SearchServiceProvider implements ServiceProviderInterface
@@ -19,12 +20,17 @@ final readonly class SearchServiceProvider implements ServiceProviderInterface
                 ChunkSearchRepositoryInterface::class,
                 static function (ContainerInterface $container): ChunkSearchRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoChunkSearchRepository($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoChunkSearchRepository($query, $orgIdHolder);
                 },
             )
             ->set(

--- a/src/Source/PdoSourceRepository.php
+++ b/src/Source/PdoSourceRepository.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace NeneCorpus\Source;
 
 use InvalidArgumentException;
+use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoSourceRepository implements SourceRepositoryInterface
 {
@@ -16,14 +18,26 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
     ) {
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
     }
 
     public function findById(int $id): ?Source
     {
         $row = $this->query->fetchOne(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM sources WHERE id = ? AND is_deleted = 0',
-            [$id],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM sources WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [$id, $this->orgId()],
         );
 
         return $row === null ? null : $this->mapRow($row);
@@ -33,8 +47,8 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
     public function findAll(int $limit, int $offset): array
     {
         $rows = $this->query->fetchAll(
-            'SELECT ' . self::SELECT_COLUMNS . ' FROM sources WHERE is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
-            [$limit, $offset],
+            'SELECT ' . self::SELECT_COLUMNS . ' FROM sources WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC LIMIT ? OFFSET ?',
+            [$this->orgId(), $limit, $offset],
         );
 
         return array_map(fn (array $row): Source => $this->mapRow($row), $rows);
@@ -59,11 +73,11 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
                         WHERE c.source_id = s.id
                     ) AS chunk_count
                 FROM sources s
-                WHERE s.is_deleted = 0
+                WHERE s.organization_id = ? AND s.is_deleted = 0
                 ORDER BY s.id DESC
                 LIMIT ? OFFSET ?
                 SQL,
-            [$limit, $offset],
+            [$this->orgId(), $limit, $offset],
         );
 
         return array_map(
@@ -83,12 +97,13 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
         $this->query->execute(
             <<<'SQL'
                 INSERT INTO sources (
-                    name, source_type, status, storage_path, original_filename, mime_type,
+                    organization_id, name, source_type, status, storage_path, original_filename, mime_type,
                     byte_size, error_message, ingestion_config_json, created_at, updated_at,
                     is_deleted, deleted_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
                 SQL,
             [
+                $this->orgId(),
                 $source->name,
                 $source->sourceType->value,
                 $source->status->value,
@@ -118,7 +133,7 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
                     name = ?, source_type = ?, status = ?, storage_path = ?,
                     original_filename = ?, mime_type = ?, byte_size = ?, error_message = ?,
                     ingestion_config_json = ?, updated_at = ?
-                WHERE id = ? AND is_deleted = 0
+                WHERE id = ? AND organization_id = ? AND is_deleted = 0
                 SQL,
             [
                 $source->name,
@@ -132,6 +147,7 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
                 $source->ingestionConfigJson,
                 $this->now(),
                 $source->id,
+                $this->orgId(),
             ],
         );
     }
@@ -139,14 +155,14 @@ final readonly class PdoSourceRepository implements SourceRepositoryInterface
     public function softDelete(int $id, string $deletedAt): void
     {
         $this->query->execute(
-            'UPDATE sources SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND is_deleted = 0',
-            [$deletedAt, $this->now(), $id],
+            'UPDATE sources SET is_deleted = 1, deleted_at = ?, updated_at = ? WHERE id = ? AND organization_id = ? AND is_deleted = 0',
+            [$deletedAt, $this->now(), $id, $this->orgId()],
         );
     }
 
     public function countAll(): int
     {
-        $rows = $this->query->fetchAll('SELECT COUNT(*) AS cnt FROM sources WHERE is_deleted = 0', []);
+        $rows = $this->query->fetchAll('SELECT COUNT(*) AS cnt FROM sources WHERE organization_id = ? AND is_deleted = 0', [$this->orgId()]);
 
         return (int) ($rows[0]['cnt'] ?? 0);
     }

--- a/src/Source/SourceServiceProvider.php
+++ b/src/Source/SourceServiceProvider.php
@@ -12,6 +12,7 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Chunk\ChunkRepositoryInterface;
 use NeneCorpus\Document\DocumentRepositoryInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
@@ -26,12 +27,17 @@ final readonly class SourceServiceProvider implements ServiceProviderInterface
                 SourceRepositoryInterface::class,
                 static function (ContainerInterface $container): SourceRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
+                    $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoSourceRepository($query);
+                    if (!$orgIdHolder instanceof RequestScopedOrgIdHolder) {
+                        throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+                    }
+
+                    return new PdoSourceRepository($query, $orgIdHolder);
                 },
             )
             ->set(

--- a/tests/Appearance/AppearanceHttpTest.php
+++ b/tests/Appearance/AppearanceHttpTest.php
@@ -10,6 +10,7 @@ use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use NeneCorpus\Tests\Support\SampleHeroImage;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -36,6 +37,7 @@ final class AppearanceHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        TenancySchemaSetup::createAndSeed($executor);
         CorpusSchemaSetup::createAdminUsers($executor);
         RateLimitSchemaSetup::create($executor);
         CorpusSchemaSetup::createAppearanceSettings($executor);

--- a/tests/Chat/AdminChatHttpTest.php
+++ b/tests/Chat/AdminChatHttpTest.php
@@ -15,11 +15,13 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\AdminHttpTestSupport;
 use NeneCorpus\Tests\Support\ChatLimitsSchemaSetup;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
@@ -49,6 +51,7 @@ final class AdminChatHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        TenancySchemaSetup::createAndSeed($executor);
         CorpusSchemaSetup::create($executor);
         ChatSchemaSetup::create($executor);
         RateLimitSchemaSetup::create($executor);
@@ -172,20 +175,23 @@ final class AdminChatHttpTest extends TestCase
 
     private function seedCorpus(PdoDatabaseQueryExecutor $executor): void
     {
-        $sourceId = (new PdoSourceRepository($executor))->save(new Source(
+        $orgIdHolder = new RequestScopedOrgIdHolder();
+        $orgIdHolder->setId(1);
+
+        $sourceId = (new PdoSourceRepository($executor, $orgIdHolder))->save(new Source(
             name: 'Catalog',
             sourceType: SourceType::Pdf,
             status: SourceStatus::Ready,
             storagePath: 'storage/uploads/catalog.pdf',
         ));
 
-        $documentId = (new PdoDocumentRepository($executor))->save(new Document(
+        $documentId = (new PdoDocumentRepository($executor, $orgIdHolder))->save(new Document(
             sourceId: $sourceId,
             title: 'Pairings',
             position: 0,
         ));
 
-        (new PdoChunkRepository($executor))->save(new Chunk(
+        (new PdoChunkRepository($executor, $orgIdHolder))->save(new Chunk(
             documentId: $documentId,
             sourceId: $sourceId,
             content: 'Dry ginjo pairs well with white fish and light seafood dishes.',

--- a/tests/Chat/ChatHttpTest.php
+++ b/tests/Chat/ChatHttpTest.php
@@ -15,10 +15,12 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatLimitsSchemaSetup;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -43,6 +45,7 @@ final class ChatHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        TenancySchemaSetup::createAndSeed($executor);
         CorpusSchemaSetup::create($executor);
         ChatSchemaSetup::create($executor);
         RateLimitSchemaSetup::create($executor);
@@ -153,20 +156,23 @@ final class ChatHttpTest extends TestCase
 
     private function seedCorpus(PdoDatabaseQueryExecutor $executor): void
     {
-        $sourceId = (new PdoSourceRepository($executor))->save(new Source(
+        $orgIdHolder = new RequestScopedOrgIdHolder();
+        $orgIdHolder->setId(1);
+
+        $sourceId = (new PdoSourceRepository($executor, $orgIdHolder))->save(new Source(
             name: 'Catalog',
             sourceType: SourceType::Pdf,
             status: SourceStatus::Ready,
             storagePath: 'storage/uploads/catalog.pdf',
         ));
 
-        $documentId = (new PdoDocumentRepository($executor))->save(new Document(
+        $documentId = (new PdoDocumentRepository($executor, $orgIdHolder))->save(new Document(
             sourceId: $sourceId,
             title: 'Pairings',
             position: 0,
         ));
 
-        (new PdoChunkRepository($executor))->save(new Chunk(
+        (new PdoChunkRepository($executor, $orgIdHolder))->save(new Chunk(
             documentId: $documentId,
             sourceId: $sourceId,
             content: 'Dry ginjo pairs well with white fish and light seafood dishes.',

--- a/tests/ChatSettings/ChatSettingsHttpTest.php
+++ b/tests/ChatSettings/ChatSettingsHttpTest.php
@@ -9,6 +9,7 @@ use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -50,6 +51,7 @@ final class ChatSettingsHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        TenancySchemaSetup::createAndSeed($executor);
         CorpusSchemaSetup::createAdminUsers($executor);
         RateLimitSchemaSetup::create($executor);
         CorpusSchemaSetup::createChatSettings($executor);

--- a/tests/Chunk/PdoChunkRepositoryTest.php
+++ b/tests/Chunk/PdoChunkRepositoryTest.php
@@ -15,12 +15,15 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
 final class PdoChunkRepositoryTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     private int $sourceId;
 
@@ -42,7 +45,10 @@ final class PdoChunkRepositoryTest extends TestCase
 
         CorpusSchemaSetup::create($this->executor);
 
-        $sourceRepository = new PdoSourceRepository($this->executor);
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
+
+        $sourceRepository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
         $this->sourceId = $sourceRepository->save(new Source(
             name: 'Parent source',
             sourceType: SourceType::Pdf,
@@ -50,7 +56,7 @@ final class PdoChunkRepositoryTest extends TestCase
             storagePath: 'storage/uploads/parent.pdf',
         ));
 
-        $documentRepository = new PdoDocumentRepository($this->executor);
+        $documentRepository = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
         $this->documentId = $documentRepository->save(new Document(
             sourceId: $this->sourceId,
             title: 'Manual',
@@ -60,7 +66,7 @@ final class PdoChunkRepositoryTest extends TestCase
 
     public function test_save_and_find_by_id_returns_chunk(): void
     {
-        $repository = new PdoChunkRepository($this->executor);
+        $repository = new PdoChunkRepository($this->executor, $this->orgIdHolder);
         $id = $repository->save(new Chunk(
             documentId: $this->documentId,
             sourceId: $this->sourceId,
@@ -81,7 +87,7 @@ final class PdoChunkRepositoryTest extends TestCase
 
     public function test_find_by_document_id_returns_chunks_in_index_order(): void
     {
-        $repository = new PdoChunkRepository($this->executor);
+        $repository = new PdoChunkRepository($this->executor, $this->orgIdHolder);
         $repository->save(new Chunk(
             documentId: $this->documentId,
             sourceId: $this->sourceId,
@@ -100,5 +106,30 @@ final class PdoChunkRepositoryTest extends TestCase
         self::assertCount(2, $chunks);
         self::assertSame('First segment', $chunks[0]->content);
         self::assertSame('Second segment', $chunks[1]->content);
+    }
+
+    public function test_org_isolation_prevents_cross_org_access(): void
+    {
+        $org2Holder = new RequestScopedOrgIdHolder();
+        $org2Holder->setId(2);
+
+        $repoOrg1 = new PdoChunkRepository($this->executor, $this->orgIdHolder);
+        $repoOrg2 = new PdoChunkRepository($this->executor, $org2Holder);
+
+        $id = $repoOrg1->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Org 1 chunk content',
+            chunkIndex: 0,
+        ));
+
+        // Org 2 cannot see Org 1's chunk
+        self::assertNull($repoOrg2->findById($id));
+
+        // Org 1 can still see its own chunk
+        self::assertNotNull($repoOrg1->findById($id));
+
+        // Org 2 sees empty list for same document
+        self::assertSame([], $repoOrg2->findByDocumentId($this->documentId));
     }
 }

--- a/tests/Document/PdoDocumentRepositoryTest.php
+++ b/tests/Document/PdoDocumentRepositoryTest.php
@@ -13,12 +13,15 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
 final class PdoDocumentRepositoryTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     private int $sourceId;
 
@@ -38,7 +41,10 @@ final class PdoDocumentRepositoryTest extends TestCase
 
         CorpusSchemaSetup::create($this->executor);
 
-        $sourceRepository = new PdoSourceRepository($this->executor);
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
+
+        $sourceRepository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
         $this->sourceId = $sourceRepository->save(new Source(
             name: 'Parent source',
             sourceType: SourceType::Pdf,
@@ -49,7 +55,7 @@ final class PdoDocumentRepositoryTest extends TestCase
 
     public function test_save_and_find_by_id_returns_document(): void
     {
-        $repository = new PdoDocumentRepository($this->executor);
+        $repository = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
         $id = $repository->save(new Document(
             sourceId: $this->sourceId,
             title: 'Chapter 1',
@@ -67,7 +73,7 @@ final class PdoDocumentRepositoryTest extends TestCase
 
     public function test_find_by_source_id_returns_documents_in_position_order(): void
     {
-        $repository = new PdoDocumentRepository($this->executor);
+        $repository = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
         $repository->save(new Document(sourceId: $this->sourceId, title: 'Second', position: 2));
         $repository->save(new Document(sourceId: $this->sourceId, title: 'First', position: 1));
 
@@ -80,7 +86,7 @@ final class PdoDocumentRepositoryTest extends TestCase
 
     public function test_soft_delete_excludes_document_from_find_by_id(): void
     {
-        $repository = new PdoDocumentRepository($this->executor);
+        $repository = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
         $id = $repository->save(new Document(
             sourceId: $this->sourceId,
             title: 'Temporary',
@@ -90,5 +96,29 @@ final class PdoDocumentRepositoryTest extends TestCase
         $repository->softDelete($id, '2026-05-25 12:00:00');
 
         self::assertNull($repository->findById($id));
+    }
+
+    public function test_org_isolation_prevents_cross_org_access(): void
+    {
+        $org2Holder = new RequestScopedOrgIdHolder();
+        $org2Holder->setId(2);
+
+        $repoOrg1 = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
+        $repoOrg2 = new PdoDocumentRepository($this->executor, $org2Holder);
+
+        $idOrg1 = $repoOrg1->save(new Document(
+            sourceId: $this->sourceId,
+            title: 'Org 1 Document',
+            position: 0,
+        ));
+
+        // Org 2 cannot see Org 1's document
+        self::assertNull($repoOrg2->findById($idOrg1));
+
+        // Org 1 can still see its own document
+        self::assertNotNull($repoOrg1->findById($idOrg1));
+
+        // Org 2 sees empty list for same source_id
+        self::assertSame([], $repoOrg2->findBySourceId($this->sourceId, 10, 0));
     }
 }

--- a/tests/Ingestion/CreateCsvSourceUseCaseTest.php
+++ b/tests/Ingestion/CreateCsvSourceUseCaseTest.php
@@ -17,12 +17,15 @@ use NeneCorpus\Ingestion\CsvUploadValidator;
 use NeneCorpus\Ingestion\UploadStorage;
 use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
 final class CreateCsvSourceUseCaseTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     private string $uploadDirectory;
 
@@ -41,6 +44,9 @@ final class CreateCsvSourceUseCaseTest extends TestCase
         )));
 
         CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
 
         $this->uploadDirectory = sys_get_temp_dir() . '/nene-corpus-uploads-' . uniqid('', true);
         mkdir($this->uploadDirectory, 0775, true);
@@ -68,9 +74,9 @@ Widget B,Another widget,200
 CSV;
 
         $useCase = new CreateCsvSourceUseCase(
-            new PdoSourceRepository($this->executor),
-            new PdoDocumentRepository($this->executor),
-            new PdoChunkRepository($this->executor),
+            new PdoSourceRepository($this->executor, $this->orgIdHolder),
+            new PdoDocumentRepository($this->executor, $this->orgIdHolder),
+            new PdoChunkRepository($this->executor, $this->orgIdHolder),
             new CsvUploadValidator(),
             new CsvParser(),
             new UploadStorage($this->uploadDirectory),
@@ -91,13 +97,13 @@ CSV;
         self::assertSame(2, $output->documentCount);
         self::assertSame(2, $output->chunkCount);
 
-        $source = (new PdoSourceRepository($this->executor))->findById($output->sourceId);
+        $source = (new PdoSourceRepository($this->executor, $this->orgIdHolder))->findById($output->sourceId);
         self::assertNotNull($source);
         self::assertSame('csv', $source->sourceType->value);
         self::assertSame('ready', $source->status->value);
         self::assertStringStartsWith('storage/uploads/', $source->storagePath);
 
-        $documents = (new PdoDocumentRepository($this->executor))->findBySourceId($output->sourceId, 10, 0);
+        $documents = (new PdoDocumentRepository($this->executor, $this->orgIdHolder))->findBySourceId($output->sourceId, 10, 0);
         self::assertCount(2, $documents);
         self::assertSame('Widget A', $documents[0]->title);
     }

--- a/tests/Ingestion/CreatePdfSourceUseCaseTest.php
+++ b/tests/Ingestion/CreatePdfSourceUseCaseTest.php
@@ -16,6 +16,7 @@ use NeneCorpus\Ingestion\PdfUploadValidator;
 use NeneCorpus\Ingestion\UploadStorage;
 use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\SampleTextPdf;
 use PHPUnit\Framework\TestCase;
@@ -23,6 +24,8 @@ use PHPUnit\Framework\TestCase;
 final class CreatePdfSourceUseCaseTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     private string $uploadDirectory;
 
@@ -41,6 +44,9 @@ final class CreatePdfSourceUseCaseTest extends TestCase
         )));
 
         CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
 
         $this->uploadDirectory = sys_get_temp_dir() . '/nene-corpus-pdf-uploads-' . uniqid('', true);
         mkdir($this->uploadDirectory, 0775, true);
@@ -62,9 +68,9 @@ final class CreatePdfSourceUseCaseTest extends TestCase
     public function test_execute_persists_pdf_source_document_and_chunks(): void
     {
         $useCase = new CreatePdfSourceUseCase(
-            new PdoSourceRepository($this->executor),
-            new PdoDocumentRepository($this->executor),
-            new PdoChunkRepository($this->executor),
+            new PdoSourceRepository($this->executor, $this->orgIdHolder),
+            new PdoDocumentRepository($this->executor, $this->orgIdHolder),
+            new PdoChunkRepository($this->executor, $this->orgIdHolder),
             new PdfUploadValidator(),
             new PdfTextExtractor(),
             new UploadStorage($this->uploadDirectory),
@@ -80,13 +86,13 @@ final class CreatePdfSourceUseCaseTest extends TestCase
         self::assertSame(1, $output->documentCount);
         self::assertSame(1, $output->chunkCount);
 
-        $source = (new PdoSourceRepository($this->executor))->findById($output->sourceId);
+        $source = (new PdoSourceRepository($this->executor, $this->orgIdHolder))->findById($output->sourceId);
         self::assertNotNull($source);
         self::assertSame('pdf', $source->sourceType->value);
         self::assertSame('ready', $source->status->value);
 
-        $chunks = (new PdoChunkRepository($this->executor))->findByDocumentId(
-            (new PdoDocumentRepository($this->executor))->findBySourceId($output->sourceId, 1, 0)[0]->id ?? 0,
+        $chunks = (new PdoChunkRepository($this->executor, $this->orgIdHolder))->findByDocumentId(
+            (new PdoDocumentRepository($this->executor, $this->orgIdHolder))->findBySourceId($output->sourceId, 1, 0)[0]->id ?? 0,
         );
         self::assertCount(1, $chunks);
         self::assertSame(1, $chunks[0]->pageNumber);

--- a/tests/Ingestion/ReindexSourceUseCaseTest.php
+++ b/tests/Ingestion/ReindexSourceUseCaseTest.php
@@ -19,6 +19,7 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\SampleTextPdf;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +27,8 @@ use PHPUnit\Framework\TestCase;
 final class ReindexSourceUseCaseTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     private string $projectRoot;
 
@@ -47,6 +50,9 @@ final class ReindexSourceUseCaseTest extends TestCase
         )));
 
         CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
     }
 
     protected function tearDown(): void
@@ -60,9 +66,9 @@ final class ReindexSourceUseCaseTest extends TestCase
         $storagePath = 'storage/uploads/' . $storedFilename;
         file_put_contents($this->projectRoot . '/' . $storagePath, SampleTextPdf::bytes());
 
-        $sources = new PdoSourceRepository($this->executor);
-        $documents = new PdoDocumentRepository($this->executor);
-        $chunks = new PdoChunkRepository($this->executor);
+        $sources = new PdoSourceRepository($this->executor, $this->orgIdHolder);
+        $documents = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
+        $chunks = new PdoChunkRepository($this->executor, $this->orgIdHolder);
 
         $sourceId = $sources->save(new Source(
             name: 'Sample manual',

--- a/tests/Llm/GenerateChatReplyUseCaseTest.php
+++ b/tests/Llm/GenerateChatReplyUseCaseTest.php
@@ -22,6 +22,7 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\InMemoryChatSettingsRepository;
 use PHPUnit\Framework\TestCase;
@@ -44,20 +45,23 @@ final class GenerateChatReplyUseCaseTest extends TestCase
 
         CorpusSchemaSetup::create($executor);
 
-        $sourceId = (new PdoSourceRepository($executor))->save(new Source(
+        $orgIdHolder = new RequestScopedOrgIdHolder();
+        $orgIdHolder->setId(1);
+
+        $sourceId = (new PdoSourceRepository($executor, $orgIdHolder))->save(new Source(
             name: 'Catalog',
             sourceType: SourceType::Pdf,
             status: SourceStatus::Ready,
             storagePath: 'storage/uploads/catalog.pdf',
         ));
 
-        $documentId = (new PdoDocumentRepository($executor))->save(new Document(
+        $documentId = (new PdoDocumentRepository($executor, $orgIdHolder))->save(new Document(
             sourceId: $sourceId,
             title: 'Pairings',
             position: 0,
         ));
 
-        (new PdoChunkRepository($executor))->save(new Chunk(
+        (new PdoChunkRepository($executor, $orgIdHolder))->save(new Chunk(
             documentId: $documentId,
             sourceId: $sourceId,
             content: 'Dry ginjo pairs well with white fish and light seafood dishes.',
@@ -66,7 +70,7 @@ final class GenerateChatReplyUseCaseTest extends TestCase
             sectionLabel: 'Pairings',
         ));
 
-        $search = new SearchChunksUseCase(new PdoChunkSearchRepository($executor));
+        $search = new SearchChunksUseCase(new PdoChunkSearchRepository($executor, $orgIdHolder));
         $useCase = new GenerateChatReplyUseCase(
             new StubClaudeMessagesClient(),
             new CorpusSearchTool($search),

--- a/tests/Search/PdoChunkSearchRepositoryTest.php
+++ b/tests/Search/PdoChunkSearchRepositoryTest.php
@@ -16,12 +16,15 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
 final class PdoChunkSearchRepositoryTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     private PdoChunkRepository $chunks;
 
@@ -45,7 +48,10 @@ final class PdoChunkSearchRepositoryTest extends TestCase
 
         CorpusSchemaSetup::create($this->executor);
 
-        $sourceRepository = new PdoSourceRepository($this->executor);
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
+
+        $sourceRepository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
         $this->sourceId = $sourceRepository->save(new Source(
             name: 'Manual',
             sourceType: SourceType::Pdf,
@@ -53,14 +59,14 @@ final class PdoChunkSearchRepositoryTest extends TestCase
             storagePath: 'storage/uploads/manual.pdf',
         ));
 
-        $documentRepository = new PdoDocumentRepository($this->executor);
+        $documentRepository = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
         $this->documentId = $documentRepository->save(new Document(
             sourceId: $this->sourceId,
             title: 'Safety guide',
             position: 0,
         ));
 
-        $this->chunks = new PdoChunkRepository($this->executor);
+        $this->chunks = new PdoChunkRepository($this->executor, $this->orgIdHolder);
     }
 
     public function test_search_returns_chunks_matching_single_term(): void
@@ -78,7 +84,7 @@ final class PdoChunkSearchRepositoryTest extends TestCase
             chunkIndex: 1,
         ));
 
-        $results = (new PdoChunkSearchRepository($this->executor))->search('safety', 10);
+        $results = (new PdoChunkSearchRepository($this->executor, $this->orgIdHolder))->search('safety', 10);
 
         self::assertCount(1, $results);
         self::assertSame('Equipment safety instructions for operators.', $results[0]->chunk->content);
@@ -100,7 +106,7 @@ final class PdoChunkSearchRepositoryTest extends TestCase
             chunkIndex: 1,
         ));
 
-        $results = (new PdoChunkSearchRepository($this->executor))->search('equipment safety', 10);
+        $results = (new PdoChunkSearchRepository($this->executor, $this->orgIdHolder))->search('equipment safety', 10);
 
         self::assertCount(2, $results);
         self::assertSame('Equipment safety instructions for operators.', $results[0]->chunk->content);
@@ -118,9 +124,9 @@ final class PdoChunkSearchRepositoryTest extends TestCase
             chunkIndex: 0,
         ));
 
-        (new PdoSourceRepository($this->executor))->softDelete($this->sourceId, '2026-05-25 12:00:00');
+        (new PdoSourceRepository($this->executor, $this->orgIdHolder))->softDelete($this->sourceId, '2026-05-25 12:00:00');
 
-        $results = (new PdoChunkSearchRepository($this->executor))->search('safety', 10);
+        $results = (new PdoChunkSearchRepository($this->executor, $this->orgIdHolder))->search('safety', 10);
 
         self::assertSame([], $results);
     }
@@ -134,10 +140,34 @@ final class PdoChunkSearchRepositoryTest extends TestCase
             chunkIndex: 0,
         ));
 
-        (new PdoDocumentRepository($this->executor))->softDelete($this->documentId, '2026-05-25 12:00:00');
+        (new PdoDocumentRepository($this->executor, $this->orgIdHolder))->softDelete($this->documentId, '2026-05-25 12:00:00');
 
-        $results = (new PdoChunkSearchRepository($this->executor))->search('safety', 10);
+        $results = (new PdoChunkSearchRepository($this->executor, $this->orgIdHolder))->search('safety', 10);
 
         self::assertSame([], $results);
+    }
+
+    public function test_search_org_isolation_excludes_other_org_chunks(): void
+    {
+        $org2Holder = new RequestScopedOrgIdHolder();
+        $org2Holder->setId(2);
+
+        // Org 1 chunk
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Safety manual for org one operators.',
+            chunkIndex: 0,
+        ));
+
+        // Search from org 2 perspective — should return nothing
+        $results = (new PdoChunkSearchRepository($this->executor, $org2Holder))->search('safety', 10);
+
+        self::assertSame([], $results);
+
+        // Search from org 1 perspective — should return the chunk
+        $results = (new PdoChunkSearchRepository($this->executor, $this->orgIdHolder))->search('safety', 10);
+
+        self::assertCount(1, $results);
     }
 }

--- a/tests/Session/CleanupChatSessionsHttpTest.php
+++ b/tests/Session/CleanupChatSessionsHttpTest.php
@@ -12,6 +12,7 @@ use NeneCorpus\Tests\Support\ChatLimitsSchemaSetup;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -42,6 +43,7 @@ final class CleanupChatSessionsHttpTest extends TestCase
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
         $this->executor = $executor;
 
+        TenancySchemaSetup::createAndSeed($executor);
         CorpusSchemaSetup::create($executor);
         ChatSchemaSetup::create($executor);
         RateLimitSchemaSetup::create($executor);

--- a/tests/Settings/LlmSettingsHttpTest.php
+++ b/tests/Settings/LlmSettingsHttpTest.php
@@ -9,6 +9,7 @@ use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\Http\RuntimeContainerFactory;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
+use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -55,6 +56,7 @@ final class LlmSettingsHttpTest extends TestCase
         $executor = $container->get(DatabaseQueryExecutorInterface::class);
         self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
 
+        TenancySchemaSetup::createAndSeed($executor);
         CorpusSchemaSetup::createAdminUsers($executor);
         RateLimitSchemaSetup::create($executor);
 

--- a/tests/Source/DeleteSourceUseCaseTest.php
+++ b/tests/Source/DeleteSourceUseCaseTest.php
@@ -15,12 +15,15 @@ use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceNotFoundException;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
 final class DeleteSourceUseCaseTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     protected function setUp(): void
     {
@@ -37,13 +40,16 @@ final class DeleteSourceUseCaseTest extends TestCase
         )));
 
         CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
     }
 
     public function test_execute_soft_deletes_source_and_removes_chunks(): void
     {
-        $sources = new PdoSourceRepository($this->executor);
-        $documents = new PdoDocumentRepository($this->executor);
-        $chunks = new PdoChunkRepository($this->executor);
+        $sources = new PdoSourceRepository($this->executor, $this->orgIdHolder);
+        $documents = new PdoDocumentRepository($this->executor, $this->orgIdHolder);
+        $chunks = new PdoChunkRepository($this->executor, $this->orgIdHolder);
 
         $sourceId = $sources->save(new Source(
             name: 'Manual',
@@ -75,9 +81,9 @@ final class DeleteSourceUseCaseTest extends TestCase
         $this->expectException(SourceNotFoundException::class);
 
         (new DeleteSourceUseCase(
-            new PdoSourceRepository($this->executor),
-            new PdoDocumentRepository($this->executor),
-            new PdoChunkRepository($this->executor),
+            new PdoSourceRepository($this->executor, $this->orgIdHolder),
+            new PdoDocumentRepository($this->executor, $this->orgIdHolder),
+            new PdoChunkRepository($this->executor, $this->orgIdHolder),
         ))->execute(999);
     }
 }

--- a/tests/Source/PdoSourceRepositoryTest.php
+++ b/tests/Source/PdoSourceRepositoryTest.php
@@ -11,12 +11,15 @@ use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
 final class PdoSourceRepositoryTest extends TestCase
 {
     private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
 
     protected function setUp(): void
     {
@@ -33,11 +36,14 @@ final class PdoSourceRepositoryTest extends TestCase
         )));
 
         CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
     }
 
     public function test_save_returns_new_id(): void
     {
-        $repository = new PdoSourceRepository($this->executor);
+        $repository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
         $id = $repository->save(new Source(
             name: 'Manual PDF',
             sourceType: SourceType::Pdf,
@@ -53,7 +59,7 @@ final class PdoSourceRepositoryTest extends TestCase
 
     public function test_find_by_id_returns_source_when_present(): void
     {
-        $repository = new PdoSourceRepository($this->executor);
+        $repository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
         $id = $repository->save(new Source(
             name: 'Catalog CSV',
             sourceType: SourceType::Csv,
@@ -71,14 +77,14 @@ final class PdoSourceRepositoryTest extends TestCase
 
     public function test_find_by_id_returns_null_when_source_is_absent(): void
     {
-        $repository = new PdoSourceRepository($this->executor);
+        $repository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
 
         self::assertNull($repository->findById(99));
     }
 
     public function test_soft_delete_excludes_source_from_find_by_id(): void
     {
-        $repository = new PdoSourceRepository($this->executor);
+        $repository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
         $id = $repository->save(new Source(
             name: 'To delete',
             sourceType: SourceType::Pdf,
@@ -93,7 +99,7 @@ final class PdoSourceRepositoryTest extends TestCase
 
     public function test_find_all_respects_limit_and_offset(): void
     {
-        $repository = new PdoSourceRepository($this->executor);
+        $repository = new PdoSourceRepository($this->executor, $this->orgIdHolder);
 
         for ($i = 1; $i <= 3; $i++) {
             $repository->save(new Source(
@@ -108,5 +114,34 @@ final class PdoSourceRepositoryTest extends TestCase
 
         self::assertCount(1, $sources);
         self::assertSame('Source 2', $sources[0]->name);
+    }
+
+    public function test_org_isolation_prevents_cross_org_access(): void
+    {
+        $org1Holder = new RequestScopedOrgIdHolder();
+        $org1Holder->setId(1);
+
+        $org2Holder = new RequestScopedOrgIdHolder();
+        $org2Holder->setId(2);
+
+        $repoOrg1 = new PdoSourceRepository($this->executor, $org1Holder);
+        $repoOrg2 = new PdoSourceRepository($this->executor, $org2Holder);
+
+        $idOrg1 = $repoOrg1->save(new Source(
+            name: 'Org 1 Source',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Pending,
+            storagePath: 'storage/uploads/org1.pdf',
+        ));
+
+        // Org 2 cannot see Org 1's source
+        self::assertNull($repoOrg2->findById($idOrg1));
+
+        // Org 1 can still see its own source
+        self::assertNotNull($repoOrg1->findById($idOrg1));
+
+        // Org 2 sees empty list
+        self::assertSame([], $repoOrg2->findAll(10, 0));
+        self::assertSame(0, $repoOrg2->countAll());
     }
 }

--- a/tests/Support/AdminHttpTestSupport.php
+++ b/tests/Support/AdminHttpTestSupport.php
@@ -10,6 +10,7 @@ final class AdminHttpTestSupport
 {
     public static function seedCorpusSchema(PdoDatabaseQueryExecutor $executor): void
     {
+        TenancySchemaSetup::createAndSeed($executor);
         CorpusSchemaSetup::create($executor);
         RateLimitSchemaSetup::create($executor);
         self::seedAdminUser($executor);

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -14,6 +14,7 @@ final class CorpusSchemaSetup
             <<<'SQL'
                 CREATE TABLE sources (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     name TEXT NOT NULL,
                     source_type TEXT NOT NULL,
                     status TEXT NOT NULL DEFAULT 'pending',
@@ -35,6 +36,7 @@ final class CorpusSchemaSetup
             <<<'SQL'
                 CREATE TABLE documents (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     source_id INTEGER NOT NULL,
                     title TEXT NOT NULL,
                     position INTEGER NOT NULL DEFAULT 0,
@@ -52,6 +54,7 @@ final class CorpusSchemaSetup
             <<<'SQL'
                 CREATE TABLE chunks (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    organization_id INTEGER NOT NULL DEFAULT 1,
                     document_id INTEGER NOT NULL,
                     source_id INTEGER NOT NULL,
                     chunk_index INTEGER NOT NULL DEFAULT 0,

--- a/tests/Support/TenancySchemaSetup.php
+++ b/tests/Support/TenancySchemaSetup.php
@@ -71,4 +71,16 @@ final class TenancySchemaSetup
             [$now],
         );
     }
+
+    /**
+     * Creates all tenancy tables and seeds the default organization and system config.
+     * Call this in HTTP test setUp before CorpusSchemaSetup::create().
+     */
+    public static function createAndSeed(PdoDatabaseQueryExecutor $executor): void
+    {
+        self::createOrganizations($executor);
+        self::createSystemConfig($executor);
+        self::seedDefaultOrganization($executor);
+        self::seedSystemConfig($executor);
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 
 // When running in a git worktree, the symlinked vendor autoloader resolves src/tests
-// to the main repo path. Add the worktree paths so new modules are found.
+// to the main repo path. Prepend the worktree paths so modified classes take priority.
 $worktreeRoot = dirname(__DIR__);
 $mainRepoRoot = realpath(dirname($worktreeRoot, 4)); // nene-corpus/.claude/worktrees/agent-X -> nene-corpus
 if ($mainRepoRoot !== false && $mainRepoRoot !== $worktreeRoot) {
-    $loader->addPsr4('NeneCorpus\\', [$worktreeRoot . '/src']);
-    $loader->addPsr4('NeneCorpus\\Tests\\', [$worktreeRoot . '/tests']);
+    $existingSrc   = $loader->getPrefixesPsr4()['NeneCorpus\\']       ?? [];
+    $existingTests = $loader->getPrefixesPsr4()['NeneCorpus\\Tests\\'] ?? [];
+    $loader->setPsr4('NeneCorpus\\', array_merge([$worktreeRoot . '/src'], $existingSrc));
+    $loader->setPsr4('NeneCorpus\\Tests\\', array_merge([$worktreeRoot . '/tests'], $existingTests));
 }
 
 if (!isset($_ENV['NENE2_LOCAL_JWT_SECRET']) && !isset($_SERVER['NENE2_LOCAL_JWT_SECRET'])) {


### PR DESCRIPTION
Closes #275

## 内容

- `Pdo{Source,Document,Chunk,ChunkSearch}Repository` に `RequestScopedOrgIdHolder` を注入
- 全 SELECT / INSERT / UPDATE / DELETE SQL に `organization_id` スコープを追加
- `{Source,Document,Chunk,Search}ServiceProvider` の DI binding を更新
- `CorpusSchemaSetup` の `sources` / `documents` / `chunks` テーブルに `organization_id` カラム追加
- `TenancySchemaSetup::createAndSeed()` ヘルパー追加
- `AdminHttpTestSupport::seedCorpusSchema` に tenancy セットアップを組み込み
- 各リポジトリテストを `RequestScopedOrgIdHolder` を渡すよう更新
- 別 org とのデータ分離テストを Source / Document / Chunk / Search に追加（計 4 件）
- Chat / Appearance / ChatSettings / Settings / Session HTTP テストに tenancy スキーマセットアップを追加
- `tests/bootstrap.php`: worktree の `src/` が main repo より優先されるよう `setPsr4` に修正

## テスト結果

- PHPUnit: 354/355 pass（1 failure = `InstallHttpTest` は Phase A foundation 時点からの既存不具合）
- PHPStan level 8: エラーなし
- PHP CS Fixer: エラーなし

## チェックリスト

- docs/review/database.md
- docs/review/backend-api.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)