### PR TITLE
fix(ingestion): composer.lock の NENE2 pin 是正と PDF 取り込みの TX 化

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.4.1 <9.0",
-        "hideyukimori/nene2": "@dev",
+        "hideyukimori/nene2": "^1.7",
         "phpmailer/phpmailer": "^7.1",
         "robmorgan/phinx": "^0.16.11",
         "smalot/pdfparser": "^2.12"
@@ -13,7 +13,12 @@
     "repositories": [
         {
             "type": "path",
-            "url": "../NENE2"
+            "url": "../NENE2",
+            "options": {
+                "versions": {
+                    "hideyukimori/nene2": "1.7.0"
+                }
+            }
         }
     ],
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f6973017a615dfaaf0226418834cf4e",
+    "content-hash": "fc53d22d0461335a6e10b7555612caf3",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -394,11 +394,11 @@
         },
         {
             "name": "hideyukimori/nene2",
-            "version": "dev-feat/908-ft182-batchlog",
+            "version": "1.7.0",
             "dist": {
                 "type": "path",
                 "url": "../NENE2",
-                "reference": "5fbd940c6dffc3b06bbf5247855364e93b43ceda"
+                "reference": "8db980a6e48949ffc4a6c7d8eb655aca8fbdf894"
             },
             "require": {
                 "monolog/monolog": "^3.0",
@@ -419,6 +419,7 @@
                 "symfony/yaml": "^8.0"
             },
             "suggest": {
+                "robmorgan/phinx": "Required by Nene2\\Install\\DatabaseSchemaApplier. A consumer that uses it MUST add phinx to its require (NOT require-dev) — it is here only as a dev dependency, so a --no-dev production build would omit it and installs would fatally fail when applying migrations.",
                 "symfony/yaml": "Required to run validate-mcp-tools.php from a consumer project (add to your require-dev)"
             },
             "type": "library",
@@ -456,6 +457,12 @@
                 ],
                 "openapi:docs": [
                     "php tools/openapi-to-md.php"
+                ],
+                "howto:index": [
+                    "php tools/build-howto-index.php"
+                ],
+                "howto:frontmatter": [
+                    "php tools/validate-howto-frontmatter.php"
                 ],
                 "mcp": [
                     "php tools/validate-mcp-tools.php"
@@ -6252,9 +6259,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "hideyukimori/nene2": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Ingestion/CreatePdfSourceUseCase.php
+++ b/src/Ingestion/CreatePdfSourceUseCase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Ingestion;
 
+use Closure;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use NeneCorpus\Chunk\Chunk;
 use NeneCorpus\Chunk\ChunkRepositoryInterface;
 use NeneCorpus\Document\Document;
@@ -12,13 +15,21 @@ use NeneCorpus\Source\Source;
 use NeneCorpus\Source\SourceRepositoryInterface;
 use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Source\SourceType;
+use Throwable;
 
 final readonly class CreatePdfSourceUseCase implements CreatePdfSourceUseCaseInterface
 {
+    /**
+     * @param Closure(DatabaseQueryExecutorInterface): SourceRepositoryInterface   $sourceRepositoryFactory
+     * @param Closure(DatabaseQueryExecutorInterface): DocumentRepositoryInterface $documentRepositoryFactory
+     * @param Closure(DatabaseQueryExecutorInterface): ChunkRepositoryInterface    $chunkRepositoryFactory
+     */
     public function __construct(
-        private SourceRepositoryInterface $sources,
-        private DocumentRepositoryInterface $documents,
-        private ChunkRepositoryInterface $chunks,
+        private DatabaseTransactionManagerInterface $transactionManager,
+        private Closure $sourceRepositoryFactory,
+        private Closure $documentRepositoryFactory,
+        private Closure $chunkRepositoryFactory,
+        private DatabaseQueryExecutorInterface $queryExecutor,
         private PdfUploadValidator $validator,
         private PdfTextExtractor $extractor,
         private UploadStorage $uploadStorage,
@@ -31,48 +42,70 @@ final readonly class CreatePdfSourceUseCase implements CreatePdfSourceUseCaseInt
         $pages = $this->extractor->extractPages($file->bytes);
         $storagePath = $this->uploadStorage->store($file);
 
-        $sourceId = $this->sources->save(new Source(
-            name: $input->name,
-            sourceType: SourceType::Pdf,
-            status: SourceStatus::Processing,
-            storagePath: $storagePath,
-            originalFilename: $file->originalFilename,
-            mimeType: $file->mimeType,
-            byteSize: $file->byteSize(),
-        ));
-
         try {
-            $documentId = $this->documents->save(new Document(
-                sourceId: $sourceId,
-                title: $input->name,
-                position: 0,
-                metadataJson: json_encode(['page_count' => count($pages)], JSON_THROW_ON_ERROR),
-            ));
+            return $this->transactionManager->transactional(
+                function (DatabaseQueryExecutorInterface $executor) use ($input, $file, $pages, $storagePath): CreateSourceOutput {
+                    $sources = ($this->sourceRepositoryFactory)($executor);
+                    $documents = ($this->documentRepositoryFactory)($executor);
+                    $chunks = ($this->chunkRepositoryFactory)($executor);
 
-            foreach ($pages as $index => $page) {
-                $content = $page['text'];
-                $this->chunks->save(new Chunk(
-                    documentId: $documentId,
-                    sourceId: $sourceId,
-                    content: $content,
-                    chunkIndex: $index,
-                    pageNumber: $page['page_number'],
-                    tokenCount: $this->estimateTokenCount($content),
-                ));
-            }
+                    $sourceId = $sources->save(new Source(
+                        name: $input->name,
+                        sourceType: SourceType::Pdf,
+                        status: SourceStatus::Processing,
+                        storagePath: $storagePath,
+                        originalFilename: $file->originalFilename,
+                        mimeType: $file->mimeType,
+                        byteSize: $file->byteSize(),
+                    ));
 
-            $this->sources->update(new Source(
-                name: $input->name,
-                sourceType: SourceType::Pdf,
-                status: SourceStatus::Ready,
-                storagePath: $storagePath,
-                originalFilename: $file->originalFilename,
-                mimeType: $file->mimeType,
-                byteSize: $file->byteSize(),
-                id: $sourceId,
-            ));
-        } catch (\Throwable $exception) {
-            $this->sources->update(new Source(
+                    $documentId = $documents->save(new Document(
+                        sourceId: $sourceId,
+                        title: $input->name,
+                        position: 0,
+                        metadataJson: json_encode(['page_count' => count($pages)], JSON_THROW_ON_ERROR),
+                    ));
+
+                    foreach ($pages as $index => $page) {
+                        $content = $page['text'];
+                        $chunks->save(new Chunk(
+                            documentId: $documentId,
+                            sourceId: $sourceId,
+                            content: $content,
+                            chunkIndex: $index,
+                            pageNumber: $page['page_number'],
+                            tokenCount: $this->estimateTokenCount($content),
+                        ));
+                    }
+
+                    $sources->update(new Source(
+                        name: $input->name,
+                        sourceType: SourceType::Pdf,
+                        status: SourceStatus::Ready,
+                        storagePath: $storagePath,
+                        originalFilename: $file->originalFilename,
+                        mimeType: $file->mimeType,
+                        byteSize: $file->byteSize(),
+                        id: $sourceId,
+                    ));
+
+                    return new CreateSourceOutput(
+                        sourceId: $sourceId,
+                        name: $input->name,
+                        status: SourceStatus::Ready,
+                        documentCount: 1,
+                        chunkCount: count($pages),
+                    );
+                },
+            );
+        } catch (Throwable $exception) {
+            // The transaction above has already rolled back in full (source row
+            // included), so the failure marker below is a brand new row written
+            // through the non-transactional executor — it must survive on its own
+            // rather than depend on state the rollback just undid.
+            $sources = ($this->sourceRepositoryFactory)($this->queryExecutor);
+
+            $sources->save(new Source(
                 name: $input->name,
                 sourceType: SourceType::Pdf,
                 status: SourceStatus::Failed,
@@ -81,19 +114,10 @@ final readonly class CreatePdfSourceUseCase implements CreatePdfSourceUseCaseInt
                 mimeType: $file->mimeType,
                 byteSize: $file->byteSize(),
                 errorMessage: $exception->getMessage(),
-                id: $sourceId,
             ));
 
             throw $exception;
         }
-
-        return new CreateSourceOutput(
-            sourceId: $sourceId,
-            name: $input->name,
-            status: SourceStatus::Ready,
-            documentCount: 1,
-            chunkCount: count($pages),
-        );
     }
 
     private function estimateTokenCount(string $content): int

--- a/src/Ingestion/IngestionServiceProvider.php
+++ b/src/Ingestion/IngestionServiceProvider.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Ingestion;
 
+use Closure;
 use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\DatabaseTransactionManagerInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Chunk\PdoChunkRepository;
 use NeneCorpus\Document\DocumentRepositoryInterface;
+use NeneCorpus\Document\PdoDocumentRepository;
 use NeneCorpus\Http\RuntimeServiceProvider;
+use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\SourceRepositoryInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
 final readonly class IngestionServiceProvider implements ServiceProviderInterface
@@ -153,10 +160,23 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
             ->set(
                 CreatePdfSourceUseCaseInterface::class,
                 static function (ContainerInterface $container): CreatePdfSourceUseCaseInterface {
+                    $transactionManager = $container->get(DatabaseTransactionManagerInterface::class);
+                    $queryExecutor = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$transactionManager instanceof DatabaseTransactionManagerInterface) {
+                        throw new LogicException('Database transaction manager service is invalid.');
+                    }
+
+                    if (!$queryExecutor instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
                     return new CreatePdfSourceUseCase(
-                        self::sourceRepository($container),
-                        self::documentRepository($container),
-                        self::chunkRepository($container),
+                        $transactionManager,
+                        self::sourceRepositoryFactory($container),
+                        self::documentRepositoryFactory($container),
+                        self::chunkRepositoryFactory($container),
+                        $queryExecutor,
                         self::pdfValidator($container),
                         self::pdfExtractor($container),
                         self::uploadStorage($container),
@@ -291,6 +311,41 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
         }
 
         return $chunks;
+    }
+
+    private static function orgIdHolder(ContainerInterface $container): RequestScopedOrgIdHolder
+    {
+        $holder = $container->get(RequestScopedOrgIdHolder::class);
+
+        if (!$holder instanceof RequestScopedOrgIdHolder) {
+            throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+        }
+
+        return $holder;
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): SourceRepositoryInterface */
+    private static function sourceRepositoryFactory(ContainerInterface $container): Closure
+    {
+        $orgIdHolder = self::orgIdHolder($container);
+
+        return static fn (DatabaseQueryExecutorInterface $executor): SourceRepositoryInterface => new PdoSourceRepository($executor, $orgIdHolder);
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): DocumentRepositoryInterface */
+    private static function documentRepositoryFactory(ContainerInterface $container): Closure
+    {
+        $orgIdHolder = self::orgIdHolder($container);
+
+        return static fn (DatabaseQueryExecutorInterface $executor): DocumentRepositoryInterface => new PdoDocumentRepository($executor, $orgIdHolder);
+    }
+
+    /** @return Closure(DatabaseQueryExecutorInterface): ChunkRepositoryInterface */
+    private static function chunkRepositoryFactory(ContainerInterface $container): Closure
+    {
+        $orgIdHolder = self::orgIdHolder($container);
+
+        return static fn (DatabaseQueryExecutorInterface $executor): ChunkRepositoryInterface => new PdoChunkRepository($executor, $orgIdHolder);
     }
 
     private static function csvValidator(ContainerInterface $container): CsvUploadValidator

--- a/tests/Ingestion/CreatePdfSourceUseCaseTest.php
+++ b/tests/Ingestion/CreatePdfSourceUseCaseTest.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Tests\Ingestion;
 
-use Nene2\Config\DatabaseConfig;
-use Nene2\Database\PdoConnectionFactory;
-use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Testing\DatabaseTestKit;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
 use NeneCorpus\Chunk\PdoChunkRepository;
 use NeneCorpus\Document\PdoDocumentRepository;
 use NeneCorpus\Ingestion\CreatePdfSourceInput;
@@ -20,30 +21,28 @@ use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
 use NeneCorpus\Tests\Support\SampleTextPdf;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class CreatePdfSourceUseCaseTest extends TestCase
 {
-    private PdoDatabaseQueryExecutor $executor;
+    private DatabaseTestKit $kit;
 
     private RequestScopedOrgIdHolder $orgIdHolder;
 
     private string $uploadDirectory;
 
+    private string $dbPath;
+
     protected function setUp(): void
     {
-        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
-            null,
-            'test',
-            'sqlite',
-            'localhost',
-            1,
-            ':memory:',
-            'nene_corpus',
-            '',
-            'utf8',
-        )));
+        // `:memory:` cannot be used here: `transactional()` opens a *separate*
+        // connection via the connection factory, which for `:memory:` would see
+        // an empty database. A file-backed SQLite DB lets both the transactional
+        // connection and this test's assertion connection see the same data.
+        $this->dbPath = sys_get_temp_dir() . '/nene-corpus-pdf-tx-' . uniqid('', true) . '.sqlite';
+        $this->kit = DatabaseTestKit::sqlite($this->dbPath);
 
-        CorpusSchemaSetup::create($this->executor);
+        CorpusSchemaSetup::create($this->kit->queryExecutor);
 
         $this->orgIdHolder = new RequestScopedOrgIdHolder();
         $this->orgIdHolder->setId(1);
@@ -63,14 +62,22 @@ final class CreatePdfSourceUseCaseTest extends TestCase
         if (is_dir($this->uploadDirectory)) {
             rmdir($this->uploadDirectory);
         }
+
+        foreach ([$this->dbPath, $this->dbPath . '-journal', $this->dbPath . '-wal', $this->dbPath . '-shm'] as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
     }
 
     public function test_execute_persists_pdf_source_document_and_chunks(): void
     {
         $useCase = new CreatePdfSourceUseCase(
-            new PdoSourceRepository($this->executor, $this->orgIdHolder),
-            new PdoDocumentRepository($this->executor, $this->orgIdHolder),
-            new PdoChunkRepository($this->executor, $this->orgIdHolder),
+            $this->kit->transactionManager,
+            fn (DatabaseQueryExecutorInterface $e) => new PdoSourceRepository($e, $this->orgIdHolder),
+            fn (DatabaseQueryExecutorInterface $e) => new PdoDocumentRepository($e, $this->orgIdHolder),
+            fn (DatabaseQueryExecutorInterface $e) => new PdoChunkRepository($e, $this->orgIdHolder),
+            $this->kit->queryExecutor,
             new PdfUploadValidator(),
             new PdfTextExtractor(),
             new UploadStorage($this->uploadDirectory),
@@ -86,16 +93,78 @@ final class CreatePdfSourceUseCaseTest extends TestCase
         self::assertSame(1, $output->documentCount);
         self::assertSame(1, $output->chunkCount);
 
-        $source = (new PdoSourceRepository($this->executor, $this->orgIdHolder))->findById($output->sourceId);
+        $source = (new PdoSourceRepository($this->kit->queryExecutor, $this->orgIdHolder))->findById($output->sourceId);
         self::assertNotNull($source);
         self::assertSame('pdf', $source->sourceType->value);
         self::assertSame('ready', $source->status->value);
 
-        $chunks = (new PdoChunkRepository($this->executor, $this->orgIdHolder))->findByDocumentId(
-            (new PdoDocumentRepository($this->executor, $this->orgIdHolder))->findBySourceId($output->sourceId, 1, 0)[0]->id ?? 0,
+        $chunks = (new PdoChunkRepository($this->kit->queryExecutor, $this->orgIdHolder))->findByDocumentId(
+            (new PdoDocumentRepository($this->kit->queryExecutor, $this->orgIdHolder))->findBySourceId($output->sourceId, 1, 0)[0]->id ?? 0,
         );
         self::assertCount(1, $chunks);
         self::assertSame(1, $chunks[0]->pageNumber);
         self::assertStringContainsString('Sample PDF', $chunks[0]->content);
+    }
+
+    public function test_execute_rolls_back_documents_and_chunks_when_a_write_fails_midway(): void
+    {
+        $failingChunks = new class () implements ChunkRepositoryInterface {
+            public function findById(int $id): ?Chunk
+            {
+                return null;
+            }
+
+            public function findByDocumentId(int $documentId): array
+            {
+                return [];
+            }
+
+            public function save(Chunk $chunk): int
+            {
+                throw new RuntimeException('simulated chunk write failure');
+            }
+
+            public function deleteByDocumentId(int $documentId): void
+            {
+            }
+
+            public function deleteBySourceId(int $sourceId): void
+            {
+            }
+        };
+
+        $useCase = new CreatePdfSourceUseCase(
+            $this->kit->transactionManager,
+            fn (DatabaseQueryExecutorInterface $e) => new PdoSourceRepository($e, $this->orgIdHolder),
+            fn (DatabaseQueryExecutorInterface $e) => new PdoDocumentRepository($e, $this->orgIdHolder),
+            fn (DatabaseQueryExecutorInterface $e) => $failingChunks,
+            $this->kit->queryExecutor,
+            new PdfUploadValidator(),
+            new PdfTextExtractor(),
+            new UploadStorage($this->uploadDirectory),
+        );
+
+        try {
+            $useCase->execute(new CreatePdfSourceInput(
+                name: 'Sample manual',
+                filename: 'sample-text.pdf',
+                content: SampleTextPdf::base64(),
+            ));
+            self::fail('Expected the simulated chunk write failure to propagate.');
+        } catch (RuntimeException $exception) {
+            self::assertSame('simulated chunk write failure', $exception->getMessage());
+        }
+
+        $documents = (new PdoDocumentRepository($this->kit->queryExecutor, $this->orgIdHolder))->findBySourceId(1, 100, 0);
+        self::assertSame([], $documents, 'The transactional document insert must have been rolled back.');
+
+        $sourceRepository = new PdoSourceRepository($this->kit->queryExecutor, $this->orgIdHolder);
+        $failedSource = $sourceRepository->findById(1);
+        self::assertNotNull($failedSource, 'A single compensating Failed source row should exist.');
+        self::assertSame('failed', $failedSource->status->value);
+        self::assertSame('simulated chunk write failure', $failedSource->errorMessage);
+
+        // No second (rolled-back) source row should have leaked through either.
+        self::assertNull($sourceRepository->findById(2));
     }
 }

--- a/tests/Support/CorpusSchemaSetup.php
+++ b/tests/Support/CorpusSchemaSetup.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Tests\Support;
 
-use Nene2\Database\PdoDatabaseQueryExecutor;
+use Nene2\Database\DatabaseQueryExecutorInterface;
 
 final class CorpusSchemaSetup
 {
-    public static function create(PdoDatabaseQueryExecutor $executor): void
+    public static function create(DatabaseQueryExecutorInterface $executor): void
     {
         $executor->execute(
             <<<'SQL'
@@ -72,7 +72,7 @@ final class CorpusSchemaSetup
         );
     }
 
-    public static function createAdminUsers(PdoDatabaseQueryExecutor $executor): void
+    public static function createAdminUsers(DatabaseQueryExecutorInterface $executor): void
     {
         $executor->execute(
             <<<'SQL'
@@ -91,7 +91,7 @@ final class CorpusSchemaSetup
         $executor->execute('CREATE UNIQUE INDEX uniq_admin_users_email ON admin_users (email)');
     }
 
-    public static function createAdminPasswordResets(PdoDatabaseQueryExecutor $executor): void
+    public static function createAdminPasswordResets(DatabaseQueryExecutorInterface $executor): void
     {
         $executor->execute(
             <<<'SQL'
@@ -109,7 +109,7 @@ final class CorpusSchemaSetup
         $executor->execute('CREATE UNIQUE INDEX uniq_admin_password_resets_token_hash ON admin_password_resets (token_hash)');
     }
 
-    public static function createChatSettings(PdoDatabaseQueryExecutor $executor): void
+    public static function createChatSettings(DatabaseQueryExecutorInterface $executor): void
     {
         $executor->execute(
             <<<'SQL'
@@ -125,7 +125,7 @@ final class CorpusSchemaSetup
         );
     }
 
-    public static function createAppearanceSettings(PdoDatabaseQueryExecutor $executor): void
+    public static function createAppearanceSettings(DatabaseQueryExecutorInterface $executor): void
     {
         $executor->execute(
             <<<'SQL'


### PR DESCRIPTION
## Summary

- **composer.lock の NENE2 pin 是正**: `hideyukimori/nene2` が feature ブランチ `dev-feat/908-ft182-batchlog`（commit `5fbd940`）に固定されていたのを `composer require hideyukimori/nene2:^1.7` でリリース版に揃えた。symlink 運用（`repositories: path -> ../NENE2`）を維持したまま、path repo の `options.versions` でバージョンを `1.7.0` に明示（`../NENE2` の git 状態から都度 `dev-<branch>` を拾ってしまう挙動を止める）。`dist.reference` は現在の `../NENE2`（main）HEAD を指しており、main 追随は継続。
- **PDF 取り込みの TX 化**: `CreatePdfSourceUseCase::execute()` の `sources->save` → `documents->save` → `chunks->save`（複数回）→ `sources->update`（Ready）が `DatabaseTransactionManagerInterface::transactional()` の外で実行されており、途中で例外が飛ぶと `documents`/`chunks` が不整合な状態で残り得た（非原子）。success path を `transactional(fn($executor) => ...)` 一本に束ね、失敗時はロールバック後に非トランザクションの `DatabaseQueryExecutorInterface` で Failed ステータスの補償レコードを別途書き込むよう変更（admin UI での失敗可視化は維持）。
- DI 側は他リポ（nene-vault 等）と同じ `Closure(DatabaseQueryExecutorInterface): XRepositoryInterface` ファクトリパターンで `IngestionServiceProvider` を更新。
- テストは `:memory:` SQLite ではなく `Nene2\Testing\DatabaseTestKit::sqlite()`（file-backed）に切替（`transactional()` が別コネクションを開くため `:memory:` では別 DB になり検証できない）。ロールバックを確認する新規テストを追加。

Closes #324

Self-review: backend-api, database

## Test plan

- [x] `composer check`（401 tests, PHPStan level 8, CS-Fixer, OpenAPI, MCP — all green）
- [x] 新規 `test_execute_rolls_back_documents_and_chunks_when_a_write_fails_midway`：チャンク書込みを意図的に失敗させ、`documents` テーブルが空のまま・`sources` に Failed の補償レコード1件のみが残ることを確認
- [x] 既存 `test_execute_persists_pdf_source_document_and_chunks` は file-backed SQLite に切替後も green