### PR TITLE
feat(admin-ui): v2 Settings に superadmin セクション（テナント解決方式 + 組織管理）を追加 (#279)

### DIFF
--- a/frontend/apps/admin/src/App.tsx
+++ b/frontend/apps/admin/src/App.tsx
@@ -22,7 +22,7 @@ function resolveRoute(): V2Route {
 
 export function App() {
   const { locale } = useLocale();
-  const { token, isReady, login, logout } = useAdminAuth();
+  const { token, profile, isReady, login, logout } = useAdminAuth();
   const [route, setRoute] = useState<V2Route>(resolveRoute);
 
   // ロケール適用（既存ロジックを維持）
@@ -82,7 +82,7 @@ export function App() {
   switch (route) {
     case 'sources':       return <SourcesPage token={token} />;
     case 'conversations': return <ConversationsPage />;
-    case 'settings':      return <SettingsPage token={token} onLogout={logout} />;
+    case 'settings':      return <SettingsPage token={token} onLogout={logout} role={profile?.role} />;
     case 'dashboard':
     default:              return <DashboardPage token={token} onLogout={logout} />;
   }

--- a/frontend/apps/admin/src/v2/pages/SettingsPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 /**
  * SettingsPage — v2 リデザイン実装 (#264)
- * 左 rail（モデル / ウィジェット / アカウント / システム）+ 右セクション切替
+ * 左 rail（モデル / ウィジェット / アカウント / システム / スーパー管理者）+ 右セクション切替
  */
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Layout } from '../Layout';
@@ -31,6 +31,8 @@ import { Msg, useMsg } from '@nene-corpus/i18n';
 import { adminApiBase } from '../../config';
 import { buildEmbedSnippet } from '../../embedSnippet';
 import { DEFAULT_WIDGET_LAYOUT } from '@nene-corpus/api-client/types';
+import { TenantResolutionSection } from './superadmin/TenantResolutionSection';
+import { OrganizationsSection } from './superadmin/OrganizationsSection';
 
 // ─────────────────────────────────────────────────────────────
 // Types
@@ -46,11 +48,14 @@ type Section =
   | 'chat-settings'
   | 'chat-limits'
   | 'notifications'
-  | 'hosting';
+  | 'hosting'
+  | 'tenant-resolution'
+  | 'organizations';
 
 interface SettingsPageProps {
   token?: string;
   onLogout?: () => void;
+  role?: 'admin' | 'superadmin';
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -1346,9 +1351,10 @@ function ChatSettingsSection({ token }: { token: string }) {
 // Main Page
 // ─────────────────────────────────────────────────────────────
 
-export function SettingsPage({ token, onLogout: _onLogout }: SettingsPageProps) {
+export function SettingsPage({ token, onLogout: _onLogout, role }: SettingsPageProps) {
   const [activeSection, setActiveSection] = useState<Section>('llm');
   const [llmConfigured, setLlmConfigured] = useState<boolean | null>(null);
+  const isSuperadmin = role === 'superadmin';
 
   // LLM 設定状態を一度だけフェッチして rail の indicator を更新
   useEffect(() => {
@@ -1370,17 +1376,19 @@ export function SettingsPage({ token, onLogout: _onLogout }: SettingsPageProps) 
 
   function renderSection(): React.ReactNode {
     switch (activeSection) {
-      case 'llm':             return <LlmSection token={token!} />;
-      case 'embed-widget':    return <EmbedWidgetSection />;
-      case 'appearance':      return <AppearanceSection token={token!} />;
-      case 'embed-snippet':   return <EmbedWidgetSection />;
-      case 'password':        return <PasswordSection token={token!} />;
-      case 'email':           return <EmailSection token={token!} />;
-      case 'chat-settings':   return <ChatSettingsSection token={token!} />;
-      case 'chat-limits':     return <ChatLimitsSection token={token!} />;
-      case 'notifications':   return <NotificationsSection token={token!} />;
-      case 'hosting':         return <HostingSection />;
-      default:                return null;
+      case 'llm':                  return <LlmSection token={token!} />;
+      case 'embed-widget':         return <EmbedWidgetSection />;
+      case 'appearance':           return <AppearanceSection token={token!} />;
+      case 'embed-snippet':        return <EmbedWidgetSection />;
+      case 'password':             return <PasswordSection token={token!} />;
+      case 'email':                return <EmailSection token={token!} />;
+      case 'chat-settings':        return <ChatSettingsSection token={token!} />;
+      case 'chat-limits':          return <ChatLimitsSection token={token!} />;
+      case 'notifications':        return <NotificationsSection token={token!} />;
+      case 'hosting':              return <HostingSection />;
+      case 'tenant-resolution':    return isSuperadmin ? <TenantResolutionSection token={token!} /> : null;
+      case 'organizations':        return isSuperadmin ? <OrganizationsSection token={token!} /> : null;
+      default:                     return null;
     }
   }
 
@@ -1434,6 +1442,14 @@ export function SettingsPage({ token, onLogout: _onLogout }: SettingsPageProps) 
           <RailItem label="チャット制限" section="chat-limits" active={activeSection} onSelect={setActiveSection} />
           <RailItem label="通知設定" section="notifications" active={activeSection} onSelect={setActiveSection} />
           <RailItem label="ホスティング" section="hosting" active={activeSection} onSelect={setActiveSection} />
+
+          {isSuperadmin && (
+            <>
+              <RailSection label="スーパー管理者" />
+              <RailItem label="テナント解決方式" section="tenant-resolution" active={activeSection} onSelect={setActiveSection} />
+              <RailItem label="組織管理" section="organizations" active={activeSection} onSelect={setActiveSection} />
+            </>
+          )}
         </aside>
 
         {/* Main panel */}

--- a/frontend/apps/admin/src/v2/pages/superadmin/OrganizationsSection.tsx
+++ b/frontend/apps/admin/src/v2/pages/superadmin/OrganizationsSection.tsx
@@ -1,0 +1,633 @@
+/**
+ * OrganizationsSection — 組織管理 CRUD UI (#279)
+ * superadmin のみに表示される。
+ */
+import { FormEvent, useEffect, useState } from 'react';
+import {
+  createOrganization,
+  deleteOrganization,
+  listOrganizations,
+  updateOrganization,
+} from '@nene-corpus/api-client/organizations';
+import type { OrganizationItem } from '@nene-corpus/api-client/organizations';
+import { ConfirmDialog } from '../../../ConfirmDialog';
+import { adminApiBase } from '../../../config';
+
+// ─── shared primitives ────────────────────────────────────────────────────────
+
+interface FormPanelProps {
+  title: string;
+  titleEn: string;
+  lead: React.ReactNode;
+  children: React.ReactNode;
+}
+
+function FormPanel({ title, titleEn, lead, children }: FormPanelProps) {
+  return (
+    <div style={{
+      background: 'var(--surface)',
+      border: '1px solid var(--hair)',
+      borderRadius: 8,
+      padding: '22px 24px 24px',
+      marginBottom: 14,
+    }}>
+      <h3 style={{
+        fontSize: 16,
+        fontWeight: 700,
+        color: 'var(--ink-strong)',
+        marginBottom: 4,
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 10,
+      }}>
+        {title}
+        <span style={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: 11,
+          fontWeight: 500,
+          color: 'var(--ink-faint)',
+          letterSpacing: '0.04em',
+        }}>
+          {titleEn}
+        </span>
+      </h3>
+      <div style={{
+        fontSize: 13,
+        color: 'var(--ink-muted)',
+        marginBottom: 20,
+        paddingBottom: 16,
+        borderBottom: '1px solid var(--hair)',
+      }}>
+        {lead}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatusMsg({ type, text }: { type: 'error' | 'success'; text: string }) {
+  return (
+    <p style={{
+      fontSize: 12.5,
+      color: type === 'error' ? 'var(--danger-text)' : 'var(--success-fg)',
+      marginTop: 8,
+    }}>
+      {text}
+    </p>
+  );
+}
+
+const PLANS = ['free', 'pro', 'enterprise'];
+
+// ─── Create form ──────────────────────────────────────────────────────────────
+
+interface CreateFormProps {
+  token: string;
+  onCreated: (org: OrganizationItem) => void;
+  onClose: () => void;
+}
+
+function CreateForm({ token, onCreated, onClose }: CreateFormProps) {
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [plan, setPlan] = useState('free');
+  const [customDomain, setCustomDomain] = useState('');
+  const [externalId, setExternalId] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const created = await createOrganization(token, {
+        name: name.trim(),
+        slug: slug.trim(),
+        plan,
+        custom_domain: customDomain.trim() !== '' ? customDomain.trim() : null,
+        external_id: externalId.trim() !== '' ? externalId.trim() : null,
+      }, adminApiBase);
+      onCreated(created);
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : '作成に失敗しました。');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{
+      background: 'var(--bg-soft)',
+      border: '1px solid var(--hair)',
+      borderRadius: 8,
+      padding: '18px 20px',
+      marginBottom: 16,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+        <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--ink-strong)' }}>
+          新しい組織を追加 // new organization
+        </span>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          style={{ fontSize: 11, padding: '2px 8px' }}
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+      <form onSubmit={(e) => void handleSubmit(e)}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          <div className="field">
+            <label className="field-label" htmlFor="new-org-name">
+              名前 <span className="en">name</span>
+              <span style={{ color: 'var(--danger)', fontSize: 11, fontWeight: 700 }}>*</span>
+            </label>
+            <input
+              id="new-org-name"
+              className="field-input"
+              type="text"
+              value={name}
+              onChange={(e) => { setName(e.target.value); }}
+              placeholder="Acme Corp"
+              required
+            />
+          </div>
+          <div className="field">
+            <label className="field-label" htmlFor="new-org-slug">
+              スラッグ <span className="en">slug</span>
+              <span style={{ color: 'var(--danger)', fontSize: 11, fontWeight: 700 }}>*</span>
+            </label>
+            <input
+              id="new-org-slug"
+              className="field-input"
+              type="text"
+              value={slug}
+              onChange={(e) => { setSlug(e.target.value); }}
+              placeholder="acme"
+              pattern="[a-z0-9]+(?:-[a-z0-9]+)*"
+              title="小文字英数字とハイフンのみ"
+              required
+            />
+            <div className="field-hint">小文字英数字とハイフンのみ</div>
+          </div>
+          <div className="field">
+            <label className="field-label" htmlFor="new-org-plan">
+              プラン <span className="en">plan</span>
+            </label>
+            <select
+              id="new-org-plan"
+              className="field-select"
+              value={plan}
+              onChange={(e) => { setPlan(e.target.value); }}
+            >
+              {PLANS.map((p) => (
+                <option key={p} value={p}>
+                  {p.charAt(0).toUpperCase() + p.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="field">
+            <label className="field-label" htmlFor="new-org-domain">
+              カスタムドメイン <span className="en">custom domain</span>
+            </label>
+            <input
+              id="new-org-domain"
+              className="field-input"
+              type="text"
+              value={customDomain}
+              onChange={(e) => { setCustomDomain(e.target.value); }}
+              placeholder="example.com"
+            />
+          </div>
+          <div className="field" style={{ gridColumn: '1 / -1' }}>
+            <label className="field-label" htmlFor="new-org-external-id">
+              外部 ID <span className="en">external id</span>
+            </label>
+            <input
+              id="new-org-external-id"
+              className="field-input"
+              type="text"
+              value={externalId}
+              onChange={(e) => { setExternalId(e.target.value); }}
+              placeholder="optional"
+            />
+          </div>
+        </div>
+        {error !== null && <StatusMsg type="error" text={error} />}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 14 }}>
+          <button className="btn btn-ghost" type="button" onClick={onClose}>キャンセル</button>
+          <button className="btn btn-primary" type="submit" disabled={saving}>
+            {saving ? '追加中…' : '組織を追加'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// ─── Edit form ────────────────────────────────────────────────────────────────
+
+interface EditFormProps {
+  token: string;
+  org: OrganizationItem;
+  onUpdated: (org: OrganizationItem) => void;
+  onClose: () => void;
+}
+
+function EditForm({ token, org, onUpdated, onClose }: EditFormProps) {
+  const [name, setName] = useState(org.name);
+  const [slug, setSlug] = useState(org.slug);
+  const [plan, setPlan] = useState(org.plan);
+  const [customDomain, setCustomDomain] = useState(org.custom_domain ?? '');
+  const [externalId, setExternalId] = useState(org.external_id ?? '');
+  const [isActive, setIsActive] = useState(org.is_active);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const updated = await updateOrganization(token, org.id, {
+        name: name.trim(),
+        slug: slug.trim(),
+        plan,
+        custom_domain: customDomain.trim() !== '' ? customDomain.trim() : null,
+        external_id: externalId.trim() !== '' ? externalId.trim() : null,
+        is_active: isActive,
+      }, adminApiBase);
+      setSuccess('保存しました。');
+      onUpdated(updated);
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : '保存に失敗しました。');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{
+      background: 'var(--bg-soft)',
+      border: '1.5px solid var(--primary-soft)',
+      borderRadius: 8,
+      padding: '18px 20px',
+      marginBottom: 16,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+        <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--ink-strong)' }}>
+          編集 // edit · <span style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 11, color: 'var(--ink-faint)' }}>id:{org.id}</span>
+        </span>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          style={{ fontSize: 11, padding: '2px 8px' }}
+          onClick={onClose}
+        >
+          ✕
+        </button>
+      </div>
+      <form onSubmit={(e) => void handleSubmit(e)}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          <div className="field">
+            <label className="field-label" htmlFor={`edit-org-name-${String(org.id)}`}>
+              名前 <span className="en">name</span>
+              <span style={{ color: 'var(--danger)', fontSize: 11, fontWeight: 700 }}>*</span>
+            </label>
+            <input
+              id={`edit-org-name-${String(org.id)}`}
+              className="field-input"
+              type="text"
+              value={name}
+              onChange={(e) => { setName(e.target.value); }}
+              required
+            />
+          </div>
+          <div className="field">
+            <label className="field-label" htmlFor={`edit-org-slug-${String(org.id)}`}>
+              スラッグ <span className="en">slug</span>
+              <span style={{ color: 'var(--danger)', fontSize: 11, fontWeight: 700 }}>*</span>
+            </label>
+            <input
+              id={`edit-org-slug-${String(org.id)}`}
+              className="field-input"
+              type="text"
+              value={slug}
+              onChange={(e) => { setSlug(e.target.value); }}
+              pattern="[a-z0-9]+(?:-[a-z0-9]+)*"
+              title="小文字英数字とハイフンのみ"
+              required
+            />
+          </div>
+          <div className="field">
+            <label className="field-label" htmlFor={`edit-org-plan-${String(org.id)}`}>
+              プラン <span className="en">plan</span>
+            </label>
+            <select
+              id={`edit-org-plan-${String(org.id)}`}
+              className="field-select"
+              value={plan}
+              onChange={(e) => { setPlan(e.target.value); }}
+            >
+              {PLANS.map((p) => (
+                <option key={p} value={p}>
+                  {p.charAt(0).toUpperCase() + p.slice(1)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="field">
+            <label className="field-label" htmlFor={`edit-org-domain-${String(org.id)}`}>
+              カスタムドメイン <span className="en">custom domain</span>
+            </label>
+            <input
+              id={`edit-org-domain-${String(org.id)}`}
+              className="field-input"
+              type="text"
+              value={customDomain}
+              onChange={(e) => { setCustomDomain(e.target.value); }}
+              placeholder="example.com"
+            />
+          </div>
+          <div className="field">
+            <label className="field-label" htmlFor={`edit-org-external-id-${String(org.id)}`}>
+              外部 ID <span className="en">external id</span>
+            </label>
+            <input
+              id={`edit-org-external-id-${String(org.id)}`}
+              className="field-input"
+              type="text"
+              value={externalId}
+              onChange={(e) => { setExternalId(e.target.value); }}
+              placeholder="optional"
+            />
+          </div>
+          <div className="field" style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 20 }}>
+            <input
+              id={`edit-org-active-${String(org.id)}`}
+              type="checkbox"
+              checked={isActive}
+              onChange={(e) => { setIsActive(e.target.checked); }}
+              style={{ accentColor: 'var(--primary)' }}
+            />
+            <label
+              htmlFor={`edit-org-active-${String(org.id)}`}
+              style={{ fontSize: 13, color: 'var(--ink)', cursor: 'pointer' }}
+            >
+              有効 // active
+            </label>
+          </div>
+        </div>
+        {error !== null && <StatusMsg type="error" text={error} />}
+        {success !== null && <StatusMsg type="success" text={success} />}
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 14 }}>
+          <button className="btn btn-ghost" type="button" onClick={onClose}>閉じる</button>
+          <button className="btn btn-primary" type="submit" disabled={saving}>
+            {saving ? '保存中…' : '保存'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// ─── Main section ─────────────────────────────────────────────────────────────
+
+interface OrganizationsSectionProps {
+  token: string;
+}
+
+export function OrganizationsSection({ token }: OrganizationsSectionProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [organizations, setOrganizations] = useState<OrganizationItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<OrganizationItem | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+
+    listOrganizations(token, adminApiBase)
+      .then((data) => {
+        if (!cancelled) {
+          setOrganizations(data.organizations);
+          setTotal(data.total);
+          setIsLoading(false);
+        }
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) {
+          setLoadError(cause instanceof Error ? cause.message : '組織一覧の読み込みに失敗しました。');
+          setIsLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [token]);
+
+  function handleCreated(org: OrganizationItem): void {
+    setOrganizations((prev) => [...prev, org]);
+    setTotal((prev) => prev + 1);
+    setShowCreateForm(false);
+  }
+
+  function handleUpdated(updated: OrganizationItem): void {
+    setOrganizations((prev) => prev.map((o) => (o.id === updated.id ? updated : o)));
+  }
+
+  async function handleConfirmDelete(): Promise<void> {
+    if (deleteTarget === null) return;
+    setIsDeleting(true);
+    try {
+      await deleteOrganization(token, deleteTarget.id, adminApiBase);
+      setOrganizations((prev) => prev.filter((o) => o.id !== deleteTarget.id));
+      setTotal((prev) => prev - 1);
+      setDeleteTarget(null);
+    } catch {
+      // keep dialog open so user sees something failed via the UI
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <>
+      <FormPanel
+        title="組織管理"
+        titleEn="// organizations"
+        lead="テナント組織の一覧・追加・編集・削除を行います。"
+      >
+        {/* Header row with add button */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', marginBottom: 14 }}>
+          {!showCreateForm && (
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={() => { setShowCreateForm(true); setEditingId(null); }}
+            >
+              + 組織を追加
+            </button>
+          )}
+        </div>
+
+        {/* Create form */}
+        {showCreateForm && (
+          <CreateForm
+            token={token}
+            onCreated={handleCreated}
+            onClose={() => { setShowCreateForm(false); }}
+          />
+        )}
+
+        {/* Edit form */}
+        {editingId !== null && (() => {
+          const org = organizations.find((o) => o.id === editingId);
+          return org !== undefined ? (
+            <EditForm
+              token={token}
+              org={org}
+              onUpdated={handleUpdated}
+              onClose={() => { setEditingId(null); }}
+            />
+          ) : null;
+        })()}
+
+        {/* Loading / error states */}
+        {isLoading && (
+          <p style={{ fontSize: 13, color: 'var(--ink-muted)' }}>読み込み中…</p>
+        )}
+        {loadError !== null && (
+          <p style={{ fontSize: 13, color: 'var(--danger-text)' }}>{loadError}</p>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && loadError === null && organizations.length === 0 && (
+          <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 10,
+            padding: '32px 16px',
+            border: '1px dashed var(--hair)',
+            borderRadius: 8,
+            textAlign: 'center',
+          }}>
+            <span style={{ fontSize: 22 }}>🏢</span>
+            <p style={{ fontSize: 13, color: 'var(--ink-muted)' }}>組織がまだありません。</p>
+            <button
+              className="btn btn-primary btn-sm"
+              type="button"
+              onClick={() => { setShowCreateForm(true); }}
+            >
+              最初の組織を追加
+            </button>
+          </div>
+        )}
+
+        {/* Table */}
+        {!isLoading && loadError === null && organizations.length > 0 && (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12.5 }}>
+              <thead>
+                <tr style={{ borderBottom: '1px solid var(--hair)', background: 'var(--bg-soft)' }}>
+                  {['ID', '名前', 'スラッグ', 'プラン', '有効', 'ドメイン', '作成日', '操作'].map((h) => (
+                    <th key={h} style={{ padding: '7px 10px', textAlign: 'left', fontWeight: 600, color: 'var(--ink-muted)', fontSize: 11, letterSpacing: '0.04em', whiteSpace: 'nowrap' }}>
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {organizations.map((org) => (
+                  <tr
+                    key={org.id}
+                    style={{
+                      borderBottom: '1px solid var(--hair)',
+                      cursor: 'pointer',
+                      background: editingId === org.id ? 'var(--primary-soft)' : 'transparent',
+                    }}
+                    onClick={() => { setEditingId(editingId === org.id ? null : org.id); setShowCreateForm(false); }}
+                  >
+                    <td style={{ padding: '7px 10px', color: 'var(--ink-faint)', fontFamily: '"JetBrains Mono", monospace' }}>{org.id}</td>
+                    <td style={{ padding: '7px 10px', color: 'var(--ink-strong)', fontWeight: 600 }}>{org.name}</td>
+                    <td style={{ padding: '7px 10px', fontFamily: '"JetBrains Mono", monospace', color: 'var(--ink-muted)' }}>{org.slug}</td>
+                    <td style={{ padding: '7px 10px' }}>
+                      <span style={{
+                        display: 'inline-flex',
+                        padding: '1px 7px',
+                        borderRadius: 20,
+                        fontSize: 11,
+                        fontWeight: 600,
+                        background: 'var(--primary-soft)',
+                        color: 'var(--primary)',
+                      }}>
+                        {org.plan}
+                      </span>
+                    </td>
+                    <td style={{ padding: '7px 10px' }}>
+                      {org.is_active ? (
+                        <span style={{ fontSize: 11, color: 'var(--success-fg)', fontWeight: 600 }}>有効</span>
+                      ) : (
+                        <span style={{ fontSize: 11, color: 'var(--ink-faint)' }}>無効</span>
+                      )}
+                    </td>
+                    <td style={{ padding: '7px 10px', color: 'var(--ink-muted)', fontFamily: '"JetBrains Mono", monospace', fontSize: 11 }}>
+                      {org.custom_domain ?? '—'}
+                    </td>
+                    <td style={{ padding: '7px 10px', color: 'var(--ink-faint)', fontSize: 11 }}>
+                      {new Date(org.created_at).toLocaleDateString('ja-JP')}
+                    </td>
+                    <td style={{ padding: '7px 10px' }} onClick={(e) => { e.stopPropagation(); }}>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <button
+                          className="btn btn-ghost"
+                          type="button"
+                          style={{ fontSize: 11, padding: '2px 8px' }}
+                          onClick={() => { setEditingId(editingId === org.id ? null : org.id); setShowCreateForm(false); }}
+                        >
+                          編集
+                        </button>
+                        <button
+                          type="button"
+                          style={{ fontSize: 11, color: 'var(--danger-text)', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px' }}
+                          onClick={() => { setDeleteTarget(org); }}
+                        >
+                          削除
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div style={{ padding: '6px 10px', fontSize: 11, color: 'var(--ink-faint)', borderTop: '1px solid var(--hair)' }}>
+              合計 {total} 件
+            </div>
+          </div>
+        )}
+      </FormPanel>
+
+      {/* Delete confirm dialog */}
+      {deleteTarget !== null && (
+        <ConfirmDialog
+          title="組織を削除"
+          description={`「${deleteTarget.name}」を削除します。この操作は取り消せません。`}
+          confirmLabel="削除"
+          variant="danger"
+          isConfirming={isDeleting}
+          onConfirm={() => { void handleConfirmDelete(); }}
+          onClose={() => { if (!isDeleting) setDeleteTarget(null); }}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/apps/admin/src/v2/pages/superadmin/TenantResolutionSection.tsx
+++ b/frontend/apps/admin/src/v2/pages/superadmin/TenantResolutionSection.tsx
@@ -1,0 +1,353 @@
+/**
+ * TenantResolutionSection — テナント解決方式設定 UI (#279)
+ * superadmin のみに表示される。
+ */
+import { FormEvent, useEffect, useState } from 'react';
+import { getSystemConfig, updateSystemConfig } from '@nene-corpus/api-client/tenancy';
+import type { SystemConfigResponse } from '@nene-corpus/api-client/tenancy';
+import { adminApiBase } from '../../../config';
+
+// ─── shared panel/field primitives (copied pattern from SettingsPage) ─────────
+
+interface FormPanelProps {
+  title: string;
+  titleEn: string;
+  lead: React.ReactNode;
+  children: React.ReactNode;
+}
+
+function FormPanel({ title, titleEn, lead, children }: FormPanelProps) {
+  return (
+    <div style={{
+      background: 'var(--surface)',
+      border: '1px solid var(--hair)',
+      borderRadius: 8,
+      padding: '22px 24px 24px',
+      marginBottom: 14,
+    }}>
+      <h3 style={{
+        fontSize: 16,
+        fontWeight: 700,
+        color: 'var(--ink-strong)',
+        marginBottom: 4,
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 10,
+      }}>
+        {title}
+        <span style={{
+          fontFamily: '"JetBrains Mono", monospace',
+          fontSize: 11,
+          fontWeight: 500,
+          color: 'var(--ink-faint)',
+          letterSpacing: '0.04em',
+        }}>
+          {titleEn}
+        </span>
+      </h3>
+      <div style={{
+        fontSize: 13,
+        color: 'var(--ink-muted)',
+        marginBottom: 20,
+        paddingBottom: 16,
+        borderBottom: '1px solid var(--hair)',
+      }}>
+        {lead}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function FormActions({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{
+      display: 'flex',
+      gap: 8,
+      justifyContent: 'flex-end',
+      paddingTop: 18,
+      marginTop: 18,
+      borderTop: '1px solid var(--hair)',
+    }}>
+      {children}
+    </div>
+  );
+}
+
+function StatusMsg({ type, text }: { type: 'error' | 'success'; text: string }) {
+  return (
+    <p style={{
+      fontSize: 12.5,
+      color: type === 'error' ? 'var(--danger-text)' : 'var(--success-fg)',
+      marginTop: 8,
+    }}>
+      {text}
+    </p>
+  );
+}
+
+// ─── MODES ────────────────────────────────────────────────────────────────────
+
+type TenantResolutionMode = 'single' | 'subdomain' | 'path';
+
+const MODES: { value: TenantResolutionMode; label: string; labelEn: string; description: string }[] = [
+  {
+    value: 'single',
+    label: 'シングルテナント（固定 org）',
+    labelEn: 'single',
+    description: 'すべてのリクエストを特定の組織に固定する。単一組織の運用に最適。',
+  },
+  {
+    value: 'subdomain',
+    label: 'サブドメイン方式',
+    labelEn: 'subdomain',
+    description: 'acme.example.com のようにサブドメインで組織を判定する。本番 SaaS 向け。',
+  },
+  {
+    value: 'path',
+    label: 'パスプレフィックス方式',
+    labelEn: 'path',
+    description: '/org/acme/... のように URL パスで組織を判定する。DNS 設定不要でシンプル。',
+  },
+];
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface TenantResolutionSectionProps {
+  token: string;
+}
+
+export function TenantResolutionSection({ token }: TenantResolutionSectionProps) {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [saved, setSaved] = useState<SystemConfigResponse | null>(null);
+
+  // draft values (undefined = not yet edited → fall back to saved)
+  const [draftMode, setDraftMode] = useState<TenantResolutionMode | undefined>(undefined);
+  const [draftOrgSlug, setDraftOrgSlug] = useState<string | undefined>(undefined);
+  const [draftBaseDomain, setDraftBaseDomain] = useState<string | undefined>(undefined);
+
+  const currentMode: TenantResolutionMode = draftMode ?? saved?.tenant_resolution_mode ?? 'single';
+  const currentOrgSlug = draftOrgSlug ?? saved?.tenant_org_slug ?? '';
+  const currentBaseDomain = draftBaseDomain ?? saved?.tenant_base_domain ?? '';
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+
+    getSystemConfig(token, adminApiBase)
+      .then((data) => {
+        if (!cancelled) {
+          setSaved(data);
+          setIsLoading(false);
+        }
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : '設定の読み込みに失敗しました。');
+          setIsLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [token]);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault();
+    setIsSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const updated = await updateSystemConfig(token, {
+        tenant_resolution_mode: currentMode,
+        tenant_org_slug: currentOrgSlug.trim(),
+        tenant_base_domain: currentBaseDomain.trim(),
+      }, adminApiBase);
+      setSaved(updated);
+      setDraftMode(undefined);
+      setDraftOrgSlug(undefined);
+      setDraftBaseDomain(undefined);
+      setSuccess('設定を保存しました。');
+    } catch (cause: unknown) {
+      setError(cause instanceof Error ? cause.message : '保存に失敗しました。');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <FormPanel
+      title="テナント解決方式"
+      titleEn="// tenant resolution"
+      lead="リクエストがどの組織に属するかを判定する方法を選択します。"
+    >
+      {isLoading ? (
+        <p style={{ fontSize: 13, color: 'var(--ink-muted)' }}>読み込み中…</p>
+      ) : (
+        <>
+          <form onSubmit={(e) => void handleSubmit(e)}>
+            {/* Radio cards */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 20 }}>
+              {MODES.map((m) => {
+                const isSelected = currentMode === m.value;
+                return (
+                  <label
+                    key={m.value}
+                    htmlFor={`mode-${m.value}`}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'flex-start',
+                      gap: 12,
+                      padding: '12px 14px',
+                      borderRadius: 7,
+                      border: isSelected
+                        ? '1.5px solid var(--primary)'
+                        : '1px solid var(--hair)',
+                      background: isSelected ? 'var(--primary-soft)' : 'var(--surface)',
+                      cursor: 'pointer',
+                      transition: 'border-color 120ms ease, background 120ms ease',
+                    }}
+                  >
+                    <input
+                      id={`mode-${m.value}`}
+                      type="radio"
+                      name="tenant_resolution_mode"
+                      value={m.value}
+                      checked={isSelected}
+                      onChange={() => { setDraftMode(m.value); }}
+                      style={{ marginTop: 3, accentColor: 'var(--primary)' }}
+                    />
+                    <div>
+                      <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--ink-strong)', display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                        {m.label}
+                        <span style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 10, fontWeight: 500, color: 'var(--ink-faint)', letterSpacing: '0.04em' }}>
+                          // {m.labelEn}
+                        </span>
+                      </div>
+                      <div style={{ fontSize: 12, color: 'var(--ink-muted)', marginTop: 3 }}>
+                        {m.description}
+                      </div>
+                    </div>
+                  </label>
+                );
+              })}
+            </div>
+
+            {/* Mode-specific auxiliary input */}
+            {currentMode === 'single' && (
+              <div className="field" style={{ marginBottom: 16 }}>
+                <label className="field-label" htmlFor="tenant-org-slug">
+                  組織スラッグ
+                  <span className="en">org slug</span>
+                </label>
+                <input
+                  id="tenant-org-slug"
+                  className="field-input"
+                  type="text"
+                  value={currentOrgSlug}
+                  onChange={(e) => { setDraftOrgSlug(e.target.value); }}
+                  placeholder="my-org"
+                  style={{ maxWidth: 280 }}
+                />
+                <div className="field-hint">すべてのリクエストをこのスラッグの組織に紐付けます。</div>
+              </div>
+            )}
+
+            {currentMode === 'subdomain' && (
+              <div className="field" style={{ marginBottom: 16 }}>
+                <label className="field-label" htmlFor="tenant-base-domain">
+                  ベースドメイン
+                  <span className="en">base domain</span>
+                </label>
+                <input
+                  id="tenant-base-domain"
+                  className="field-input"
+                  type="text"
+                  value={currentBaseDomain}
+                  onChange={(e) => { setDraftBaseDomain(e.target.value); }}
+                  placeholder="example.com"
+                  style={{ maxWidth: 280 }}
+                />
+                <div className="field-hint">
+                  例:{' '}
+                  <code style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 11 }}>example.com</code>
+                  {' '}→ リクエストの{' '}
+                  <code style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 11 }}>acme.example.com</code>
+                  {' '}から{' '}
+                  <code style={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 11 }}>acme</code>
+                  {' '}を抽出します。
+                </div>
+              </div>
+            )}
+
+            {currentMode === 'path' && (
+              <div style={{
+                background: 'var(--bg-soft)',
+                border: '1px solid var(--hair)',
+                borderRadius: 6,
+                padding: '10px 14px',
+                fontSize: 12,
+                color: 'var(--ink-muted)',
+                marginBottom: 16,
+              }}>
+                URL の先頭パスセグメントを組織スラッグとして使用します。<br />
+                例:{' '}
+                <code style={{ fontFamily: '"JetBrains Mono", monospace' }}>/acme/api/v1/…</code>
+                {' '}→{' '}
+                <code style={{ fontFamily: '"JetBrains Mono", monospace' }}>acme</code>
+              </div>
+            )}
+
+            {error !== null && <StatusMsg type="error" text={error} />}
+            {success !== null && <StatusMsg type="success" text={success} />}
+
+            <FormActions>
+              <button className="btn btn-primary" type="submit" disabled={isSaving}>
+                {isSaving ? '保存中…' : '設定を保存'}
+              </button>
+            </FormActions>
+          </form>
+
+          {/* Current saved values */}
+          {saved !== null && (
+            <div style={{
+              marginTop: 20,
+              paddingTop: 16,
+              borderTop: '1px solid var(--hair)',
+            }}>
+              <div style={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: 'var(--ink-muted)',
+                marginBottom: 10,
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                fontFamily: '"JetBrains Mono", monospace',
+              }}>
+                現在の DB 保存値 // saved config
+              </div>
+              <div className="meta-grid">
+                <span className="k">解決方式</span>
+                <span className="v mono" style={{ fontSize: 12 }}>{saved.tenant_resolution_mode}</span>
+                {saved.tenant_org_slug !== '' && (
+                  <>
+                    <span className="k">組織スラッグ</span>
+                    <span className="v mono" style={{ fontSize: 12 }}>{saved.tenant_org_slug}</span>
+                  </>
+                )}
+                {saved.tenant_resolution_mode === 'subdomain' && saved.tenant_base_domain !== '' && (
+                  <>
+                    <span className="k">ベースドメイン</span>
+                    <span className="v mono" style={{ fontSize: 12 }}>{saved.tenant_base_domain}</span>
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </FormPanel>
+  );
+}

--- a/frontend/apps/admin/tsconfig.json
+++ b/frontend/apps/admin/tsconfig.json
@@ -9,7 +9,20 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "paths": {
+      "@nene-corpus/api-client": ["../../packages/api-client/src/index.ts"],
+      "@nene-corpus/api-client/account": ["../../packages/api-client/src/account.ts"],
+      "@nene-corpus/api-client/appearance": ["../../packages/api-client/src/appearance.ts"],
+      "@nene-corpus/api-client/llm-settings": ["../../packages/api-client/src/llm-settings.ts"],
+      "@nene-corpus/api-client/chat-settings": ["../../packages/api-client/src/chat-settings.ts"],
+      "@nene-corpus/api-client/notifications": ["../../packages/api-client/src/notifications.ts"],
+      "@nene-corpus/api-client/tenancy": ["../../packages/api-client/src/tenancy.ts"],
+      "@nene-corpus/api-client/organizations": ["../../packages/api-client/src/organizations.ts"],
+      "@nene-corpus/api-client/types": ["../../packages/api-client/src/types.ts"],
+      "@nene-corpus/i18n": ["../../packages/i18n/src/index.ts"],
+      "@nene-corpus/tokens": ["../../packages/tokens/src/index.ts"]
+    }
   },
   "include": ["src"]
 }

--- a/frontend/apps/admin/vite.config.ts
+++ b/frontend/apps/admin/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       '@nene-corpus/api-client/llm-settings': resolve(appRoot, '../../packages/api-client/src/llm-settings.ts'),
       '@nene-corpus/api-client/chat-settings': resolve(appRoot, '../../packages/api-client/src/chat-settings.ts'),
       '@nene-corpus/api-client/notifications': resolve(appRoot, '../../packages/api-client/src/notifications.ts'),
+      '@nene-corpus/api-client/tenancy': resolve(appRoot, '../../packages/api-client/src/tenancy.ts'),
+      '@nene-corpus/api-client/organizations': resolve(appRoot, '../../packages/api-client/src/organizations.ts'),
       '@nene-corpus/api-client/types': resolve(appRoot, '../../packages/api-client/src/types.ts'),
       '@nene-corpus/api-client': resolve(appRoot, '../../packages/api-client/src/index.ts'),
       '@nene-corpus/i18n': resolve(appRoot, '../../packages/i18n/src/index.ts'),

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -16,6 +16,10 @@ export type { CreateSourcePayload } from './ingestion';
 export { createChatSession, sendChatMessage } from './chat';
 export { getAnalyticsSummary, getTopQuestions, buildExportUrl } from './analytics';
 export type { AnalyticsSummaryResponse, AnalyticsDailyCount, AnalyticsHourlyCount, TopQuestion, TopQuestionsResponse } from './analytics';
+export { getSystemConfig, updateSystemConfig } from './tenancy';
+export type { SystemConfigResponse, UpdateSystemConfigRequest } from './tenancy';
+export { listOrganizations, getOrganization, createOrganization, updateOrganization, deleteOrganization } from './organizations';
+export type { OrganizationItem, ListOrganizationsResponse, CreateOrganizationRequest, UpdateOrganizationRequest } from './organizations';
 export { fetchJson } from './fetch-json';
 export { DEFAULT_WIDGET_HERO, DEFAULT_WIDGET_CHAT, DEFAULT_WIDGET_LAYOUT } from './types';
 export type {

--- a/frontend/packages/api-client/src/organizations.ts
+++ b/frontend/packages/api-client/src/organizations.ts
@@ -1,0 +1,91 @@
+import { fetchJson } from './fetch-json';
+
+export interface OrganizationItem {
+  id: number;
+  name: string;
+  slug: string;
+  custom_domain: string | null;
+  plan: string;
+  is_active: boolean;
+  external_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListOrganizationsResponse {
+  organizations: OrganizationItem[];
+  total: number;
+}
+
+export interface CreateOrganizationRequest {
+  name: string;
+  slug: string;
+  plan?: string;
+  custom_domain?: string | null;
+  external_id?: string | null;
+}
+
+export type UpdateOrganizationRequest = Partial<
+  Omit<OrganizationItem, 'id' | 'created_at' | 'updated_at'>
+>;
+
+export async function listOrganizations(
+  token: string,
+  apiBase = '',
+): Promise<ListOrganizationsResponse> {
+  return fetchJson<ListOrganizationsResponse>(`${apiBase}/admin/superadmin/organizations`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export async function getOrganization(
+  token: string,
+  id: number,
+  apiBase = '',
+): Promise<OrganizationItem> {
+  return fetchJson<OrganizationItem>(`${apiBase}/admin/superadmin/organizations/${String(id)}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export async function createOrganization(
+  token: string,
+  body: CreateOrganizationRequest,
+  apiBase = '',
+): Promise<OrganizationItem> {
+  return fetchJson<OrganizationItem>(`${apiBase}/admin/superadmin/organizations`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function updateOrganization(
+  token: string,
+  id: number,
+  body: UpdateOrganizationRequest,
+  apiBase = '',
+): Promise<OrganizationItem> {
+  return fetchJson<OrganizationItem>(`${apiBase}/admin/superadmin/organizations/${String(id)}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export async function deleteOrganization(
+  token: string,
+  id: number,
+  apiBase = '',
+): Promise<void> {
+  await fetchJson<null>(`${apiBase}/admin/superadmin/organizations/${String(id)}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}

--- a/frontend/packages/api-client/src/tenancy.ts
+++ b/frontend/packages/api-client/src/tenancy.ts
@@ -1,0 +1,34 @@
+import { fetchJson } from './fetch-json';
+
+export interface SystemConfigResponse {
+  tenant_resolution_mode: 'single' | 'subdomain' | 'path';
+  tenant_org_slug: string;
+  tenant_base_domain: string;
+}
+
+export interface UpdateSystemConfigRequest {
+  tenant_resolution_mode?: 'single' | 'subdomain' | 'path';
+  tenant_org_slug?: string;
+  tenant_base_domain?: string;
+}
+
+export async function getSystemConfig(token: string, apiBase = ''): Promise<SystemConfigResponse> {
+  return fetchJson<SystemConfigResponse>(`${apiBase}/admin/superadmin/system-config`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+export async function updateSystemConfig(
+  token: string,
+  body: UpdateSystemConfigRequest,
+  apiBase = '',
+): Promise<SystemConfigResponse> {
+  return fetchJson<SystemConfigResponse>(`${apiBase}/admin/superadmin/system-config`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/frontend/packages/api-client/src/types.ts
+++ b/frontend/packages/api-client/src/types.ts
@@ -36,7 +36,7 @@ export interface LoginAdminResponse {
 export interface AdminMeResponse {
   id: number;
   email: string;
-  role: string;
+  role: 'admin' | 'superadmin';
 }
 
 export interface SourceListItem {


### PR DESCRIPTION
Closes #279

## 内容

- **API クライアント追加**
  - `frontend/packages/api-client/src/tenancy.ts` — `getSystemConfig` / `updateSystemConfig`
  - `frontend/packages/api-client/src/organizations.ts` — `listOrganizations` / `getOrganization` / `createOrganization` / `updateOrganization` / `deleteOrganization`
  - `index.ts` から re-export、`vite.config.ts` + `tsconfig.json` に alias 追加
- **AdminMeResponse 型更新** — `role: string` → `role: 'admin' | 'superadmin'`
- **v2 Settings に「スーパー管理者」グループ追加** — `isSuperadmin` ガードで superadmin のみ表示
  - テナント解決方式: 3 mode ラジオ UI（single / subdomain / path）+ モード別補助入力 + DB 保存値表示
  - 組織管理: 一覧テーブル / 追加フォーム / 行クリック編集 / 削除（既存 ConfirmDialog 流用）

## チェックリスト

- docs/review/backend-api.md（API クライアント型追加）

## typecheck

`npm run typecheck --prefix frontend/apps/admin` → pass（エラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)