### PR TITLE
feat(conformance): 準拠リンタ conformance を check ゲートに配線する (#331)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.4.1 <9.0",
-        "hideyukimori/nene2": "^1.7",
+        "hideyukimori/nene2": "^1.8.2",
         "phpmailer/phpmailer": "^7.1",
         "robmorgan/phinx": "^0.16.11",
         "smalot/pdfparser": "^2.12"
@@ -16,7 +16,7 @@
             "url": "../NENE2",
             "options": {
                 "versions": {
-                    "hideyukimori/nene2": "1.7.0"
+                    "hideyukimori/nene2": "1.8.2"
                 }
             }
         }
@@ -38,6 +38,7 @@
         "cs:fix": "php-cs-fixer fix --config=.php-cs-fixer.php",
         "openapi": "php tools/validate-openapi.php",
         "mcp": "php vendor/hideyukimori/nene2/tools/validate-mcp-tools.php --root=.",
+        "conformance": "php vendor/hideyukimori/nene2/tools/conformance.php --root=.",
         "migrations:status": "phinx status -c phinx.php",
         "migrations:migrate": "phinx migrate -c phinx.php",
     "migrations:rollback": "phinx rollback -c phinx.php",
@@ -47,7 +48,8 @@
             "@analyse",
             "@cs",
             "@openapi",
-            "@mcp"
+            "@mcp",
+            "@conformance"
         ]
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc53d22d0461335a6e10b7555612caf3",
+    "content-hash": "f2695d5ed0ddfa3758e1bb6063461ef9",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -394,11 +394,11 @@
         },
         {
             "name": "hideyukimori/nene2",
-            "version": "1.7.0",
+            "version": "1.8.2",
             "dist": {
                 "type": "path",
                 "url": "../NENE2",
-                "reference": "8db980a6e48949ffc4a6c7d8eb655aca8fbdf894"
+                "reference": "98869b1e494f6ec5c708694a3f3a51e923d43231"
             },
             "require": {
                 "monolog/monolog": "^3.0",
@@ -467,6 +467,9 @@
                 "mcp": [
                     "php tools/validate-mcp-tools.php"
                 ],
+                "conformance": [
+                    "php tools/conformance.php"
+                ],
                 "version:check": [
                     "php tools/validate-version.php"
                 ],
@@ -488,6 +491,7 @@
                     "@cs",
                     "@openapi",
                     "@mcp",
+                    "@conformance",
                     "@version:check"
                 ]
             },

--- a/conformance.baseline.json
+++ b/conformance.baseline.json
@@ -1,0 +1,90 @@
+{
+    "version": 1,
+    "allow": [],
+    "ignore": [
+        {
+            "rule": "D4",
+            "file": "src/AdminAuth/PdoAdminPasswordResetRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 2
+        },
+        {
+            "rule": "D4",
+            "file": "src/AdminAuth/PdoAdminUserRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 3
+        },
+        {
+            "rule": "D4",
+            "file": "src/Appearance/PdoAppearanceSettingsRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/ChatLimits/PdoChatLimitsRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/ChatSettings/PdoChatSettingsRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Chunk/PdoChunkRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Document/DeleteDocumentUseCase.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Document/PdoDocumentRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Ingestion/SourceCorpusCleaner.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Install/InstallAdminUserCreator.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Install/InstallLock.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Message/PdoChatMessageRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Source/DeleteSourceUseCase.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        },
+        {
+            "rule": "D4",
+            "file": "src/Source/PdoSourceRepository.php",
+            "message": "Raw current-time read gmdate() with no explicit timestamp. Inject Nene2\\Http\\ClockInterface (Nene2\\Http\\UtcClock in production) instead of reading the wall clock directly.",
+            "count": 1
+        }
+    ]
+}


### PR DESCRIPTION
## 目的

上流化設計 04（`_work/reports/2026-07-06/upstream-design/04-conformance-linter.md`）の準拠リンタ `tools/conformance.php`（NENE2 v1.8.2・error 4ルール D1–D4）を corpus の `composer check` に配線する。検品C の横展開。既存ドリフトは baseline で grandfather し、**新規混入のみ error でゲート**する。

## 変更点

- **NENE2 依存を `^1.8.2` に更新**: `require.hideyukimori/nene2` を `^1.7`→`^1.8.2`、path-repo の `repositories[].options.versions.hideyukimori/nene2` を `1.7.0`→`1.8.2`、`composer update hideyukimori/nene2`（lock を 1.7.0→1.8.2）。
- **配線**: `scripts.conformance` = `php vendor/hideyukimori/nene2/tools/conformance.php --root=.` を追加し、`scripts.check` 配列に `@conformance` を組み込む（D3 self-registration が自己充足）。
- **baseline 生成**: `conformance.baseline.json`（`--write-baseline`）。既存ドリフト 17件を grandfather。

## findings 内訳

report-only で **error 17件・すべて D4（生 `gmdate()` の wall-clock 読み取り）**、baseline 上は 14 ファイルグループ（`Pdo*Repository` が複数箇所）。#330 Clock sweep は `time()`/`date()`/`DateTime('now')` を掃討済みだが、DB 永続化用（`updated_at`/`deleted_at`/lock 書き込み）の `gmdate()` 直書きが残存。**いずれもルールの真ポジ＝真FP は 0件**なので `allow` は空、全件 `ignore` に grandfather。将来 Clock 注入で解消したら baseline から外す。

## 検証結果

- `composer conformance` → exit 0（17 suppressed by baseline）
- `composer check` → 緑（418 tests OK / phpstan L8 no errors / cs 0 / openapi valid / mcp valid / conformance OK）
- **ゲート実効確認**: `src/` に新規 `gmdate()` を仕込むと `[D4] ... exit 1` で検出、撤去で exit 0 に戻ることを確認。

Closes #331

Self-review: backend-api, release-ci

## 残リスク

- baseline は既存 D4 を grandfather しているだけで、17件の `gmdate()` 直書き自体は未修正（別 issue で Clock 注入して段階撤去）。
- 現状 error は D4 のみ検出。D1（JWT 既定secret）は #320 fail-close 済で違反 0、D2/D3 も clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)