### PR TITLE
fix(admin-ui): 「本番」環境表示を chrome から削除する

### DIFF
--- a/frontend/apps/admin/src/v2/Statusbar.tsx
+++ b/frontend/apps/admin/src/v2/Statusbar.tsx
@@ -17,7 +17,6 @@ export function Statusbar({
 
   return (
     <div className="statusbar">
-      <span className="chunk env">本番 PROD</span>
       <span className="chunk">
         <span className="dot ok" />
         <span className="lbl">corpus:</span>

--- a/frontend/apps/admin/src/v2/Topbar.tsx
+++ b/frontend/apps/admin/src/v2/Topbar.tsx
@@ -38,8 +38,6 @@ export function Topbar({ crumb, theme, onToggleTheme, onToggleDrawer, userEmail 
       <div className="topbar-mid">
         <span>AYANE</span>
         <span className="sep">/</span>
-        <span className="crumb">本番</span>
-        <span className="sep">/</span>
         <span className="leaf">{crumb}</span>
       </div>
       <div className="topbar-right">


### PR DESCRIPTION
自己ホスト型 SMB デプロイには本番/ステージングの環境区別が無いため、Topbar breadcrumb と Statusbar の環境インジケータ（本番 / 本番 PROD）を削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)