### PR TITLE
fix(build): release ZIP が vendor シンボリックリンクで失敗する不具合を修正する

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -70,6 +70,19 @@ rsync -a \
 
 touch "$STAGING_DIR/storage/uploads/.gitkeep"
 
+echo "==> Dereference path-dependency symlinks in staging vendor"
+# vendor/vendor is a self-referential symlink that zip would follow infinitely
+rm -f "$STAGING_DIR/vendor/vendor"
+# vendor/hideyukimori/nene2 is a Composer path-repo symlink → copy real content
+NENE2_VENDOR_LINK="$STAGING_DIR/vendor/hideyukimori/nene2"
+if [[ -L "$NENE2_VENDOR_LINK" ]]; then
+  rm "$NENE2_VENDOR_LINK"
+  mkdir -p "$NENE2_VENDOR_LINK"
+  # Whitelist: copy only runtime-required files (src/ + composer.json)
+  rsync -a "$NENE2_DIR/src/" "$NENE2_VENDOR_LINK/src/"
+  cp "$NENE2_DIR/composer.json" "$NENE2_VENDOR_LINK/composer.json"
+fi
+
 echo "==> Create ZIP: ${ZIP_PATH}"
 mkdir -p "$(dirname "$ZIP_PATH")"
 rm -f "$ZIP_PATH"


### PR DESCRIPTION
Closes #310

## Summary

- `tools/build-release.sh` のステージング後処理を修正
- Composer path dependency（`vendor/hideyukimori/nene2`）と循環リンク（`vendor/vendor`）が原因で ZIP が生成されない不具合を修正

## 原因

| シンボリックリンク | 問題 |
|---|---|
| `vendor/vendor → /home/.../nene-corpus/vendor` | zip が無限ループ |
| `vendor/hideyukimori/nene2 → ../../../NENE2/` | Tier A で解決できないパス |

## 修正内容

ステージング後に 2 ステップの後処理を追加：

1. `vendor/vendor`（循環リンク）を削除
2. `vendor/hideyukimori/nene2` リンクを実体コピーに置換  
   - ホワイトリスト: `src/` + `composer.json` のみ  
   - `.vitepress/dist`（847MB）・`node_modules`・`tests` 等は除外  
   - コピー後サイズ: 728KB

## 検証

- 修正後の ZIP: `nene-corpus-4203d52.zip` 19MB（旧 18MB と同等）
- ZIP 内容: 全18マイグレーション・Tenancy モジュール・NENE2 src を確認

## Self-review

- [x] `docs/review/backend-api.md` — 対象外（build スクリプトのみ）
- [x] 既存テストに影響なし（build スクリプト変更のみ）