### PR TITLE
fix(admin-auth): 本番で JWT secret 未設定時にフェイルクローズする (#320)

### DIFF
--- a/src/AdminAuth/AdminAuthServiceProvider.php
+++ b/src/AdminAuth/AdminAuthServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Auth\BearerTokenMiddleware;
 use Nene2\Auth\LocalBearerTokenVerifier;
 use Nene2\Auth\TokenIssuerInterface;
 use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
@@ -30,6 +31,13 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
 
     public const TOKEN_ISSUER = 'nene-corpus.admin_auth.token_issuer';
 
+    /**
+     * Dev/test-only fallback secret. Never reaches production: there
+     * {@see self::resolveJwtSecret()} fails closed instead. This value is
+     * publicly known, so it must never sign or verify real tokens.
+     */
+    private const DEFAULT_DEV_SECRET = 'nene-corpus-dev-secret';
+
     public function register(ContainerBuilder $builder): void
     {
         $builder
@@ -50,18 +58,17 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
             )
             ->set(
                 self::TOKEN_ISSUER,
-                static function (ContainerInterface $container): ?TokenIssuerInterface {
+                static function (ContainerInterface $container): TokenIssuerInterface {
                     $config = $container->get(AppConfig::class);
 
                     if (!$config instanceof AppConfig) {
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    if ($config->localJwtSecret === null) {
-                        return null;
-                    }
-
-                    return new LocalBearerTokenVerifier($config->localJwtSecret);
+                    // Always build a verifier: the secret is resolved fail-closed
+                    // (production without a secret refuses to boot), so admin auth
+                    // is never silently disabled.
+                    return new LocalBearerTokenVerifier(self::resolveJwtSecret($config));
                 },
             )
             ->set(
@@ -360,7 +367,7 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
             )
             ->set(
                 self::AUTH_MIDDLEWARE,
-                static function (ContainerInterface $container): ?AdminBearerTokenMiddleware {
+                static function (ContainerInterface $container): AdminBearerTokenMiddleware {
                     $config = $container->get(AppConfig::class);
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
 
@@ -368,21 +375,44 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Application config service is invalid.');
                     }
 
-                    if ($config->localJwtSecret === null) {
-                        return null;
-                    }
-
                     if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
                         throw new LogicException('Problem details response factory service is invalid.');
                     }
 
+                    // Always build the auth middleware so it is unconditionally part
+                    // of the chain; resolveJwtSecret() fails closed in production.
                     $bearer = new BearerTokenMiddleware(
                         $problemDetails,
-                        new LocalBearerTokenVerifier($config->localJwtSecret),
+                        new LocalBearerTokenVerifier(self::resolveJwtSecret($config)),
                     );
 
                     return new AdminBearerTokenMiddleware($bearer);
                 },
             );
+    }
+
+    /**
+     * Resolves the HMAC secret for local admin bearer tokens, failing closed.
+     *
+     * The same secret signs and verifies admin bearer tokens, so a predictable
+     * value is a full authentication bypass (a forged superadmin token). In
+     * production the secret is therefore mandatory: if NENE2_LOCAL_JWT_SECRET is
+     * unset (or empty) we refuse to boot rather than silently fall back to the
+     * public dev constant. Local/test may use the dev fallback for convenience.
+     */
+    private static function resolveJwtSecret(AppConfig $config): string
+    {
+        if ($config->localJwtSecret !== null && $config->localJwtSecret !== '') {
+            return $config->localJwtSecret;
+        }
+
+        if ($config->environment === AppEnvironment::Production) {
+            throw new LogicException(
+                'NENE2_LOCAL_JWT_SECRET must be set in production. '
+                . 'Generate one with: php -r "echo bin2hex(random_bytes(32));"',
+            );
+        }
+
+        return self::DEFAULT_DEV_SECRET;
     }
 }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -227,7 +227,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                     $basePathMiddleware  = $container->get(InstallServiceProvider::BASE_PATH_MIDDLEWARE);
                     $orgResolver         = $container->get(OrgResolverMiddleware::class);
 
-                    if ($authMiddleware !== null && !$authMiddleware instanceof AdminBearerTokenMiddleware) {
+                    if (!$authMiddleware instanceof AdminBearerTokenMiddleware) {
                         throw new LogicException('Admin auth middleware service is invalid.');
                     }
 
@@ -251,15 +251,18 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Org resolver middleware service is invalid.');
                     }
 
+                    // The admin auth middleware is now always present (the verifier
+                    // is built fail-closed), so it is added unconditionally rather
+                    // than being dropped by array_filter when no secret is set.
                     /** @var list<\Psr\Http\Server\MiddlewareInterface> $requestMiddleware */
-                    $requestMiddleware = array_values(array_filter([
+                    $requestMiddleware = [
                         $basePathMiddleware,
                         $loginRateLimit,
                         $authMiddleware,
                         $superadminMiddleware,
                         $orgResolver,
                         $chatRateLimit,
-                    ]));
+                    ];
 
                     return new RuntimeApplicationFactory(
                         $responseFactory,
@@ -269,7 +272,7 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         $exceptionHandlers,
                         $requestIdHolder,
                         $routeRegistrars,
-                        $requestMiddleware !== [] ? $requestMiddleware : null,
+                        $requestMiddleware,
                         [],
                         null,
                         $config->debug,

--- a/tests/AdminAuth/JwtSecretResolutionTest.php
+++ b/tests/AdminAuth/JwtSecretResolutionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\AdminAuth;
+
+use LogicException;
+use Nene2\Config\AppConfig;
+use Nene2\Config\AppEnvironment;
+use Nene2\Config\DatabaseConfig;
+use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * P0 fail-open fix: the local admin JWT secret must fail closed in production
+ * when NENE2_LOCAL_JWT_SECRET is unset (or empty), rather than leaving the auth
+ * middleware disabled — which would open every admin route with no token.
+ */
+final class JwtSecretResolutionTest extends TestCase
+{
+    public function test_production_without_secret_refuses_to_boot(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('NENE2_LOCAL_JWT_SECRET');
+
+        self::resolve(self::config(AppEnvironment::Production, null));
+    }
+
+    public function test_production_with_empty_secret_refuses_to_boot(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('NENE2_LOCAL_JWT_SECRET');
+
+        self::resolve(self::config(AppEnvironment::Production, ''));
+    }
+
+    public function test_production_with_secret_uses_it(): void
+    {
+        self::assertSame(
+            'a-real-production-secret',
+            self::resolve(self::config(AppEnvironment::Production, 'a-real-production-secret')),
+        );
+    }
+
+    public function test_local_without_secret_falls_back_to_dev_constant(): void
+    {
+        // Local/test convenience: the dev fallback is allowed only off-production.
+        self::assertNotSame('', self::resolve(self::config(AppEnvironment::Local, null)));
+    }
+
+    private static function resolve(AppConfig $config): string
+    {
+        $method = new ReflectionMethod(AdminAuthServiceProvider::class, 'resolveJwtSecret');
+
+        /** @var string $secret */
+        $secret = $method->invoke(null, $config);
+
+        return $secret;
+    }
+
+    private static function config(AppEnvironment $env, ?string $secret): AppConfig
+    {
+        return new AppConfig(
+            $env,
+            false,
+            'NeNe Corpus',
+            new DatabaseConfig(null, 'test', 'sqlite', '', 1, ':memory:', '', '', ''),
+            null,
+            $secret,
+        );
+    }
+}


### PR DESCRIPTION
Closes #320

## 目的

P0 セキュリティ（`_work/reports/2026-07-05/nene-backend-audit.md` §2・CONFIRMED）。NeNe Corpus は fail-open で、`NENE2_LOCAL_JWT_SECRET` 未設定だと admin 認証ミドルウェアが middleware chain から外れ全 admin ルートが無認証開放になっていた。invoice / field / clear の fail-closed 実装と挙動を統一する（Variant B）。

## 変更点

- **`src/AdminAuth/AdminAuthServiceProvider.php`**
  - `TOKEN_ISSUER` / `AUTH_MIDDLEWARE`: `localJwtSecret === null` で `null` を返す分岐を撤去し、**verifier を常に生成**（`self::resolveJwtSecret($config)` 経由）。
  - `resolveJwtSecret()` を追加。ガードは `!== null && !== ''`。本番×未設定/空 → `LogicException`（起動拒否）、dev/test → `DEFAULT_DEV_SECRET = 'nene-corpus-dev-secret'`。
  - `use Nene2\Config\AppEnvironment;` を追加（`LogicException` は import 済みなので非修飾）。
- **`src/Http/RuntimeServiceProvider.php`**
  - `array_filter` を撤去し、admin 認証ミドルウェアを**無条件で chain に積む**。`$authMiddleware` の instanceof チェックを非 null 前提に変更。middleware は常に非空になるため後段の `!== [] ? … : null` 三項も撤去。
- **`tests/AdminAuth/JwtSecretResolutionTest.php`**（新規・`ReflectionMethod`・4 ケース）: 本番×null 拒否 / 本番×空拒否 / 本番×設定採用 / dev×既定鍵。

ENV キー: `NENE2_LOCAL_JWT_SECRET`（`vendor/hideyukimori/nene2/src/Config/ConfigLoader.php` で確認・共有キー）。`composer.lock` は不変更。

## 検証結果

- `composer check` **green**（PHPUnit 404 tests / PHPStan L8 / CS / OpenAPI / MCP、追加調整なし）。
- **本番×secret 未設定 → 起動拒否**: `APP_ENV=production` ＋ secret 未設定で `AUTH_MIDDLEWARE` 解決 → boot 拒否。DI が `ServiceResolutionException` で包むが `getPrevious()` チェーンに `LogicException`（"NENE2_LOCAL_JWT_SECRET must be set in production"）を確認。env は `$_SERVER` 経由・`environment->value === 'production'` を先に確認済み（no-op でない）。
- **★Variant B 固有★ dev×secret 未設定 → 認証段が chain に残ったまま起動**: `APP_ENV=local` ＋ secret 未設定で `AUTH_MIDDLEWARE` が非 null の `AdminBearerTokenMiddleware` を返し、`RuntimeApplicationFactory` の middleware chain に `AdminBearerTokenMiddleware` が含まれ、`RequestHandler`（`MiddlewareDispatcher`）が構築される＝fail-open が塞がれたことを確認。
- **dev 非回帰**: 既存 404 tests（bootstrap の既定 secret 下）が全て green。

## Self-review

`docs/review/middleware-security.md`

## 残リスク / スコープ

- スコープはこの fail-close ＋ 認証無条件化のみ。他の逸脱は別 Issue。
- 根治（NENE2 側の fail-closed verifier factory 共通化）は指示書記載の別 Issue（issues #7 後段）。