### PR TITLE
feat(admin-ui): v2 画面の deep-link URL を実装する (#303)

### DIFF
--- a/frontend/apps/admin/src/v2/Sidebar.tsx
+++ b/frontend/apps/admin/src/v2/Sidebar.tsx
@@ -54,9 +54,9 @@ export function Sidebar({ active, corpusStatus = '3 / 4 取り込み済み', mod
   ];
 
   const navModel: NavItemDef[] = [
-    { id: 'llm',        ja: 'LLM',    route: '/settings',     icon: <LlmIcon />,        dot: modelStatus },
-    { id: 'embeddings', ja: '埋め込み', route: '/settings',   icon: <EmbeddingsIcon /> },
-    { id: 'appearance', ja: '外観',   route: '/settings',     icon: <AppearanceIcon /> },
+    { id: 'llm',        ja: 'LLM',    route: '/settings/llm',        icon: <LlmIcon />,        dot: modelStatus },
+    { id: 'embeddings', ja: '埋め込み', route: '/settings/model',     icon: <EmbeddingsIcon /> },
+    { id: 'appearance', ja: '外観',   route: '/settings/widget',     icon: <AppearanceIcon /> },
   ];
 
   const navSystem: NavItemDef[] = [

--- a/frontend/apps/admin/src/v2/pages/ConversationsPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/ConversationsPage.tsx
@@ -20,6 +20,7 @@ import { formatTimestamp, useLocale } from '@nene-corpus/i18n';
 import { adminApiBase } from '../../config';
 import { useAdminAuth } from '../../useAdminAuth';
 import { Layout } from '../Layout';
+import { useRoute, useNavigate } from '../router';
 import { formatClientIp } from '../../conversationLogsFormat';
 
 // ─── 定数 ────────────────────────────────────────────────────────────────────
@@ -572,6 +573,8 @@ interface ConversationsPageProps {
 export function ConversationsPage({ onLogout }: ConversationsPageProps = {}) {
   const { token } = useAdminAuth();
   const { locale } = useLocale();
+  const route = useRoute();
+  const navigate = useNavigate();
 
   // ── KPI ステート ──────────────────────────────────────────────────────────
   const [kpiSessions, setKpiSessions] = useState<number | null>(null);
@@ -662,6 +665,14 @@ export function ConversationsPage({ onLogout }: ConversationsPageProps = {}) {
     void loadSessions(page, ctrl.signal);
     return () => ctrl.abort();
   }, [loadSessions, page]);
+
+  // URL → 選択同期（/conversations/{sessionId} の deep link）
+  useEffect(() => {
+    const m = /^\/conversations\/(\d+)/.exec(route);
+    if (m === null) return;
+    const id = Number(m[1]);
+    setSelectedId((prev) => (prev === id ? prev : id));
+  }, [route]);
 
   // ── 古いログ整理 (#6) ──────────────────────────────────────────────────────
   function openCleanup() {
@@ -840,6 +851,7 @@ export function ConversationsPage({ onLogout }: ConversationsPageProps = {}) {
           onSelect={(id) => {
             setSelectedId(id);
             setMessages([]);
+            navigate(`/conversations/${String(id)}`);
           }}
           total={total}
           page={page}
@@ -865,7 +877,7 @@ export function ConversationsPage({ onLogout }: ConversationsPageProps = {}) {
             messages={messages}
             isLoading={isLoadingMessages}
             error={messagesError}
-            onClose={() => setSelectedId(null)}
+            onClose={() => { setSelectedId(null); navigate('/conversations'); }}
             locale={locale}
           />
         ) : (

--- a/frontend/apps/admin/src/v2/pages/SettingsPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@
  */
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Layout } from '../Layout';
+import { useRoute, useNavigate } from '../router';
 import { getLlmSettings, testLlmConnection, updateLlmSettings } from '@nene-corpus/api-client/llm-settings';
 import { getChatSettings, updateChatSettings } from '@nene-corpus/api-client/chat-settings';
 import { getChatLimitsSettings, updateChatLimitsSettings } from '@nene-corpus/api-client';
@@ -1396,10 +1397,33 @@ function ChatSettingsSection({ token }: { token: string }) {
 
 type SettingsTab = 'model' | 'widget' | 'account' | 'system';
 
+// URL セグメント → タブ（サイドバーの semantic 名も解決）
+const TAB_ALIASES: Record<string, SettingsTab> = {
+  model: 'model', llm: 'model', embeddings: 'model',
+  widget: 'widget', appearance: 'widget',
+  account: 'account',
+  system: 'system', superadmin: 'system',
+};
+
 export function SettingsPage({ token, onLogout, role }: SettingsPageProps) {
+  const route = useRoute();
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<SettingsTab>('model');
   const [llmConfigured, setLlmConfigured] = useState<boolean | null>(null);
   const isSuperadmin = role === 'superadmin';
+
+  // URL → タブ同期（/settings/{tab}・/settings/llm 等の deep link）
+  useEffect(() => {
+    const seg = /^\/settings\/([a-z-]+)/.exec(route)?.[1];
+    if (seg !== undefined && TAB_ALIASES[seg] !== undefined) {
+      setActiveTab(TAB_ALIASES[seg]);
+    }
+  }, [route]);
+
+  function selectTab(tab: SettingsTab): void {
+    setActiveTab(tab);
+    navigate(`/settings/${tab}`);
+  }
 
   // LLM 設定状態を一度だけフェッチして rail の indicator を更新
   useEffect(() => {
@@ -1483,7 +1507,7 @@ export function SettingsPage({ token, onLogout, role }: SettingsPageProps) {
         <button
           type="button"
           className={activeTab === 'model' ? 'on' : undefined}
-          onClick={() => setActiveTab('model')}
+          onClick={() => selectTab('model')}
         >
           モデル
           {llmConfigured === false && <span className="dot" aria-label="未設定" />}
@@ -1492,21 +1516,21 @@ export function SettingsPage({ token, onLogout, role }: SettingsPageProps) {
         <button
           type="button"
           className={activeTab === 'widget' ? 'on' : undefined}
-          onClick={() => setActiveTab('widget')}
+          onClick={() => selectTab('widget')}
         >
           ウィジェット
         </button>
         <button
           type="button"
           className={activeTab === 'account' ? 'on' : undefined}
-          onClick={() => setActiveTab('account')}
+          onClick={() => selectTab('account')}
         >
           アカウント
         </button>
         <button
           type="button"
           className={activeTab === 'system' ? 'on' : undefined}
-          onClick={() => setActiveTab('system')}
+          onClick={() => selectTab('system')}
         >
           システム
         </button>

--- a/frontend/apps/admin/src/v2/pages/SourcesPage.tsx
+++ b/frontend/apps/admin/src/v2/pages/SourcesPage.tsx
@@ -27,6 +27,7 @@ import { adminApiBase } from '../../config';
 import { detectSourceType, readFileAsBase64 } from '../../fileBase64';
 import { ConfirmDialog } from '../../ConfirmDialog';
 import { Layout } from '../Layout';
+import { useRoute, useNavigate } from '../router';
 
 // ── SVG アイコン ────────────────────────────────────────────────────
 
@@ -99,6 +100,8 @@ interface SourcesPageProps {
 // ── SourcesPage (メイン) ──────────────────────────────────────────
 
 export function SourcesPage({ token, onLogout }: SourcesPageProps) {
+  const route = useRoute();
+  const navigate = useNavigate();
   const [sources, setSources] = useState<SourceListItem[]>([]);
   const [totalSources, setTotalSources] = useState(0);
   const [isLoadingSources, setIsLoadingSources] = useState(true);
@@ -183,6 +186,21 @@ export function SourcesPage({ token, onLogout }: SourcesPageProps) {
     return () => controller.abort();
   }, [load, reloadKey]);
 
+  // URL → 選択同期（/sources/{id} の deep link）
+  useEffect(() => {
+    const idMatch = /^\/sources\/(\d+)/.exec(route);
+    if (idMatch === null) return;
+    const id = Number(idMatch[1]);
+    if (selectedSource?.source_id === id) return;
+    const found = sources.find((s) => s.source_id === id);
+    if (found !== undefined) setSelectedSource(found);
+  }, [route, sources, selectedSource]);
+
+  function selectSource(source: SourceListItem): void {
+    setSelectedSource(source);
+    navigate(`/sources/${source.source_id}`);
+  }
+
   function handleUploaded() {
     setReloadKey(k => k + 1);
   }
@@ -194,6 +212,7 @@ export function SourcesPage({ token, onLogout }: SourcesPageProps) {
     setConfirmTarget(null);
     if (selectedSource?.source_id === target.source_id) {
       setSelectedSource(null);
+      navigate('/sources');
     }
     try {
       await deleteSource(token, target.source_id, adminApiBase);
@@ -350,7 +369,7 @@ export function SourcesPage({ token, onLogout }: SourcesPageProps) {
                       source={source}
                       isSelected={selectedSource?.source_id === source.source_id}
                       isDeleting={deletingId === source.source_id}
-                      onClick={() => setSelectedSource(source)}
+                      onClick={() => selectSource(source)}
                       onDelete={() => setConfirmTarget(source)}
                       onEdit={() => openEdit(source)}
                     />


### PR DESCRIPTION
## 概要
Sources / Conversations / Settings の選択状態・タブを URL に反映（共有可能 URL・ブラウザ戻る進む対応）。旧 #297 を 4タブ Settings に合わせて再実装。

- `/sources/{id}` ソース自動選択
- `/conversations/{sessionId}` セッション自動選択
- `/settings/{tab}`（model/widget/account/system、llm/appearance 等の別名も解決）

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)