### PR TITLE
feat(clock): 生 time()/date() を NENE2 ClockInterface 注入に置換する

### DIFF
--- a/src/AdminAuth/AdminAuthServiceProvider.php
+++ b/src/AdminAuth/AdminAuthServiceProvider.php
@@ -14,6 +14,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Mail\MailerInterface;
@@ -80,14 +81,19 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                 static function (ContainerInterface $container): LoginAdminUseCaseInterface {
                     $users = $container->get(AdminUserRepositoryInterface::class);
                     $issuer = $container->get(self::TOKEN_ISSUER);
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$users instanceof AdminUserRepositoryInterface) {
                         throw new LogicException('Admin user repository service is invalid.');
                     }
 
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
                     $issuer = $issuer instanceof TokenIssuerInterface ? $issuer : null;
 
-                    return new LoginAdminUseCase($users, $issuer);
+                    return new LoginAdminUseCase($users, $issuer, $clock);
                 },
             )
             ->set(
@@ -224,6 +230,7 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                     $users  = $container->get(AdminUserRepositoryInterface::class);
                     $resets = $container->get(AdminPasswordResetRepositoryInterface::class);
                     $mailer = $container->get(MailerInterface::class);
+                    $clock  = $container->get(ClockInterface::class);
 
                     if (!$users instanceof AdminUserRepositoryInterface) {
                         throw new LogicException('Admin user repository service is invalid.');
@@ -237,7 +244,11 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Mailer service is invalid.');
                     }
 
-                    return new RequestPasswordResetUseCase($users, $resets, $mailer);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new RequestPasswordResetUseCase($users, $resets, $mailer, $clock);
                 },
             )
             ->set(
@@ -245,6 +256,7 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                 static function (ContainerInterface $container): ConfirmPasswordResetUseCaseInterface {
                     $resets = $container->get(AdminPasswordResetRepositoryInterface::class);
                     $users  = $container->get(AdminUserRepositoryInterface::class);
+                    $clock  = $container->get(ClockInterface::class);
 
                     if (!$resets instanceof AdminPasswordResetRepositoryInterface) {
                         throw new LogicException('Admin password reset repository service is invalid.');
@@ -254,7 +266,11 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Admin user repository service is invalid.');
                     }
 
-                    return new ConfirmPasswordResetUseCase($resets, $users);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new ConfirmPasswordResetUseCase($resets, $users, $clock);
                 },
             )
             ->set(
@@ -308,6 +324,7 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                 static function (ContainerInterface $container): AdminLoginRateLimitMiddleware {
                     $problemDetails = $container->get(ProblemDetailsResponseFactory::class);
                     $storage        = $container->get(RateLimitStorageInterface::class);
+                    $clock          = $container->get(ClockInterface::class);
 
                     if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
                         throw new LogicException('Problem details response factory service is invalid.');
@@ -317,7 +334,11 @@ final readonly class AdminAuthServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Rate limit storage service is invalid.');
                     }
 
-                    return new AdminLoginRateLimitMiddleware($problemDetails, $storage);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new AdminLoginRateLimitMiddleware($problemDetails, $storage, $clock);
                 },
             )
             ->set(

--- a/src/AdminAuth/AdminLoginRateLimitMiddleware.php
+++ b/src/AdminAuth/AdminLoginRateLimitMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\AdminAuth;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Http\RequestMetadataExtractor;
 use Psr\Http\Message\ResponseInterface;
@@ -31,6 +32,7 @@ final readonly class AdminLoginRateLimitMiddleware implements MiddlewareInterfac
     public function __construct(
         private ProblemDetailsResponseFactory $problemDetails,
         private RateLimitStorageInterface $storage,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -49,7 +51,7 @@ final readonly class AdminLoginRateLimitMiddleware implements MiddlewareInterfac
         $result = $this->storage->hit($key, self::WINDOW_SECONDS);
 
         if ($result['count'] > self::MAX_ATTEMPTS) {
-            $retryAfter = max(0, $result['reset_at'] - time());
+            $retryAfter = max(0, $result['reset_at'] - $this->clock->now()->getTimestamp());
             $response   = $this->problemDetails->create(
                 $request,
                 'too_many_requests',

--- a/src/AdminAuth/AdminPasswordReset.php
+++ b/src/AdminAuth/AdminPasswordReset.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneCorpus\AdminAuth;
 
+use Nene2\Http\ClockInterface;
+
 final readonly class AdminPasswordReset
 {
     public function __construct(
@@ -16,9 +18,9 @@ final readonly class AdminPasswordReset
     ) {
     }
 
-    public function isExpired(): bool
+    public function isExpired(ClockInterface $clock): bool
     {
-        return strtotime($this->expiresAt) < time();
+        return strtotime($this->expiresAt) < $clock->now()->getTimestamp();
     }
 
     public function isUsed(): bool

--- a/src/AdminAuth/ConfirmPasswordResetUseCase.php
+++ b/src/AdminAuth/ConfirmPasswordResetUseCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NeneCorpus\AdminAuth;
 
+use Nene2\Http\ClockInterface;
+
 final readonly class ConfirmPasswordResetUseCase implements ConfirmPasswordResetUseCaseInterface
 {
     private const MIN_PASSWORD_LENGTH = 8;
@@ -11,6 +13,7 @@ final readonly class ConfirmPasswordResetUseCase implements ConfirmPasswordReset
     public function __construct(
         private AdminPasswordResetRepositoryInterface $resets,
         private AdminUserRepositoryInterface $users,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -27,7 +30,7 @@ final readonly class ConfirmPasswordResetUseCase implements ConfirmPasswordReset
         $tokenHash = hash('sha256', $rawToken);
         $reset = $this->resets->findByTokenHash($tokenHash);
 
-        if ($reset === null || $reset->isExpired() || $reset->isUsed()) {
+        if ($reset === null || $reset->isExpired($this->clock) || $reset->isUsed()) {
             throw new InvalidPasswordResetTokenException('The reset token is invalid, expired, or already used.');
         }
 

--- a/src/AdminAuth/LoginAdminUseCase.php
+++ b/src/AdminAuth/LoginAdminUseCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\AdminAuth;
 
 use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Http\ClockInterface;
 
 final readonly class LoginAdminUseCase implements LoginAdminUseCaseInterface
 {
@@ -16,6 +17,7 @@ final readonly class LoginAdminUseCase implements LoginAdminUseCaseInterface
     public function __construct(
         private AdminUserRepositoryInterface $adminUsers,
         private ?TokenIssuerInterface $tokenIssuer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -32,7 +34,7 @@ final readonly class LoginAdminUseCase implements LoginAdminUseCaseInterface
             throw new InvalidAdminCredentialsException('Invalid email or password.');
         }
 
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $expiresAt = $now + self::TOKEN_TTL_SECONDS;
 
         $token = $this->tokenIssuer->issue([

--- a/src/AdminAuth/RequestPasswordResetUseCase.php
+++ b/src/AdminAuth/RequestPasswordResetUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneCorpus\AdminAuth;
 
+use Nene2\Http\ClockInterface;
 use NeneCorpus\Mail\MailerInterface;
 use NeneCorpus\Mail\MailMessage;
 
@@ -16,6 +17,7 @@ final readonly class RequestPasswordResetUseCase implements RequestPasswordReset
         private AdminUserRepositoryInterface $users,
         private AdminPasswordResetRepositoryInterface $resets,
         private MailerInterface $mailer,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -39,8 +41,8 @@ final readonly class RequestPasswordResetUseCase implements RequestPasswordReset
 
         $rawToken = bin2hex(random_bytes(32));
         $tokenHash = hash('sha256', $rawToken);
-        $now = gmdate('Y-m-d H:i:s');
-        $expiresAt = gmdate('Y-m-d H:i:s', time() + self::TOKEN_TTL_SECONDS);
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
+        $expiresAt = gmdate('Y-m-d H:i:s', $this->clock->now()->getTimestamp() + self::TOKEN_TTL_SECONDS);
 
         $this->resets->save(new AdminPasswordReset(
             tokenHash: $tokenHash,

--- a/src/Analytics/AnalyticsServiceProvider.php
+++ b/src/Analytics/AnalyticsServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
@@ -42,12 +43,17 @@ final readonly class AnalyticsServiceProvider implements ServiceProviderInterfac
                 GetAnalyticsSummaryUseCaseInterface::class,
                 static function (ContainerInterface $container): GetAnalyticsSummaryUseCaseInterface {
                     $repo = $container->get(AnalyticsRepositoryInterface::class);
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$repo instanceof AnalyticsRepositoryInterface) {
                         throw new LogicException('Analytics repository service is invalid.');
                     }
 
-                    return new GetAnalyticsSummaryUseCase($repo);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new GetAnalyticsSummaryUseCase($repo, $clock);
                 },
             )
             ->set(

--- a/src/Analytics/GetAnalyticsSummaryUseCase.php
+++ b/src/Analytics/GetAnalyticsSummaryUseCase.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Analytics;
 
+use Nene2\Http\ClockInterface;
+
 final readonly class GetAnalyticsSummaryUseCase implements GetAnalyticsSummaryUseCaseInterface
 {
     public function __construct(
         private AnalyticsRepositoryInterface $repo,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -45,7 +48,7 @@ final readonly class GetAnalyticsSummaryUseCase implements GetAnalyticsSummaryUs
         $result = [];
 
         for ($i = $days - 1; $i >= 0; $i--) {
-            $date = gmdate('Y-m-d', time() - $i * 86400);
+            $date = gmdate('Y-m-d', $this->clock->now()->getTimestamp() - $i * 86400);
             $data = $byDate[$date] ?? null;
 
             $result[] = new DailyCount(

--- a/src/ChatLimits/ChatLimitsServiceProvider.php
+++ b/src/ChatLimits/ChatLimitsServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
@@ -41,6 +42,7 @@ final readonly class ChatLimitsServiceProvider implements ServiceProviderInterfa
                 static function (ContainerInterface $container): ChatTokenTrackerInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
                     $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
@@ -50,7 +52,11 @@ final readonly class ChatLimitsServiceProvider implements ServiceProviderInterfa
                         throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
                     }
 
-                    return new PdoChatTokenTracker($query, $orgIdHolder);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new PdoChatTokenTracker($query, $orgIdHolder, $clock);
                 },
             )
             ->set(

--- a/src/ChatLimits/PdoChatTokenTracker.php
+++ b/src/ChatLimits/PdoChatTokenTracker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\ChatLimits;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 /**
@@ -23,6 +24,7 @@ final readonly class PdoChatTokenTracker implements ChatTokenTrackerInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedOrgIdHolder $orgIdHolder,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -56,7 +58,7 @@ final readonly class PdoChatTokenTracker implements ChatTokenTrackerInterface
 
     private function addToWindow(string $key, int $amount): void
     {
-        $now = time();
+        $now = $this->clock->now()->getTimestamp();
         $row = $this->query->fetchOne(
             'SELECT hit_count, reset_at FROM rate_limit_buckets WHERE bucket_key = ?',
             [$key],
@@ -104,7 +106,7 @@ final readonly class PdoChatTokenTracker implements ChatTokenTrackerInterface
             return 0;
         }
 
-        if ((int) $row['reset_at'] <= time()) {
+        if ((int) $row['reset_at'] <= $this->clock->now()->getTimestamp()) {
             return 0;
         }
 
@@ -113,6 +115,6 @@ final readonly class PdoChatTokenTracker implements ChatTokenTrackerInterface
 
     private function now(): string
     {
-        return gmdate('Y-m-d H:i:s');
+        return $this->clock->now()->format('Y-m-d H:i:s');
     }
 }

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -16,9 +16,11 @@ use Nene2\Database\PdoDatabaseTransactionManager;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Http\ResponseEmitter;
 use Nene2\Http\RuntimeApplicationFactory;
+use Nene2\Http\UtcClock;
 use Nene2\Log\MonologLoggerFactory;
 use Nene2\Log\RequestIdHolder;
 use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
@@ -46,6 +48,11 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
         $builder->addProvider(new ApplicationServiceProvider());
 
         $builder
+            // Single source of "now" for the whole app. Inject ClockInterface into
+            // use cases/services instead of reading the wall clock (time()/date())
+            // directly; UtcClock keeps production behaviour identical while tests can
+            // bind a fixed clock for determinism.
+            ->set(ClockInterface::class, static fn (ContainerInterface $container): ClockInterface => new UtcClock())
             ->set(
                 ConfigLoader::class,
                 static function (ContainerInterface $container): ConfigLoader {

--- a/src/Notification/NotificationServiceProvider.php
+++ b/src/Notification/NotificationServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Config\EnvironmentVariableUpdater;
@@ -95,6 +96,7 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                 static function (ContainerInterface $container): SendDailyReportUseCase {
                     $mailer = $container->get(MailerInterface::class);
                     $repo   = $container->get(DailyReportRepositoryInterface::class);
+                    $clock  = $container->get(ClockInterface::class);
 
                     if (!$mailer instanceof MailerInterface) {
                         throw new LogicException('Mailer service is invalid.');
@@ -104,7 +106,11 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                         throw new LogicException('DailyReportRepository service is invalid.');
                     }
 
-                    return new SendDailyReportUseCase($mailer, $repo);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new SendDailyReportUseCase($mailer, $repo, $clock);
                 },
             )
             ->set(
@@ -113,6 +119,7 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                     $mailer      = $container->get(MailerInterface::class);
                     $storage     = $container->get(RateLimitStorageInterface::class);
                     $orgIdHolder = $container->get(RequestScopedOrgIdHolder::class);
+                    $clock       = $container->get(ClockInterface::class);
 
                     if (!$mailer instanceof MailerInterface) {
                         throw new LogicException('Mailer service is invalid.');
@@ -126,7 +133,11 @@ final readonly class NotificationServiceProvider implements ServiceProviderInter
                         throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
                     }
 
-                    return new RateLimitNotifier($mailer, $storage, $orgIdHolder);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new RateLimitNotifier($mailer, $storage, $orgIdHolder, $clock);
                 },
             )
             ->set(

--- a/src/Notification/RateLimitNotifier.php
+++ b/src/Notification/RateLimitNotifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Notification;
 
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Mail\MailerInterface;
 use NeneCorpus\Mail\MailMessage;
@@ -22,6 +23,7 @@ final readonly class RateLimitNotifier
         private MailerInterface $mailer,
         private RateLimitStorageInterface $storage,
         private RequestScopedOrgIdHolder $orgIdHolder,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -42,7 +44,7 @@ final readonly class RateLimitNotifier
         $orgId = $this->orgIdHolder->getId() ?? 1;
 
         // Track daily hits regardless of cooldown (org-scoped)
-        $today = date('Y-m-d');
+        $today = $this->clock->now()->format('Y-m-d');
         $this->storage->hit(self::HITS_KEY_PREFIX . $orgId . ':' . $today, 86400);
 
         // Cooldown check — use 1 hit-per-window as the gate (org-scoped)
@@ -69,7 +71,7 @@ final readonly class RateLimitNotifier
 
     private function buildText(string $ip, string $scope, int $cooldownSeconds): string
     {
-        $time = date('Y-m-d H:i:s');
+        $time = $this->clock->now()->format('Y-m-d H:i:s');
         $nextNotify = (int) ($cooldownSeconds / 60);
 
         return implode("\n", [
@@ -88,7 +90,7 @@ final readonly class RateLimitNotifier
 
     private function buildHtml(string $ip, string $scope, int $cooldownSeconds): string
     {
-        $time       = htmlspecialchars(date('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8');
+        $time       = htmlspecialchars($this->clock->now()->format('Y-m-d H:i:s'), ENT_QUOTES, 'UTF-8');
         $ip         = htmlspecialchars($ip, ENT_QUOTES, 'UTF-8');
         $scope      = htmlspecialchars($scope, ENT_QUOTES, 'UTF-8');
         $nextNotify = (int) ($cooldownSeconds / 60);

--- a/src/Notification/SendDailyReportUseCase.php
+++ b/src/Notification/SendDailyReportUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace NeneCorpus\Notification;
 
+use Nene2\Http\ClockInterface;
 use NeneCorpus\Mail\MailerInterface;
 use NeneCorpus\Mail\MailMessage;
 use NeneCorpus\Mail\MailSendException;
@@ -13,6 +14,7 @@ final readonly class SendDailyReportUseCase
     public function __construct(
         private MailerInterface $mailer,
         private DailyReportRepositoryInterface $reportRepository,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -26,7 +28,7 @@ final readonly class SendDailyReportUseCase
             throw new NotificationException('SMTP is not configured.');
         }
 
-        $date  = $date ?? date('Y-m-d');
+        $date  = $date ?? $this->clock->now()->format('Y-m-d');
         $stats = $this->reportRepository->getStats($date);
 
         $subject = sprintf('[NeNe Corpus] 日次チャットレポート %s', $date);

--- a/src/Organization/OrganizationServiceProvider.php
+++ b/src/Organization/OrganizationServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -23,12 +24,17 @@ final readonly class OrganizationServiceProvider implements ServiceProviderInter
                 OrganizationRepositoryInterface::class,
                 static function (ContainerInterface $c): OrganizationRepositoryInterface {
                     $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoOrganizationRepository($query);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new PdoOrganizationRepository($query, $clock);
                 },
             )
             ->set(

--- a/src/Organization/PdoOrganizationRepository.php
+++ b/src/Organization/PdoOrganizationRepository.php
@@ -6,6 +6,7 @@ namespace NeneCorpus\Organization;
 
 use Nene2\Database\DatabaseConstraintException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 
 final readonly class PdoOrganizationRepository implements OrganizationRepositoryInterface
 {
@@ -13,6 +14,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -59,7 +61,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
 
     public function save(Organization $organization): int
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         try {
             $this->query->execute(
@@ -89,7 +91,7 @@ final readonly class PdoOrganizationRepository implements OrganizationRepository
             throw new OrganizationNotFoundException(0);
         }
 
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         $this->query->execute(
             'UPDATE organizations SET name = ?, slug = ?, custom_domain = ?, external_id = ?, plan = ?, is_active = ?, updated_at = ? WHERE id = ?',

--- a/src/RateLimit/ConsumerChatRateLimitMiddleware.php
+++ b/src/RateLimit/ConsumerChatRateLimitMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\RateLimit;
 
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Chat\SendChatMessageHandler;
 use NeneCorpus\ChatLimits\ChatLimitsRepositoryInterface;
@@ -42,6 +43,7 @@ final readonly class ConsumerChatRateLimitMiddleware implements MiddlewareInterf
         private RateLimitStorageInterface $storage,
         private ChatLimitsRepositoryInterface $limitsRepository,
         private ChatTokenTrackerInterface $tokenTracker,
+        private ClockInterface $clock,
         private ?RateLimitNotifier $notifier = null,
     ) {
     }
@@ -126,7 +128,7 @@ final readonly class ConsumerChatRateLimitMiddleware implements MiddlewareInterf
 
         // 5. Hourly per-IP limit
         $ipCount = 0;
-        $ipResetAt = time() + self::HOURLY_WINDOW;
+        $ipResetAt = $this->clock->now()->getTimestamp() + self::HOURLY_WINDOW;
 
         if ($limits->ipRequestsPerHour > 0) {
             $result = $this->storage->hit('chat:ip:' . $ip, self::HOURLY_WINDOW);
@@ -145,7 +147,7 @@ final readonly class ConsumerChatRateLimitMiddleware implements MiddlewareInterf
         }
 
         $sessionCount = 0;
-        $sessionResetAt = time() + self::HOURLY_WINDOW;
+        $sessionResetAt = $this->clock->now()->getTimestamp() + self::HOURLY_WINDOW;
 
         if ($sessionToken !== '') {
             // 6. Hourly per-session limit
@@ -214,7 +216,7 @@ final readonly class ConsumerChatRateLimitMiddleware implements MiddlewareInterf
         int $resetAt,
         string $scope,
     ): ResponseInterface {
-        $retryAfter = max(0, $resetAt - time());
+        $retryAfter = max(0, $resetAt - $this->clock->now()->getTimestamp());
 
         // Fire notification email (best-effort, never blocks response)
         if ($this->notifier !== null) {

--- a/src/RateLimit/PdoRateLimitStorage.php
+++ b/src/RateLimit/PdoRateLimitStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\RateLimit;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
@@ -13,13 +14,14 @@ final readonly class PdoRateLimitStorage implements RateLimitStorageInterface
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedOrgIdHolder $orgIdHolder,
+        private ClockInterface $clock,
     ) {
     }
 
     public function hit(string $key, int $windowSeconds): array
     {
         $orgId = $this->orgId();
-        $now   = time();
+        $now   = $this->clock->now()->getTimestamp();
         $row   = $this->query->fetchOne(
             'SELECT hit_count, reset_at FROM rate_limit_buckets WHERE organization_id = ? AND bucket_key = ?',
             [$orgId, $key],
@@ -71,6 +73,6 @@ final readonly class PdoRateLimitStorage implements RateLimitStorageInterface
 
     private function now(): string
     {
-        return gmdate('Y-m-d H:i:s');
+        return $this->clock->now()->format('Y-m-d H:i:s');
     }
 }

--- a/src/RateLimit/RateLimitServiceProvider.php
+++ b/src/RateLimit/RateLimitServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Error\ProblemDetailsResponseFactory;
+use Nene2\Http\ClockInterface;
 use Nene2\Middleware\RateLimitStorageInterface;
 use NeneCorpus\ChatLimits\ChatLimitsRepositoryInterface;
 use NeneCorpus\ChatLimits\ChatTokenTrackerInterface;
@@ -28,6 +29,7 @@ final readonly class RateLimitServiceProvider implements ServiceProviderInterfac
                 static function (ContainerInterface $container): RateLimitStorageInterface {
                     $query  = $container->get(DatabaseQueryExecutorInterface::class);
                     $holder = $container->get(RequestScopedOrgIdHolder::class);
+                    $clock  = $container->get(ClockInterface::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
@@ -37,7 +39,11 @@ final readonly class RateLimitServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
                     }
 
-                    return new PdoRateLimitStorage($query, $holder);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new PdoRateLimitStorage($query, $holder, $clock);
                 },
             )
             ->set(
@@ -47,6 +53,7 @@ final readonly class RateLimitServiceProvider implements ServiceProviderInterfac
                     $storage = $container->get(RateLimitStorageInterface::class);
                     $limitsRepository = $container->get(ChatLimitsRepositoryInterface::class);
                     $tokenTracker = $container->get(ChatTokenTrackerInterface::class);
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$problemDetails instanceof ProblemDetailsResponseFactory) {
                         throw new LogicException('Problem details response factory service is invalid.');
@@ -64,10 +71,14 @@ final readonly class RateLimitServiceProvider implements ServiceProviderInterfac
                         throw new LogicException('Chat token tracker service is invalid.');
                     }
 
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
                     /** @var RateLimitNotifier|null $notifier */
                     $notifier = $container->has(RateLimitNotifier::class) ? $container->get(RateLimitNotifier::class) : null;
 
-                    return new ConsumerChatRateLimitMiddleware($problemDetails, $storage, $limitsRepository, $tokenTracker, $notifier instanceof RateLimitNotifier ? $notifier : null);
+                    return new ConsumerChatRateLimitMiddleware($problemDetails, $storage, $limitsRepository, $tokenTracker, $clock, $notifier instanceof RateLimitNotifier ? $notifier : null);
                 },
             );
     }

--- a/src/Session/PdoChatSessionRepository.php
+++ b/src/Session/PdoChatSessionRepository.php
@@ -6,6 +6,7 @@ namespace NeneCorpus\Session;
 
 use InvalidArgumentException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 final readonly class PdoChatSessionRepository implements ChatSessionRepositoryInterface
@@ -17,6 +18,7 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
         private RequestScopedOrgIdHolder $orgIdHolder,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -108,7 +110,7 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
 
     public function deleteOlderThan(int $days): int
     {
-        $cutoff = gmdate('Y-m-d H:i:s', time() - $days * 86400);
+        $cutoff = gmdate('Y-m-d H:i:s', $this->clock->now()->getTimestamp() - $days * 86400);
 
         $before = $this->countAll();
         $this->query->execute('DELETE FROM chat_sessions WHERE created_at < ? AND organization_id = ?', [$cutoff, $this->orgId()]);
@@ -145,6 +147,6 @@ final readonly class PdoChatSessionRepository implements ChatSessionRepositoryIn
 
     private function now(): string
     {
-        return gmdate('Y-m-d H:i:s');
+        return $this->clock->now()->format('Y-m-d H:i:s');
     }
 }

--- a/src/Session/SessionServiceProvider.php
+++ b/src/Session/SessionServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Message\ChatMessageRepositoryInterface;
 use NeneCorpus\Message\ListChatSessionMessagesHandler;
@@ -28,6 +29,7 @@ final readonly class SessionServiceProvider implements ServiceProviderInterface
                 static function (ContainerInterface $container): ChatSessionRepositoryInterface {
                     $query = $container->get(DatabaseQueryExecutorInterface::class);
                     $holder = $container->get(RequestScopedOrgIdHolder::class);
+                    $clock = $container->get(ClockInterface::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
@@ -37,7 +39,11 @@ final readonly class SessionServiceProvider implements ServiceProviderInterface
                         throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
                     }
 
-                    return new PdoChatSessionRepository($query, $holder);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new PdoChatSessionRepository($query, $holder, $clock);
                 },
             )
             ->set(

--- a/src/SystemConfig/PdoSystemConfigRepository.php
+++ b/src/SystemConfig/PdoSystemConfigRepository.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace NeneCorpus\SystemConfig;
 
 use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Http\ClockInterface;
 
 final readonly class PdoSystemConfigRepository implements SystemConfigRepositoryInterface
 {
     public function __construct(
         private DatabaseQueryExecutorInterface $query,
+        private ClockInterface $clock,
     ) {
     }
 
@@ -25,7 +27,7 @@ final readonly class PdoSystemConfigRepository implements SystemConfigRepository
 
     public function set(string $key, string $value): void
     {
-        $now = date('Y-m-d H:i:s');
+        $now = $this->clock->now()->format('Y-m-d H:i:s');
 
         // Use REPLACE INTO for broad DB compatibility (MySQL and SQLite both support it).
         // MySQL: REPLACE = DELETE + INSERT on PK conflict.

--- a/src/SystemConfig/SystemConfigServiceProvider.php
+++ b/src/SystemConfig/SystemConfigServiceProvider.php
@@ -8,6 +8,7 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use Psr\Container\ContainerInterface;
 
@@ -22,12 +23,17 @@ final readonly class SystemConfigServiceProvider implements ServiceProviderInter
                 SystemConfigRepositoryInterface::class,
                 static function (ContainerInterface $c): SystemConfigRepositoryInterface {
                     $query = $c->get(DatabaseQueryExecutorInterface::class);
+                    $clock = $c->get(ClockInterface::class);
 
                     if (!$query instanceof DatabaseQueryExecutorInterface) {
                         throw new LogicException('Database query executor service is invalid.');
                     }
 
-                    return new PdoSystemConfigRepository($query);
+                    if (!$clock instanceof ClockInterface) {
+                        throw new LogicException('Clock service is invalid.');
+                    }
+
+                    return new PdoSystemConfigRepository($query, $clock);
                 },
             )
             ->set(

--- a/tests/AdminAuth/AdminPasswordResetTest.php
+++ b/tests/AdminAuth/AdminPasswordResetTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NeneCorpus\Tests\AdminAuth;
 
 use NeneCorpus\AdminAuth\AdminPasswordReset;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,9 +14,28 @@ use PHPUnit\Framework\TestCase;
  * 敵対的観点:
  *  - 期限が「ちょうど」今の場合は境界値なので expired 扱いになるかをチェック
  *  - usedAt = '' (空文字) が null と区別されるかをチェック
+ *
+ * isExpired() は注入された ClockInterface を基準に判定するため、固定時計
+ * （FixedClock）で "now" を固定し、境界値を決定論的に検証する（wall-clock 非依存）。
  */
 final class AdminPasswordResetTest extends TestCase
 {
+    /** 判定基準となる固定の "now"（UTC）。 */
+    private const NOW = '2026-01-15 12:00:00';
+
+    private FixedClock $clock;
+
+    protected function setUp(): void
+    {
+        $this->clock = new FixedClock(self::NOW . 'Z');
+    }
+
+    /** 固定 now からの相対秒で expiresAt 文字列を作る。 */
+    private function atOffset(int $seconds): string
+    {
+        return gmdate('Y-m-d H:i:s', strtotime(self::NOW) + $seconds);
+    }
+
     // ── isExpired() ──────────────────────────────────────────────────
 
     public function test_is_expired_returns_true_for_past_date(): void
@@ -23,12 +43,12 @@ final class AdminPasswordResetTest extends TestCase
         $reset = new AdminPasswordReset(
             tokenHash: 'hash',
             adminUserId: 1,
-            expiresAt: gmdate('Y-m-d H:i:s', time() - 1),
+            expiresAt: $this->atOffset(-1),
             usedAt: null,
-            createdAt: gmdate('Y-m-d H:i:s'),
+            createdAt: self::NOW,
         );
 
-        self::assertTrue($reset->isExpired());
+        self::assertTrue($reset->isExpired($this->clock));
     }
 
     public function test_is_expired_returns_true_for_past_date_far(): void
@@ -38,10 +58,10 @@ final class AdminPasswordResetTest extends TestCase
             adminUserId: 1,
             expiresAt: '2000-01-01 00:00:00',
             usedAt: null,
-            createdAt: gmdate('Y-m-d H:i:s'),
+            createdAt: self::NOW,
         );
 
-        self::assertTrue($reset->isExpired());
+        self::assertTrue($reset->isExpired($this->clock));
     }
 
     public function test_is_expired_returns_false_for_future_date(): void
@@ -49,12 +69,12 @@ final class AdminPasswordResetTest extends TestCase
         $reset = new AdminPasswordReset(
             tokenHash: 'hash',
             adminUserId: 1,
-            expiresAt: gmdate('Y-m-d H:i:s', time() + 3600),
+            expiresAt: $this->atOffset(3600),
             usedAt: null,
-            createdAt: gmdate('Y-m-d H:i:s'),
+            createdAt: self::NOW,
         );
 
-        self::assertFalse($reset->isExpired());
+        self::assertFalse($reset->isExpired($this->clock));
     }
 
     public function test_is_expired_returns_false_for_far_future(): void
@@ -64,25 +84,34 @@ final class AdminPasswordResetTest extends TestCase
             adminUserId: 1,
             expiresAt: '2099-12-31 23:59:59',
             usedAt: null,
-            createdAt: gmdate('Y-m-d H:i:s'),
+            createdAt: self::NOW,
         );
 
-        self::assertFalse($reset->isExpired());
+        self::assertFalse($reset->isExpired($this->clock));
     }
 
-    public function test_is_expired_returns_true_when_expires_exactly_now(): void
+    public function test_is_expired_boundary_equal_now_is_not_expired(): void
     {
-        // strtotime(expiresAt) < time() → 同値は expired 扱いになるはずだが、
-        // 実際には < なので「同値」= expired ではない。1 秒前は expired。
-        $reset = new AdminPasswordReset(
+        // strtotime(expiresAt) < now → 同値は expired ではない。1 秒前は expired。
+        $notYet = new AdminPasswordReset(
             tokenHash: 'hash',
             adminUserId: 1,
-            expiresAt: gmdate('Y-m-d H:i:s', time() - 1),
+            expiresAt: $this->atOffset(0),
             usedAt: null,
-            createdAt: gmdate('Y-m-d H:i:s'),
+            createdAt: self::NOW,
         );
 
-        self::assertTrue($reset->isExpired());
+        self::assertFalse($notYet->isExpired($this->clock));
+
+        $oneSecondAgo = new AdminPasswordReset(
+            tokenHash: 'hash',
+            adminUserId: 1,
+            expiresAt: $this->atOffset(-1),
+            usedAt: null,
+            createdAt: self::NOW,
+        );
+
+        self::assertTrue($oneSecondAgo->isExpired($this->clock));
     }
 
     // ── isUsed() ─────────────────────────────────────────────────────
@@ -92,9 +121,9 @@ final class AdminPasswordResetTest extends TestCase
         $reset = new AdminPasswordReset(
             tokenHash: 'hash',
             adminUserId: 1,
-            expiresAt: gmdate('Y-m-d H:i:s', time() + 3600),
+            expiresAt: $this->atOffset(3600),
             usedAt: null,
-            createdAt: gmdate('Y-m-d H:i:s'),
+            createdAt: self::NOW,
         );
 
         self::assertFalse($reset->isUsed());
@@ -105,9 +134,9 @@ final class AdminPasswordResetTest extends TestCase
         $reset = new AdminPasswordReset(
             tokenHash: 'hash',
             adminUserId: 1,
-            expiresAt: gmdate('Y-m-d H:i:s', time() + 3600),
-            usedAt: gmdate('Y-m-d H:i:s'),
-            createdAt: gmdate('Y-m-d H:i:s'),
+            expiresAt: $this->atOffset(3600),
+            usedAt: self::NOW,
+            createdAt: self::NOW,
         );
 
         self::assertTrue($reset->isUsed());
@@ -124,7 +153,7 @@ final class AdminPasswordResetTest extends TestCase
             createdAt: '2000-01-01 00:00:00',
         );
 
-        self::assertTrue($reset->isExpired());
+        self::assertTrue($reset->isExpired($this->clock));
         self::assertTrue($reset->isUsed());
     }
 }

--- a/tests/AdminAuth/ConfirmPasswordResetUseCaseTest.php
+++ b/tests/AdminAuth/ConfirmPasswordResetUseCaseTest.php
@@ -13,6 +13,7 @@ use NeneCorpus\AdminAuth\InvalidPasswordResetTokenException;
 use NeneCorpus\AdminAuth\PdoAdminPasswordResetRepository;
 use NeneCorpus\AdminAuth\PdoAdminUserRepository;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,6 +29,9 @@ use PHPUnit\Framework\TestCase;
  */
 final class ConfirmPasswordResetUseCaseTest extends TestCase
 {
+    /** Fixed "now" used by the injected clock (UTC). */
+    private const NOW = '2026-06-15 12:00:00';
+
     private PdoDatabaseQueryExecutor $executor;
     private PdoAdminUserRepository $users;
     private PdoAdminPasswordResetRepository $resets;
@@ -63,7 +67,8 @@ final class ConfirmPasswordResetUseCaseTest extends TestCase
         $this->adminId = (int) $adminRow['id'];
         $this->users = new PdoAdminUserRepository($this->executor);
         $this->resets = new PdoAdminPasswordResetRepository($this->executor);
-        $this->useCase = new ConfirmPasswordResetUseCase($this->resets, $this->users);
+        // Fixed clock so token-expiry boundaries are deterministic (no wall-clock).
+        $this->useCase = new ConfirmPasswordResetUseCase($this->resets, $this->users, new FixedClock(self::NOW . 'Z'));
     }
 
     // ── ガード: 空トークン・短パスワード (DB前チェック) ──────────────
@@ -108,7 +113,7 @@ final class ConfirmPasswordResetUseCaseTest extends TestCase
         $this->resets->save(new AdminPasswordReset(
             tokenHash: $tokenHash,
             adminUserId: $this->adminId,
-            expiresAt: gmdate('Y-m-d H:i:s', time() - 1), // 1秒前に期限切れ
+            expiresAt: '2026-06-15 11:59:59', // 固定 now の1秒前に期限切れ
             usedAt: null,
             createdAt: gmdate('Y-m-d H:i:s'),
         ));
@@ -126,7 +131,7 @@ final class ConfirmPasswordResetUseCaseTest extends TestCase
         $this->resets->save(new AdminPasswordReset(
             tokenHash: $tokenHash,
             adminUserId: $this->adminId,
-            expiresAt: gmdate('Y-m-d H:i:s', time() + 3600),
+            expiresAt: '2026-06-15 13:00:00', // 固定 now の1時間後（有効）
             usedAt: gmdate('Y-m-d H:i:s'), // 使用済み
             createdAt: gmdate('Y-m-d H:i:s'),
         ));
@@ -146,7 +151,7 @@ final class ConfirmPasswordResetUseCaseTest extends TestCase
         $this->resets->save(new AdminPasswordReset(
             tokenHash: $tokenHash,
             adminUserId: $this->adminId,
-            expiresAt: gmdate('Y-m-d H:i:s', time() + 3600),
+            expiresAt: '2026-06-15 13:00:00', // 固定 now の1時間後（有効）
             usedAt: null,
             createdAt: gmdate('Y-m-d H:i:s'),
         ));
@@ -167,7 +172,7 @@ final class ConfirmPasswordResetUseCaseTest extends TestCase
         $this->resets->save(new AdminPasswordReset(
             tokenHash: $tokenHash,
             adminUserId: $this->adminId,
-            expiresAt: gmdate('Y-m-d H:i:s', time() + 3600),
+            expiresAt: '2026-06-15 13:00:00', // 固定 now の1時間後（有効）
             usedAt: null,
             createdAt: gmdate('Y-m-d H:i:s'),
         ));
@@ -189,7 +194,7 @@ final class ConfirmPasswordResetUseCaseTest extends TestCase
         $this->resets->save(new AdminPasswordReset(
             tokenHash: $tokenHash,
             adminUserId: $this->adminId,
-            expiresAt: gmdate('Y-m-d H:i:s', time() + 3600),
+            expiresAt: '2026-06-15 13:00:00', // 固定 now の1時間後（有効）
             usedAt: null,
             createdAt: gmdate('Y-m-d H:i:s'),
         ));

--- a/tests/AdminAuth/LoginAdminUseCaseTest.php
+++ b/tests/AdminAuth/LoginAdminUseCaseTest.php
@@ -12,6 +12,7 @@ use NeneCorpus\AdminAuth\LoginAdminInput;
 use NeneCorpus\AdminAuth\LoginAdminUseCase;
 use NeneCorpus\AdminAuth\PdoAdminUserRepository;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class LoginAdminUseCaseTest extends TestCase
@@ -47,6 +48,7 @@ final class LoginAdminUseCaseTest extends TestCase
         $useCase = new LoginAdminUseCase(
             new PdoAdminUserRepository($this->executor),
             new LocalBearerTokenVerifier('test-jwt-secret'),
+            new FixedClock(),
         );
 
         $output = $useCase->execute(new LoginAdminInput(
@@ -64,6 +66,7 @@ final class LoginAdminUseCaseTest extends TestCase
         $useCase = new LoginAdminUseCase(
             new PdoAdminUserRepository($this->executor),
             new LocalBearerTokenVerifier('test-jwt-secret'),
+            new FixedClock(),
         );
 
         $this->expectException(\NeneCorpus\AdminAuth\InvalidAdminCredentialsException::class);

--- a/tests/AdminAuth/RequestPasswordResetUseCaseTest.php
+++ b/tests/AdminAuth/RequestPasswordResetUseCaseTest.php
@@ -13,6 +13,7 @@ use NeneCorpus\AdminAuth\RequestPasswordResetUseCase;
 use NeneCorpus\Mail\MailerInterface;
 use NeneCorpus\Mail\MailMessage;
 use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -70,7 +71,7 @@ final class RequestPasswordResetUseCaseTest extends TestCase
         $mailer->expects(self::never())->method('send');
         $mailer->method('isConfigured')->willReturn(true);
 
-        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer);
+        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer, new FixedClock());
 
         // 例外なし・メール送信なし
         $useCase->execute('nobody@unknown.com', 'https://example.com/admin/');
@@ -87,7 +88,7 @@ final class RequestPasswordResetUseCaseTest extends TestCase
         $mailerNotConfigured->expects(self::never())->method('send');
         $mailerNotConfigured->method('isConfigured')->willReturn(false);
 
-        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailerNotConfigured);
+        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailerNotConfigured, new FixedClock());
 
         // 既知メール → 例外なし（外から区別できない）
         $useCase->execute('known@example.com', 'https://example.com/admin/');
@@ -107,7 +108,7 @@ final class RequestPasswordResetUseCaseTest extends TestCase
         $mailer->method('isConfigured')->willReturn(false);
         $mailer->expects(self::never())->method('send');
 
-        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer);
+        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer, new FixedClock());
         $useCase->execute('known@example.com', 'https://example.com/admin/');
 
         $countRow = $this->executor->fetchOne('SELECT COUNT(*) AS c FROM admin_password_resets');
@@ -129,7 +130,7 @@ final class RequestPasswordResetUseCaseTest extends TestCase
                 $capturedMessage = $msg;
             });
 
-        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer);
+        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer, new FixedClock());
         $useCase->execute('known@example.com', 'https://example.com/admin/reset');
 
         // token が DB に保存された
@@ -157,7 +158,7 @@ final class RequestPasswordResetUseCaseTest extends TestCase
                 $capturedMessage = $msg;
             });
 
-        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer);
+        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer, new FixedClock());
         $useCase->execute('known@example.com', 'https://example.com/admin/');
 
         self::assertNotNull($capturedMessage);
@@ -172,7 +173,7 @@ final class RequestPasswordResetUseCaseTest extends TestCase
         $mailer->method('send')->willReturnCallback(static function (): void {
         });
 
-        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer);
+        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer, new FixedClock());
         $useCase->execute('known@example.com', 'https://example.com/admin/');
 
         $row = $this->executor->fetchOne('SELECT token_hash FROM admin_password_resets LIMIT 1');
@@ -196,7 +197,7 @@ final class RequestPasswordResetUseCaseTest extends TestCase
         $mailer->method('send')->willReturnCallback(static function (): void {
         });
 
-        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer);
+        $useCase = new RequestPasswordResetUseCase($this->users, $this->resets, $mailer, new FixedClock());
         $useCase->execute('known@example.com', 'https://example.com/admin/');
 
         // 期限切れ token は削除され、新しい token だけ残る

--- a/tests/Chat/SendChatMessageUseCaseEdgeCaseTest.php
+++ b/tests/Chat/SendChatMessageUseCaseEdgeCaseTest.php
@@ -23,6 +23,7 @@ use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -61,7 +62,7 @@ final class SendChatMessageUseCaseEdgeCaseTest extends TestCase
         $holder = new RequestScopedOrgIdHolder();
         $holder->setId(1);
 
-        $this->sessions = new PdoChatSessionRepository($this->executor, $holder);
+        $this->sessions = new PdoChatSessionRepository($this->executor, $holder, new FixedClock());
         $this->messages = new PdoChatMessageRepository($this->executor, $holder);
     }
 

--- a/tests/Chat/SendChatMessageUseCaseTest.php
+++ b/tests/Chat/SendChatMessageUseCaseTest.php
@@ -21,6 +21,7 @@ use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class SendChatMessageUseCaseTest extends TestCase
@@ -44,7 +45,7 @@ final class SendChatMessageUseCaseTest extends TestCase
         $holder = new RequestScopedOrgIdHolder();
         $holder->setId(1);
 
-        $sessions = new PdoChatSessionRepository($executor, $holder);
+        $sessions = new PdoChatSessionRepository($executor, $holder, new FixedClock());
         $sessionId = $sessions->save(new ChatSession(publicToken: 'token-abc'));
         $session = $sessions->findById($sessionId);
         self::assertNotNull($session);

--- a/tests/ChatLimits/PdoChatTokenTrackerTest.php
+++ b/tests/ChatLimits/PdoChatTokenTrackerTest.php
@@ -9,6 +9,7 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\ChatLimits\PdoChatTokenTracker;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\FixedClock;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -47,7 +48,7 @@ final class PdoChatTokenTrackerTest extends TestCase
 
         $this->orgIdHolder = new RequestScopedOrgIdHolder();
         $this->orgIdHolder->setId(1);
-        $this->tracker = new PdoChatTokenTracker($this->executor, $this->orgIdHolder);
+        $this->tracker = new PdoChatTokenTracker($this->executor, $this->orgIdHolder, new FixedClock());
     }
 
     // ── ゼロトークン ──────────────────────────────────────────────────
@@ -121,11 +122,11 @@ final class PdoChatTokenTrackerTest extends TestCase
         $now = gmdate('Y-m-d H:i:s');
         $this->executor->execute(
             'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
-            ['chat:tokens:ip:5.5.5.5', 9999, time() - 1, $now],
+            ['chat:tokens:ip:5.5.5.5', 9999, 1, $now],
         );
         $this->executor->execute(
             'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
-            ['chat:tokens:global', 9999, time() - 1, $now],
+            ['chat:tokens:global', 9999, 1, $now],
         );
 
         // 期限切れバケットは 0 として返す
@@ -139,7 +140,7 @@ final class PdoChatTokenTrackerTest extends TestCase
         $now = gmdate('Y-m-d H:i:s');
         $this->executor->execute(
             'INSERT INTO rate_limit_buckets (bucket_key, hit_count, reset_at, updated_at) VALUES (?, ?, ?, ?)',
-            ['chat:tokens:ip:6.6.6.6', 9999, time() - 1, $now],
+            ['chat:tokens:ip:6.6.6.6', 9999, 1, $now],
         );
 
         // 新しくトークンを track → リセットして 100 になる（9999 に加算されない）

--- a/tests/Message/PdoChatMessageRepositoryTest.php
+++ b/tests/Message/PdoChatMessageRepositoryTest.php
@@ -14,6 +14,7 @@ use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class PdoChatMessageRepositoryTest extends TestCase
@@ -42,7 +43,7 @@ final class PdoChatMessageRepositoryTest extends TestCase
         $holder = new RequestScopedOrgIdHolder();
         $holder->setId($orgId);
 
-        return new PdoChatSessionRepository($this->executor, $holder);
+        return new PdoChatSessionRepository($this->executor, $holder, new FixedClock());
     }
 
     private function makeMessages(int $orgId = 1): PdoChatMessageRepository

--- a/tests/Notification/RateLimitNotifierTest.php
+++ b/tests/Notification/RateLimitNotifierTest.php
@@ -10,6 +10,7 @@ use NeneCorpus\Mail\MailSendException;
 use NeneCorpus\Notification\NotificationConfig;
 use NeneCorpus\Notification\RateLimitNotifier;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class RateLimitNotifierTest extends TestCase
@@ -41,7 +42,7 @@ final class RateLimitNotifierTest extends TestCase
         $mailer->expects(self::never())->method('send');
         $storage->expects(self::never())->method('hit');
 
-        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder(), new FixedClock()))->notifyIfNeeded(
             $this->makeConfig(enabled: false),
             'ops@example.com',
             '1.2.3.4',
@@ -57,7 +58,7 @@ final class RateLimitNotifierTest extends TestCase
         $mailer->expects(self::once())->method('isConfigured')->willReturn(false);
         $mailer->expects(self::never())->method('send');
 
-        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder(), new FixedClock()))->notifyIfNeeded(
             $this->makeConfig(enabled: true),
             'ops@example.com',
             '1.2.3.4',
@@ -76,7 +77,7 @@ final class RateLimitNotifierTest extends TestCase
         // Both calls: daily hits tracking + cooldown gate
         $storage->method('hit')->willReturn(['count' => 1, 'reset_at' => time() + 3600]);
 
-        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder(), new FixedClock()))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '1.2.3.4',
@@ -103,7 +104,7 @@ final class RateLimitNotifierTest extends TestCase
             },
         );
 
-        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder(), new FixedClock()))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '192.168.0.1',
@@ -121,7 +122,7 @@ final class RateLimitNotifierTest extends TestCase
         $storage->method('hit')->willReturn(['count' => 1, 'reset_at' => time() + 3600]);
 
         // Must not throw
-        (new RateLimitNotifier($mailer, $storage, $this->makeHolder()))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder(), new FixedClock()))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '10.0.0.1',
@@ -138,7 +139,7 @@ final class RateLimitNotifierTest extends TestCase
 
         $mailer->method('isConfigured')->willReturn(true);
 
-        $today = date('Y-m-d');
+        $today = '2026-01-15'; // 固定時計の日付に一致
         $orgId = 1;
         $hitsKeyPrefix = 'notify:ratelimit:hits:' . $orgId . ':' . $today;
 
@@ -151,7 +152,7 @@ final class RateLimitNotifierTest extends TestCase
             ))
             ->willReturn(['count' => 2, 'reset_at' => time() + 86400]);
 
-        (new RateLimitNotifier($mailer, $storage, $this->makeHolder($orgId)))->notifyIfNeeded(
+        (new RateLimitNotifier($mailer, $storage, $this->makeHolder($orgId), new FixedClock()))->notifyIfNeeded(
             $this->makeConfig(),
             'ops@example.com',
             '1.2.3.4',

--- a/tests/Notification/SendDailyReportUseCaseTest.php
+++ b/tests/Notification/SendDailyReportUseCaseTest.php
@@ -10,6 +10,7 @@ use NeneCorpus\Notification\DailyReportRepositoryInterface;
 use NeneCorpus\Notification\DailyReportStats;
 use NeneCorpus\Notification\NotificationException;
 use NeneCorpus\Notification\SendDailyReportUseCase;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class SendDailyReportUseCaseTest extends TestCase
@@ -35,7 +36,7 @@ final class SendDailyReportUseCaseTest extends TestCase
         $this->expectException(NotificationException::class);
         $this->expectExceptionMessage('SMTP is not configured');
 
-        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2026-01-15');
+        (new SendDailyReportUseCase($mailer, $repo, new FixedClock()))->execute('to@example.com', '2026-01-15');
     }
 
     public function test_sends_mail_and_returns_stats(): void
@@ -49,7 +50,7 @@ final class SendDailyReportUseCaseTest extends TestCase
         $mailer->method('isConfigured')->willReturn(true);
         $mailer->expects(self::once())->method('send');
 
-        $result = (new SendDailyReportUseCase($mailer, $repo))->execute('ops@example.com', '2026-01-15');
+        $result = (new SendDailyReportUseCase($mailer, $repo, new FixedClock()))->execute('ops@example.com', '2026-01-15');
 
         self::assertSame($stats, $result);
     }
@@ -68,7 +69,7 @@ final class SendDailyReportUseCaseTest extends TestCase
             },
         );
 
-        (new SendDailyReportUseCase($mailer, $repo))->execute('report@example.com', '2026-01-15');
+        (new SendDailyReportUseCase($mailer, $repo, new FixedClock()))->execute('report@example.com', '2026-01-15');
 
         self::assertNotNull($capturedMessage);
         self::assertSame('report@example.com', $capturedMessage->to);
@@ -88,7 +89,7 @@ final class SendDailyReportUseCaseTest extends TestCase
             },
         );
 
-        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2026-01-15');
+        (new SendDailyReportUseCase($mailer, $repo, new FixedClock()))->execute('to@example.com', '2026-01-15');
 
         self::assertNotNull($capturedMessage);
         self::assertStringContainsString('2026-01-15', $capturedMessage->subject);
@@ -108,7 +109,7 @@ final class SendDailyReportUseCaseTest extends TestCase
             },
         );
 
-        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2026-01-15');
+        (new SendDailyReportUseCase($mailer, $repo, new FixedClock()))->execute('to@example.com', '2026-01-15');
 
         self::assertNotNull($capturedMessage);
         // Stats values should appear in the HTML body
@@ -132,14 +133,14 @@ final class SendDailyReportUseCaseTest extends TestCase
         $mailer = $this->createStub(MailerInterface::class);
         $mailer->method('isConfigured')->willReturn(true);
 
-        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com', '2025-12-31');
+        (new SendDailyReportUseCase($mailer, $repo, new FixedClock()))->execute('to@example.com', '2025-12-31');
 
         self::assertSame('2025-12-31', $capturedDate);
     }
 
     public function test_uses_today_when_date_not_specified(): void
     {
-        $today = date('Y-m-d');
+        $today = '2026-01-15'; // 固定時計の日付に一致
         $capturedDate = null;
 
         $repo = $this->createStub(DailyReportRepositoryInterface::class);
@@ -153,7 +154,7 @@ final class SendDailyReportUseCaseTest extends TestCase
         $mailer = $this->createStub(MailerInterface::class);
         $mailer->method('isConfigured')->willReturn(true);
 
-        (new SendDailyReportUseCase($mailer, $repo))->execute('to@example.com');
+        (new SendDailyReportUseCase($mailer, $repo, new FixedClock()))->execute('to@example.com');
 
         self::assertSame($today, $capturedDate);
     }

--- a/tests/Organization/PdoOrganizationRepositoryTest.php
+++ b/tests/Organization/PdoOrganizationRepositoryTest.php
@@ -11,6 +11,7 @@ use NeneCorpus\Organization\Organization;
 use NeneCorpus\Organization\OrganizationNotFoundException;
 use NeneCorpus\Organization\OrganizationSlugConflictException;
 use NeneCorpus\Organization\PdoOrganizationRepository;
+use NeneCorpus\Tests\Support\FixedClock;
 use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +38,7 @@ final class PdoOrganizationRepositoryTest extends TestCase
         TenancySchemaSetup::createOrganizations($this->executor);
         TenancySchemaSetup::seedDefaultOrganization($this->executor);
 
-        $this->repository = new PdoOrganizationRepository($this->executor);
+        $this->repository = new PdoOrganizationRepository($this->executor, new FixedClock());
     }
 
     public function test_findById_returns_organization(): void

--- a/tests/RateLimit/PdoRateLimitStorageTest.php
+++ b/tests/RateLimit/PdoRateLimitStorageTest.php
@@ -9,6 +9,7 @@ use Nene2\Database\PdoConnectionFactory;
 use Nene2\Database\PdoDatabaseQueryExecutor;
 use NeneCorpus\RateLimit\PdoRateLimitStorage;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\FixedClock;
 use NeneCorpus\Tests\Support\RateLimitSchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -39,7 +40,7 @@ final class PdoRateLimitStorageTest extends TestCase
 
     public function test_hit_increments_count_within_window(): void
     {
-        $storage = new PdoRateLimitStorage($this->executor, $this->holder);
+        $storage = new PdoRateLimitStorage($this->executor, $this->holder, new FixedClock());
 
         $first  = $storage->hit('chat:session:abc', 60);
         $second = $storage->hit('chat:session:abc', 60);
@@ -51,12 +52,12 @@ final class PdoRateLimitStorageTest extends TestCase
 
     public function test_hit_resets_count_after_window_expires(): void
     {
-        $storage = new PdoRateLimitStorage($this->executor, $this->holder);
+        $storage = new PdoRateLimitStorage($this->executor, $this->holder, new FixedClock());
         $storage->hit('chat:ip:127.0.0.1', 60);
 
         $this->executor->execute(
             'UPDATE rate_limit_buckets SET reset_at = ? WHERE organization_id = ? AND bucket_key = ?',
-            [time() - 1, 1, 'chat:ip:127.0.0.1'],
+            [1, 1, 'chat:ip:127.0.0.1'],
         );
 
         $result = $storage->hit('chat:ip:127.0.0.1', 60);
@@ -68,11 +69,11 @@ final class PdoRateLimitStorageTest extends TestCase
     {
         $holderOrg1 = new RequestScopedOrgIdHolder();
         $holderOrg1->setId(1);
-        $storageOrg1 = new PdoRateLimitStorage($this->executor, $holderOrg1);
+        $storageOrg1 = new PdoRateLimitStorage($this->executor, $holderOrg1, new FixedClock());
 
         $holderOrg2 = new RequestScopedOrgIdHolder();
         $holderOrg2->setId(2);
-        $storageOrg2 = new PdoRateLimitStorage($this->executor, $holderOrg2);
+        $storageOrg2 = new PdoRateLimitStorage($this->executor, $holderOrg2, new FixedClock());
 
         // Org 1 hits twice, org 2 hits once with the same key
         $storageOrg1->hit('chat:session:xyz', 60);

--- a/tests/Session/PdoChatSessionRepositoryTest.php
+++ b/tests/Session/PdoChatSessionRepositoryTest.php
@@ -11,6 +11,7 @@ use NeneCorpus\Session\ChatSession;
 use NeneCorpus\Session\PdoChatSessionRepository;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tests\Support\ChatSchemaSetup;
+use NeneCorpus\Tests\Support\FixedClock;
 use PHPUnit\Framework\TestCase;
 
 final class PdoChatSessionRepositoryTest extends TestCase
@@ -39,7 +40,7 @@ final class PdoChatSessionRepositoryTest extends TestCase
         $holder = new RequestScopedOrgIdHolder();
         $holder->setId($orgId);
 
-        return new PdoChatSessionRepository($this->executor, $holder);
+        return new PdoChatSessionRepository($this->executor, $holder, new FixedClock());
     }
 
     public function test_save_and_find_by_public_token(): void

--- a/tests/Support/FixedClock.php
+++ b/tests/Support/FixedClock.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use DateTimeImmutable;
+use Nene2\Http\ClockInterface;
+
+/**
+ * Deterministic {@see ClockInterface} for tests: always returns the instant it
+ * was constructed with (defaulting to a fixed UTC moment). Lets time-boundary
+ * behaviour (expiry windows, `reset_at`, daily trend dates) be asserted without
+ * wall-clock flakiness.
+ */
+final class FixedClock implements ClockInterface
+{
+    private DateTimeImmutable $now;
+
+    public function __construct(string $instant = '2026-01-15T12:00:00Z')
+    {
+        $this->now = new DateTimeImmutable($instant);
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+}

--- a/tests/SystemConfig/SystemConfigUseCaseTest.php
+++ b/tests/SystemConfig/SystemConfigUseCaseTest.php
@@ -12,6 +12,7 @@ use NeneCorpus\SystemConfig\InvalidTenantResolutionModeException;
 use NeneCorpus\SystemConfig\PdoSystemConfigRepository;
 use NeneCorpus\SystemConfig\UpdateSystemConfigInput;
 use NeneCorpus\SystemConfig\UpdateSystemConfigUseCase;
+use NeneCorpus\Tests\Support\FixedClock;
 use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use PHPUnit\Framework\TestCase;
 
@@ -38,7 +39,7 @@ final class SystemConfigUseCaseTest extends TestCase
         TenancySchemaSetup::createSystemConfig($this->executor);
         TenancySchemaSetup::seedSystemConfig($this->executor);
 
-        $this->repository = new PdoSystemConfigRepository($this->executor);
+        $this->repository = new PdoSystemConfigRepository($this->executor, new FixedClock());
     }
 
     public function test_get_returns_default_config(): void

--- a/tests/Tenancy/OrgResolverMiddlewareTest.php
+++ b/tests/Tenancy/OrgResolverMiddlewareTest.php
@@ -12,6 +12,7 @@ use NeneCorpus\Organization\PdoOrganizationRepository;
 use NeneCorpus\SystemConfig\PdoSystemConfigRepository;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use NeneCorpus\Tenancy\Resolution\OrgResolverMiddleware;
+use NeneCorpus\Tests\Support\FixedClock;
 use NeneCorpus\Tests\Support\TenancySchemaSetup;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
@@ -52,8 +53,8 @@ final class OrgResolverMiddlewareTest extends TestCase
         $this->holder = new RequestScopedOrgIdHolder();
         $this->middleware = new OrgResolverMiddleware(
             $this->holder,
-            new PdoOrganizationRepository($this->executor),
-            new PdoSystemConfigRepository($this->executor),
+            new PdoOrganizationRepository($this->executor, new FixedClock()),
+            new PdoSystemConfigRepository($this->executor, new FixedClock()),
             new ProblemDetailsResponseFactory($psr17, $psr17, 'https://nene-corpus.example'),
         );
     }


### PR DESCRIPTION
## 目的

検品C の準拠 sweep（Clock）を corpus に適用。生の壁時計読みを NENE2 `Nene2\Http\ClockInterface`（本番 `UtcClock`）注入に寄せ、時刻境界のテストを決定論化する。採用済みの clear / field / invoice / origin と同じ参照形（独自 Clock 禁止）。

Closes #329

## 変更点

- **DI 束縛**: `RuntimeServiceProvider` で `ClockInterface → UtcClock` を1回束縛。
- **注入 + 置換**（13 ドメインクラス・計23サイト）:
  - `time()` → `$this->clock->now()->getTimestamp()`
  - 単一引数 `gmdate()`/`date()` の "now" → `$this->clock->now()->format(...)`
  - 対象: Session / ChatLimits / RateLimit / AdminAuth / Analytics / SystemConfig / Organization / Notification
  - `AdminPasswordReset::isExpired(ClockInterface $clock)` に変更（値オブジェクト。呼び出し側 `ConfirmPasswordResetUseCase` が clock を注入）
  - 各 ServiceProvider（8個）で clock を配線
- **表示整形の明示タイムスタンプ付き**（`gmdate('Y-m-d H:i:s', $explicitTs)` / `gmdate('c', $expiresAt)`）は対象外（RawClockRule D4 の除外規則どおり）。

## 本番不変の担保

既定 `UtcClock` で挙動は完全同値:
- `UtcClock->now()->getTimestamp()` == `time()`（Unix 秒 UTC）
- `->format('Y-m-d H:i:s')` == `gmdate('Y-m-d H:i:s')`
- 既存 `date()` はタイムゾーン未設定＝UTC 既定のため `gmdate()` と同値

## テスト（FixedClock で決定論化）

- 新規 `tests/Support/FixedClock.php`（固定 instant を返す `ClockInterface` 実装）
- `AdminPasswordResetTest` / `ConfirmPasswordResetUseCaseTest` を固定 now に書き換え、失効境界（`< now` の同値・1秒前）を wall-clock 非依存で検証
- ウィンドウ系テストの手動 `time()-1` fixture は固定過去エポックに置換して決定論化

## 検証結果

- `composer test` → **OK (418 tests, 1355 assertions)**
- `composer analyse`（PHPStan level 8）→ **No errors**
- `composer cs` → **0 files to fix**
- `php -l` 全変更ファイル OK
- NENE2 `1.8.0` 解決確認済み

## スコープ

Clock のみ。V（Validation builder）/ ConfigLoader は 06 レポートどおり defer。各リポジトリの created_at/updated_at 用単発 `gmdate()` ヘルパ（時刻分岐なしの保存タイムスタンプ・約20箇所）はフォローアップ（issue #329 に明記）。

Self-review: backend-api, database, middleware-security

🤖 Generated with [Claude Code](https://claude.com/claude-code)