### PR TITLE
fix: 検品C 先行セキュリティ2件（pagination 上限 clamp / .env 0640・escape）

### DIFF
--- a/src/Install/EnvFileWriter.php
+++ b/src/Install/EnvFileWriter.php
@@ -4,10 +4,25 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Install;
 
+use Nene2\Install\EnvironmentWriter;
+use RuntimeException;
+
+/**
+ * Renders the installed `.env` by merging operator-supplied values into the committed
+ * `.env.example` template (comments and untouched defaults are preserved verbatim).
+ *
+ * Security-critical work is delegated to NENE2's {@see EnvironmentWriter}: every value the
+ * operator supplies is serialised through it, so quotes, spaces, `#`, `$`, backslashes and the
+ * like round-trip safely through phpdotenv and line breaks / null bytes are refused (closing the
+ * `.env` injection hole). The file is written atomically and `chmod`ed to 0640, failing closed if
+ * it cannot be made non-world-readable — so the DB password and JWT secret are never left readable
+ * by every user on a shared host.
+ */
 final readonly class EnvFileWriter
 {
     public function __construct(
         private string $projectRoot,
+        private EnvironmentWriter $environmentWriter,
     ) {
     }
 
@@ -54,7 +69,7 @@ final readonly class EnvFileWriter
             $key = $matches[1];
 
             if (array_key_exists($key, $values)) {
-                $output[] = $key . '=' . $this->escapeValue($values[$key]);
+                $output[] = $this->serializeLine($key, $values[$key]);
                 $writtenKeys[$key] = true;
 
                 continue;
@@ -65,27 +80,63 @@ final readonly class EnvFileWriter
 
         foreach ($values as $key => $value) {
             if (!isset($writtenKeys[$key])) {
-                $output[] = $key . '=' . $this->escapeValue($value);
+                $output[] = $this->serializeLine($key, $value);
             }
         }
 
         $content = implode(PHP_EOL, $output) . PHP_EOL;
 
-        if (file_put_contents($targetPath, $content, LOCK_EX) === false) {
-            throw new InstallRuntimeException('Unable to write .env file.');
-        }
+        $this->writeAtomically($targetPath, $content);
     }
 
-    private function escapeValue(string $value): string
+    /**
+     * Serialise a single `KEY=value` line through the NENE2 EnvironmentWriter so the value is
+     * escaped (and line breaks / null bytes are rejected) exactly as the toolkit does.
+     */
+    private function serializeLine(string $key, string $value): string
     {
-        if ($value === '') {
-            return '';
+        try {
+            $serialized = $this->environmentWriter->serialize([$key => $value]);
+        } catch (RuntimeException $exception) {
+            throw new InstallRuntimeException(
+                sprintf('Unable to serialise the environment value for %s: %s', $key, $exception->getMessage()),
+                0,
+                $exception,
+            );
         }
 
-        if (preg_match('/[\s#"\']/', $value) === 1) {
-            return '"' . str_replace(['\\', '"'], ['\\\\', '\\"'], $value) . '"';
+        return rtrim($serialized, "\n");
+    }
+
+    /**
+     * Atomically write the rendered content, refusing to persist secrets in a world-readable file
+     * (fail-closed on 0640, mirroring EnvironmentWriter's own guarantee for the template case).
+     */
+    private function writeAtomically(string $path, string $content): void
+    {
+        $tmp = $path . '.tmp.' . bin2hex(random_bytes(6));
+
+        if (@file_put_contents($tmp, $content, LOCK_EX) === false) {
+            throw new InstallRuntimeException('Unable to write .env file.');
         }
 
-        return $value;
+        @chmod($tmp, 0640);
+
+        $perms = fileperms($tmp);
+
+        if ($perms !== false && ($perms & 0007) !== 0) {
+            @unlink($tmp);
+
+            throw new InstallRuntimeException(
+                'The .env file could not be restricted to non-world-readable permissions; '
+                . 'refusing to persist the database password and JWT secret where any host user could read them.',
+            );
+        }
+
+        if (!@rename($tmp, $path)) {
+            @unlink($tmp);
+
+            throw new InstallRuntimeException('Unable to write .env file.');
+        }
     }
 }

--- a/src/Install/InstallServiceProvider.php
+++ b/src/Install/InstallServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Install\EnvironmentWriter;
 use NeneCorpus\Http\BasePathMiddleware;
 use NeneCorpus\Http\RuntimeServiceProvider;
 use Psr\Container\ContainerInterface;
@@ -55,7 +56,7 @@ final readonly class InstallServiceProvider implements ServiceProviderInterface
                         throw new LogicException('Project root service is invalid.');
                     }
 
-                    return new EnvFileWriter($projectRoot);
+                    return new EnvFileWriter($projectRoot, new EnvironmentWriter());
                 },
             )
             ->set(

--- a/src/Message/ListChatSessionMessagesHandler.php
+++ b/src/Message/ListChatSessionMessagesHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\Message;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
 use Nene2\Routing\Router;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,14 +22,16 @@ final readonly class ListChatSessionMessagesHandler
     {
         $parameters = $request->getAttribute(Router::PARAMETERS_ATTRIBUTE, []);
         $sessionId = (int) ($parameters['id'] ?? 0);
-        $query = $request->getQueryParams();
-        $limit = isset($query['limit']) ? (int) $query['limit'] : 100;
-        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+
+        // Bound the page size structurally: an unbounded ?limit= is a DoS / limit-injection
+        // vector. The parser keeps the historical default of 100, caps at the use case's own
+        // MAX_LIMIT (200), and rejects out-of-range values with 422 (envelope unchanged here).
+        $pagination = PaginationQueryParser::parse($request, defaultLimit: 100, maxLimit: 200);
 
         $messages = $this->useCase->execute(new ListChatSessionMessagesInput(
             sessionId: $sessionId,
-            limit: $limit,
-            offset: $offset,
+            limit: $pagination->limit,
+            offset: $pagination->offset,
         ));
 
         return $this->response->create([

--- a/src/Session/ListChatSessionsHandler.php
+++ b/src/Session/ListChatSessionsHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\Session;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -18,11 +19,15 @@ final readonly class ListChatSessionsHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $query = $request->getQueryParams();
-        $limit = isset($query['limit']) ? (int) $query['limit'] : 50;
-        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+        // Bound the page size structurally: an unbounded ?limit= is a DoS / limit-injection
+        // vector. The parser keeps the historical default of 50 and rejects out-of-range
+        // values with 422 (response envelope is intentionally left unchanged here).
+        $pagination = PaginationQueryParser::parse($request, defaultLimit: 50, maxLimit: 200);
 
-        $output = $this->useCase->execute(new ListChatSessionsInput(limit: $limit, offset: $offset));
+        $output = $this->useCase->execute(new ListChatSessionsInput(
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
 
         return $this->response->create([
             'sessions' => array_map(

--- a/src/Source/ListSourcesHandler.php
+++ b/src/Source/ListSourcesHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\Source;
 
 use Nene2\Http\JsonResponseFactory;
+use Nene2\Http\PaginationQueryParser;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -18,11 +19,15 @@ final readonly class ListSourcesHandler
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $query = $request->getQueryParams();
-        $limit = isset($query['limit']) ? (int) $query['limit'] : 50;
-        $offset = isset($query['offset']) ? (int) $query['offset'] : 0;
+        // Bound the page size structurally: an unbounded ?limit= is a DoS / limit-injection
+        // vector. The parser keeps the historical default of 50 and rejects out-of-range
+        // values with 422 (response envelope is intentionally left unchanged here).
+        $pagination = PaginationQueryParser::parse($request, defaultLimit: 50, maxLimit: 200);
 
-        $output = $this->useCase->execute(new ListSourcesInput(limit: $limit, offset: $offset));
+        $output = $this->useCase->execute(new ListSourcesInput(
+            limit: $pagination->limit,
+            offset: $pagination->offset,
+        ));
 
         return $this->response->create([
             'sources' => array_map(

--- a/tests/Http/AdminListPaginationTest.php
+++ b/tests/Http/AdminListPaginationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Http;
+
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Guards the pagination limit clamp (security: an unbounded ?limit= is a DoS / limit-injection
+ * vector). The admin list endpoints must bound the page size and reject an out-of-range limit
+ * with 422 rather than accept an arbitrarily large one. The rejection happens in the handler,
+ * before any repository query, so it holds even for endpoints whose data is not seeded here.
+ */
+final class AdminListPaginationTest extends TestCase
+{
+    private const JWT_SECRET = 'test-admin-jwt-secret';
+
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-pagination-' . uniqid('', true) . '.sqlite';
+
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_ENV['DB_ADAPTER'] = 'sqlite';
+        $_ENV['DB_NAME'] = $this->databasePath;
+        $_SERVER['DB_ADAPTER'] = 'sqlite';
+        $_SERVER['DB_NAME'] = $this->databasePath;
+
+        $container = (new RuntimeContainerFactory())->create();
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+
+        AdminHttpTestSupport::seedCorpusSchema($executor);
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        unset(
+            $_ENV['DB_ADAPTER'],
+            $_SERVER['DB_ADAPTER'],
+            $_ENV['DB_NAME'],
+            $_SERVER['DB_NAME'],
+        );
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function listEndpoints(): iterable
+    {
+        yield 'sources' => ['/admin/sources'];
+        yield 'chat sessions' => ['/admin/chat/sessions'];
+        yield 'chat session messages' => ['/admin/chat/sessions/1/messages'];
+    }
+
+    #[DataProvider('listEndpoints')]
+    public function test_limit_above_maximum_is_rejected_with_422(string $path): void
+    {
+        $response = $this->authorizedRequest('GET', $path . '?limit=999999');
+
+        self::assertSame(422, $response->getStatusCode(), $path . ' must reject an over-range limit');
+    }
+
+    #[DataProvider('listEndpoints')]
+    public function test_non_positive_limit_is_rejected_with_422(string $path): void
+    {
+        $response = $this->authorizedRequest('GET', $path . '?limit=0');
+
+        self::assertSame(422, $response->getStatusCode(), $path . ' must reject a non-positive limit');
+    }
+
+    public function test_sources_accepts_limit_within_bounds(): void
+    {
+        $response = $this->authorizedRequest('GET', '/admin/sources?limit=10&offset=0');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertArrayHasKey('sources', $this->decodeJson($response));
+    }
+
+    public function test_sources_accepts_maximum_limit(): void
+    {
+        $response = $this->authorizedRequest('GET', '/admin/sources?limit=200');
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    private function authorizedRequest(string $method, string $path): ResponseInterface
+    {
+        $token = $this->loginToken();
+
+        return $this->application()->handle(
+            $this->factory()->createServerRequest($method, 'https://example.test' . $path)
+                ->withHeader('Authorization', 'Bearer ' . $token),
+        );
+    }
+
+    private function loginToken(): string
+    {
+        $response = $this->application()->handle(
+            $this->factory()->createServerRequest('POST', 'https://example.test/admin/auth/login')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->factory()->createStream(json_encode([
+                    'email' => 'admin@example.com',
+                    'password' => 'secret-password',
+                ], JSON_THROW_ON_ERROR))),
+        );
+
+        $payload = $this->decodeJson($response);
+
+        return (string) $payload['access_token'];
+    }
+
+    private function application(): RequestHandlerInterface
+    {
+        $container = (new RuntimeContainerFactory())->create();
+        $application = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $application);
+
+        return $application;
+    }
+
+    private function factory(): Psr17Factory
+    {
+        return new Psr17Factory();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $decoded = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Install/EnvFileWriterTest.php
+++ b/tests/Install/EnvFileWriterTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Install;
+
+use Dotenv\Dotenv;
+use Nene2\Install\EnvironmentWriter;
+use NeneCorpus\Install\EnvFileWriter;
+use NeneCorpus\Install\InstallRuntimeException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the security fixes delegated to NENE2's EnvironmentWriter: the installed .env must be
+ * written non-world-readable (0640, fail-closed) and every operator-supplied value must be
+ * escaped so it round-trips through phpdotenv verbatim (no .env injection).
+ */
+final class EnvFileWriterTest extends TestCase
+{
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/nene-corpus-envwriter-' . uniqid('', true);
+        mkdir($this->projectRoot, 0775, true);
+
+        file_put_contents(
+            $this->projectRoot . '/.env.example',
+            <<<'ENV'
+                APP_ENV=local
+                APP_NAME="NeNe Corpus"
+                # --- Admin auth — never commit real secrets ---
+                NENE2_LOCAL_JWT_SECRET=
+                ANTHROPIC_API_KEY=
+                DB_PASSWORD=
+                ENV,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['/.env', '/.env.example'] as $file) {
+            if (is_file($this->projectRoot . $file)) {
+                unlink($this->projectRoot . $file);
+            }
+        }
+
+        if (is_dir($this->projectRoot)) {
+            rmdir($this->projectRoot);
+        }
+    }
+
+    public function test_env_is_written_non_world_readable(): void
+    {
+        $this->writer()->write(['DB_PASSWORD' => 'secret']);
+
+        $envPath = $this->projectRoot . '/.env';
+        self::assertFileExists($envPath);
+
+        $perms = fileperms($envPath);
+        self::assertNotFalse($perms);
+        self::assertSame(0, $perms & 0007, '.env must not be world-accessible');
+        self::assertSame(0640, $perms & 0777);
+    }
+
+    #[DataProvider('awkwardValues')]
+    public function test_values_round_trip_through_phpdotenv(string $value): void
+    {
+        $this->writer()->write([
+            'DB_PASSWORD' => $value,
+            'ANTHROPIC_API_KEY' => $value,
+        ]);
+
+        $content = file_get_contents($this->projectRoot . '/.env');
+        self::assertIsString($content);
+
+        $parsed = Dotenv::parse($content);
+        self::assertSame($value, $parsed['DB_PASSWORD'] ?? null);
+        self::assertSame($value, $parsed['ANTHROPIC_API_KEY'] ?? null);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function awkwardValues(): iterable
+    {
+        yield 'dollar (phpdotenv expansion)' => ['pa$$word'];
+        yield 'braced var' => ['${HOME}'];
+        yield 'double quote' => ['has"quote'];
+        yield 'space and hash' => ['has space #and hash'];
+        yield 'backslash' => ['back\\slash'];
+        yield 'everything' => ['mix "a" $b \\c #d = e'];
+    }
+
+    public function test_template_comments_are_preserved(): void
+    {
+        $this->writer()->write(['DB_PASSWORD' => 'secret']);
+
+        $content = file_get_contents($this->projectRoot . '/.env');
+        self::assertIsString($content);
+        self::assertStringContainsString('# --- Admin auth', $content);
+    }
+
+    public function test_value_with_newline_is_rejected(): void
+    {
+        $this->expectException(InstallRuntimeException::class);
+
+        $this->writer()->write(['DB_PASSWORD' => "line1\nINJECTED=evil"]);
+    }
+
+    private function writer(): EnvFileWriter
+    {
+        return new EnvFileWriter($this->projectRoot, new EnvironmentWriter());
+    }
+}

--- a/tests/Notification/UpdateNotificationSettingsUseCaseTest.php
+++ b/tests/Notification/UpdateNotificationSettingsUseCaseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Tests\Notification;
 
+use Nene2\Install\EnvironmentWriter;
 use NeneCorpus\Config\EnvironmentVariableUpdater;
 use NeneCorpus\Install\EnvFileWriter;
 use NeneCorpus\Notification\GetNotificationSettingsUseCase;
@@ -85,7 +86,7 @@ final class UpdateNotificationSettingsUseCaseTest extends TestCase
     private function makeUseCase(): UpdateNotificationSettingsUseCase
     {
         return new UpdateNotificationSettingsUseCase(
-            new EnvFileWriter($this->tmpDir),
+            new EnvFileWriter($this->tmpDir, new EnvironmentWriter()),
             new EnvironmentVariableUpdater(),
             new GetNotificationSettingsUseCase(),
         );


### PR DESCRIPTION
## 目的
検品 C レーンの先行セキュリティ2件。いずれも横断監査（`_work/reports/2026-07-06/upstream-design/07-pagination.md`, `08-installer.md`）で特定した実害のある穴を、NENE2 既存部品の採用で塞ぐ。envelope 統一など破壊的変更は含めない（Wave2 で別途）。

## 変更点
### S2: pagination 上限 clamp（`Closes #326`）
上限なしの `?limit=` を受け付けていた 3 handler に NENE2 `PaginationQueryParser` を drop-in 採用。
- `ListSourcesHandler`（既定50・上限200）
- `ListChatSessionsHandler`（既定50・上限200）
- `ListChatSessionMessagesHandler`（既定100・上限200 = UseCase の MAX_LIMIT と一致）

**limit の解釈・上限のみ**取り込み、レスポンス envelope（`sources`/`sessions`/`messages` 名前付きキー）は不変。範囲外・非正の limit は 422。既定ページサイズは現行値を温存（縮小しない）。`ListDocumentsHandler` は既に max 200 clamp 済みのため対象外。

### S3: `.env` の 0640 fail-closed 書き込み + 値エスケープ（`Closes #327`）
`EnvFileWriter` に NENE2 `Nene2\Install\EnvironmentWriter` を注入。
- 値のシリアライズ（`\ " $` escape・改行/NUL 拒否）を EnvironmentWriter に委譲 → `.env` インジェクションを防止（従来 `escapeValue` は `$` を escape せず改行も許容していた）
- 書き込みを atomic + `chmod 0640` fail-closed 化 → world-readable な DB パスワード/JWT secret の露出を防止（0640 にできなければ書込拒否）
- `.env.example` テンプレートマージ（コメント・既定キー保持）は維持（設計レポート §7 推奨の最小案 b）

## 検証
- `composer test`: **418 tests / 1354 assertions 緑**（新規: pagination 6・EnvFileWriter 9）
- `composer analyse`（PHPStan level8）: No errors
- `composer cs`（CS-Fixer dry-run）: 0 fixable
- `composer openapi` / `composer mcp`: valid
- `php -l` 変更ファイル: syntax OK

## セルフレビュー
Self-review: backend-api, middleware-security, database

🤖 Generated with [Claude Code](https://claude.com/claude-code)