### PR TITLE
feat(upstream): NeNe Records 読み取りクライアントを実装する

### DIFF
--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -56,6 +56,7 @@ use NeneCorpus\Source\SourceServiceProvider;
 use NeneCorpus\SystemConfig\SystemConfigRouteRegistrar;
 use NeneCorpus\SystemConfig\SystemConfigServiceProvider;
 use NeneCorpus\Tenancy\Context\TenancyServiceProvider;
+use NeneCorpus\Upstream\UpstreamServiceProvider;
 use Psr\Container\ContainerInterface;
 
 final readonly class ApplicationServiceProvider implements ServiceProviderInterface
@@ -89,6 +90,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new OrganizationServiceProvider())
             ->addProvider(new SystemConfigServiceProvider())
             ->addProvider(new TenancyServiceProvider())
+            ->addProvider(new UpstreamServiceProvider())
             ->set(
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {

--- a/src/Upstream/HttpNeneRecordsClient.php
+++ b/src/Upstream/HttpNeneRecordsClient.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Upstream;
+
+final readonly class HttpNeneRecordsClient implements NeneRecordsClientInterface
+{
+    public function __construct(private NeneRecordsConfig $config)
+    {
+    }
+
+    public function searchEntities(string $query, int $limit = 5): array
+    {
+        $url = rtrim((string) $this->config->baseUrl, '/') . '/api/v1/entities?' . http_build_query([
+            'q' => $query,
+            'status' => 'published',
+            'limit' => $limit,
+        ]);
+
+        $response = $this->get($url);
+
+        if ($response === null) {
+            return [];
+        }
+
+        $data = json_decode($response, true);
+
+        if (!is_array($data) || !isset($data['items']) || !is_array($data['items'])) {
+            return [];
+        }
+
+        return array_map(
+            static fn (mixed $item): NeneRecordsEntity => NeneRecordsEntity::fromArray(
+                is_array($item) ? $item : [],
+            ),
+            $data['items'],
+        );
+    }
+
+    public function getRecord(string $entityTypeSlug, string $entitySlug): ?NeneRecordsEntity
+    {
+        $url = rtrim((string) $this->config->baseUrl, '/')
+            . '/api/v1/public/entity-types/'
+            . rawurlencode($entityTypeSlug)
+            . '/records/'
+            . rawurlencode($entitySlug);
+
+        $response = $this->get($url);
+
+        if ($response === null) {
+            return null;
+        }
+
+        $data = json_decode($response, true);
+
+        if (!is_array($data) || !isset($data['entity']) || !is_array($data['entity'])) {
+            return null;
+        }
+
+        return NeneRecordsEntity::fromArray($data['entity']);
+    }
+
+    public function ping(): bool
+    {
+        $url = rtrim((string) $this->config->baseUrl, '/') . '/health';
+        $response = $this->get($url);
+
+        return $response !== null;
+    }
+
+    private function get(string $url): ?string
+    {
+        $ctx = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'header' => $this->buildHeaders(),
+                'timeout' => 5.0,
+                'ignore_errors' => true,
+            ],
+        ]);
+
+        $body = @file_get_contents($url, false, $ctx);
+
+        if ($body === false) {
+            return null;
+        }
+
+        // $http_response_header is set by file_get_contents
+        $statusLine = $http_response_header[0] ?? '';
+        preg_match('/HTTP\/\S+ (\d{3})/', $statusLine, $m);
+        $status = isset($m[1]) ? (int) $m[1] : 0;
+
+        return ($status >= 200 && $status < 300) ? $body : null;
+    }
+
+    private function buildHeaders(): string
+    {
+        $headers = ["Accept: application/json\r\n"];
+
+        if ($this->config->bearerToken !== null) {
+            $headers[] = "Authorization: Bearer {$this->config->bearerToken}\r\n";
+        }
+
+        return implode('', $headers);
+    }
+}

--- a/src/Upstream/NeneRecordsClientInterface.php
+++ b/src/Upstream/NeneRecordsClientInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Upstream;
+
+interface NeneRecordsClientInterface
+{
+    /**
+     * Full-text search across slug and text field values.
+     * Uses GET /api/v1/entities?q={query}&status=published
+     *
+     * @return NeneRecordsEntity[]
+     */
+    public function searchEntities(string $query, int $limit = 5): array;
+
+    /**
+     * Fetch a single public record view.
+     * Uses GET /api/v1/public/entity-types/{slug}/records/{entitySlug}
+     */
+    public function getRecord(string $entityTypeSlug, string $entitySlug): ?NeneRecordsEntity;
+
+    /**
+     * Connectivity check against GET /health.
+     */
+    public function ping(): bool;
+}

--- a/src/Upstream/NeneRecordsConfig.php
+++ b/src/Upstream/NeneRecordsConfig.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Upstream;
+
+final readonly class NeneRecordsConfig
+{
+    public function __construct(
+        public ?string $baseUrl,
+        public ?string $bearerToken,
+    ) {
+    }
+
+    public static function fromEnvironment(): self
+    {
+        return new self(
+            baseUrl: self::readEnv('NENE_RECORDS_API_BASE_URL'),
+            bearerToken: self::readEnv('NENE_RECORDS_BEARER_TOKEN'),
+        );
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->baseUrl !== null && $this->baseUrl !== '';
+    }
+
+    private static function readEnv(string $key): ?string
+    {
+        $value = $_ENV[$key] ?? $_SERVER[$key] ?? null;
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/src/Upstream/NeneRecordsEntity.php
+++ b/src/Upstream/NeneRecordsEntity.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Upstream;
+
+final readonly class NeneRecordsEntity
+{
+    public function __construct(
+        public int $id,
+        public int $entityTypeId,
+        public ?string $slug,
+        public string $status,
+        public ?string $metaTitle,
+        public ?string $metaDescription,
+        public ?string $publishedAt,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: (int) ($data['id'] ?? 0),
+            entityTypeId: (int) ($data['entity_type_id'] ?? 0),
+            slug: isset($data['slug']) && is_string($data['slug']) ? $data['slug'] : null,
+            status: is_string($data['status'] ?? null) ? $data['status'] : 'draft',
+            metaTitle: isset($data['meta_title']) && is_string($data['meta_title']) ? $data['meta_title'] : null,
+            metaDescription: isset($data['meta_description']) && is_string($data['meta_description']) ? $data['meta_description'] : null,
+            publishedAt: isset($data['published_at']) && is_string($data['published_at']) ? $data['published_at'] : null,
+        );
+    }
+
+    /** Human-readable label for use in LLM context. */
+    public function label(): string
+    {
+        return $this->metaTitle ?? $this->slug ?? "entity:{$this->id}";
+    }
+}

--- a/src/Upstream/NullNeneRecordsClient.php
+++ b/src/Upstream/NullNeneRecordsClient.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Upstream;
+
+/** Used when NENE_RECORDS_API_BASE_URL is not configured. */
+final readonly class NullNeneRecordsClient implements NeneRecordsClientInterface
+{
+    public function searchEntities(string $query, int $limit = 5): array
+    {
+        return [];
+    }
+
+    public function getRecord(string $entityTypeSlug, string $entitySlug): ?NeneRecordsEntity
+    {
+        return null;
+    }
+
+    public function ping(): bool
+    {
+        return false;
+    }
+}

--- a/src/Upstream/UpstreamServiceProvider.php
+++ b/src/Upstream/UpstreamServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Upstream;
+
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+final readonly class UpstreamServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                NeneRecordsConfig::class,
+                static fn (): NeneRecordsConfig => NeneRecordsConfig::fromEnvironment(),
+            )
+            ->set(
+                NeneRecordsClientInterface::class,
+                static function (ContainerInterface $container): NeneRecordsClientInterface {
+                    $config = $container->get(NeneRecordsConfig::class);
+
+                    if (!$config instanceof NeneRecordsConfig || !$config->isConfigured()) {
+                        return new NullNeneRecordsClient();
+                    }
+
+                    return new HttpNeneRecordsClient($config);
+                },
+            );
+    }
+}

--- a/tests/Unit/Upstream/NeneRecordsConfigTest.php
+++ b/tests/Unit/Upstream/NeneRecordsConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Unit\Upstream;
+
+use NeneCorpus\Upstream\NeneRecordsConfig;
+use PHPUnit\Framework\TestCase;
+
+final class NeneRecordsConfigTest extends TestCase
+{
+    public function test_not_configured_when_base_url_absent(): void
+    {
+        $config = new NeneRecordsConfig(baseUrl: null, bearerToken: null);
+        self::assertFalse($config->isConfigured());
+    }
+
+    public function test_not_configured_when_base_url_empty(): void
+    {
+        $config = new NeneRecordsConfig(baseUrl: '', bearerToken: null);
+        self::assertFalse($config->isConfigured());
+    }
+
+    public function test_configured_when_base_url_present(): void
+    {
+        $config = new NeneRecordsConfig(baseUrl: 'http://records.example.com', bearerToken: null);
+        self::assertTrue($config->isConfigured());
+    }
+
+    public function test_configured_with_bearer_token(): void
+    {
+        $config = new NeneRecordsConfig(baseUrl: 'http://records.example.com', bearerToken: 'token-abc');
+        self::assertTrue($config->isConfigured());
+        self::assertSame('token-abc', $config->bearerToken);
+    }
+
+    public function test_from_environment_trims_whitespace(): void
+    {
+        $_ENV['NENE_RECORDS_API_BASE_URL'] = '  http://example.com  ';
+        $_ENV['NENE_RECORDS_BEARER_TOKEN'] = '  tok  ';
+
+        $config = NeneRecordsConfig::fromEnvironment();
+
+        self::assertSame('http://example.com', $config->baseUrl);
+        self::assertSame('tok', $config->bearerToken);
+
+        unset($_ENV['NENE_RECORDS_API_BASE_URL'], $_ENV['NENE_RECORDS_BEARER_TOKEN']);
+    }
+
+    public function test_from_environment_returns_null_for_empty_string(): void
+    {
+        $_ENV['NENE_RECORDS_API_BASE_URL'] = '';
+        $_ENV['NENE_RECORDS_BEARER_TOKEN'] = '';
+
+        $config = NeneRecordsConfig::fromEnvironment();
+
+        self::assertNull($config->baseUrl);
+        self::assertNull($config->bearerToken);
+        self::assertFalse($config->isConfigured());
+
+        unset($_ENV['NENE_RECORDS_API_BASE_URL'], $_ENV['NENE_RECORDS_BEARER_TOKEN']);
+    }
+}

--- a/tests/Unit/Upstream/NeneRecordsEntityTest.php
+++ b/tests/Unit/Upstream/NeneRecordsEntityTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Unit\Upstream;
+
+use NeneCorpus\Upstream\NeneRecordsEntity;
+use PHPUnit\Framework\TestCase;
+
+final class NeneRecordsEntityTest extends TestCase
+{
+    public function test_from_array_maps_fields(): void
+    {
+        $entity = NeneRecordsEntity::fromArray([
+            'id' => 42,
+            'entity_type_id' => 3,
+            'slug' => 'test-post',
+            'status' => 'published',
+            'meta_title' => 'Test Post',
+            'meta_description' => 'A description.',
+            'published_at' => '2026-05-30T00:00:00Z',
+        ]);
+
+        self::assertSame(42, $entity->id);
+        self::assertSame(3, $entity->entityTypeId);
+        self::assertSame('test-post', $entity->slug);
+        self::assertSame('published', $entity->status);
+        self::assertSame('Test Post', $entity->metaTitle);
+        self::assertSame('A description.', $entity->metaDescription);
+        self::assertSame('2026-05-30T00:00:00Z', $entity->publishedAt);
+    }
+
+    public function test_from_array_handles_null_fields(): void
+    {
+        $entity = NeneRecordsEntity::fromArray([
+            'id' => 1,
+            'entity_type_id' => 1,
+            'slug' => null,
+            'status' => 'draft',
+            'meta_title' => null,
+            'meta_description' => null,
+            'published_at' => null,
+        ]);
+
+        self::assertNull($entity->slug);
+        self::assertNull($entity->metaTitle);
+        self::assertNull($entity->metaDescription);
+        self::assertNull($entity->publishedAt);
+    }
+
+    public function test_label_returns_meta_title_when_present(): void
+    {
+        $entity = NeneRecordsEntity::fromArray([
+            'id' => 1, 'entity_type_id' => 1,
+            'slug' => 'my-slug', 'status' => 'published',
+            'meta_title' => 'My Title',
+            'meta_description' => null, 'published_at' => null,
+        ]);
+
+        self::assertSame('My Title', $entity->label());
+    }
+
+    public function test_label_falls_back_to_slug(): void
+    {
+        $entity = NeneRecordsEntity::fromArray([
+            'id' => 5, 'entity_type_id' => 1,
+            'slug' => 'my-slug', 'status' => 'published',
+            'meta_title' => null,
+            'meta_description' => null, 'published_at' => null,
+        ]);
+
+        self::assertSame('my-slug', $entity->label());
+    }
+
+    public function test_label_falls_back_to_id(): void
+    {
+        $entity = NeneRecordsEntity::fromArray([
+            'id' => 99, 'entity_type_id' => 1,
+            'slug' => null, 'status' => 'draft',
+            'meta_title' => null,
+            'meta_description' => null, 'published_at' => null,
+        ]);
+
+        self::assertSame('entity:99', $entity->label());
+    }
+}

--- a/tests/Unit/Upstream/NullNeneRecordsClientTest.php
+++ b/tests/Unit/Upstream/NullNeneRecordsClientTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Unit\Upstream;
+
+use NeneCorpus\Upstream\NullNeneRecordsClient;
+use PHPUnit\Framework\TestCase;
+
+final class NullNeneRecordsClientTest extends TestCase
+{
+    private NullNeneRecordsClient $client;
+
+    protected function setUp(): void
+    {
+        $this->client = new NullNeneRecordsClient();
+    }
+
+    public function test_search_returns_empty_array(): void
+    {
+        self::assertSame([], $this->client->searchEntities('anything'));
+    }
+
+    public function test_get_record_returns_null(): void
+    {
+        self::assertNull($this->client->getRecord('blog', 'some-post'));
+    }
+
+    public function test_ping_returns_false(): void
+    {
+        self::assertFalse($this->client->ping());
+    }
+}


### PR DESCRIPTION
Closes #313

## Summary

- `src/Upstream/` モジュールを新規作成（Phase 5 P1）
- ADR 0002 の境界方針に従い、NeNe Records への読み取り専用 HTTP クライアントを実装

## 実装内容

| ファイル | 役割 |
|---|---|
| `NeneRecordsConfig` | 環境変数 DTO（isConfigured でゼロ設定を検出）|
| `NeneRecordsEntity` | エンティティ値オブジェクト + `label()` メソッド |
| `NeneRecordsClientInterface` | `searchEntities` / `getRecord` / `ping` |
| `HttpNeneRecordsClient` | `file_get_contents` + stream_context による HTTP 実装（5s タイムアウト）|
| `NullNeneRecordsClient` | 未設定時の Null Object（graceful degrade）|
| `UpstreamServiceProvider` | 設定済み → Http、未設定 → Null を DI に注入 |

## API マッピング

| メソッド | エンドポイント |
|---|---|
| `searchEntities(query, limit)` | `GET /api/v1/entities?q=...&status=published` |
| `getRecord(typeSlug, entitySlug)` | `GET /api/v1/public/entity-types/{slug}/records/{entitySlug}` |
| `ping()` | `GET /health` |

## テスト

- `tests/Unit/Upstream/` に 3 クラス追加
- PHPUnit 400/400・PHPStan level8・CS-Fixer・OpenAPI・MCP すべてグリーン

## Self-review

- [x] `docs/review/backend-api.md` — Handler/UseCase/Repository 変更なし（純粋追加）
- [x] `docs/review/database.md` — DB 変更なし