### PR TITLE
docs(readme): Current Status のフェーズ定義を実態に同期する (#335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Ops / AI (MCP)         ───────────────────
 
 ## Current Status
 
-Phases 1–3 core deliverables are complete. See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
+Phases 1–4 core deliverables are complete, including multi-tenancy. See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 
 | Area | State |
 | --- | --- |
@@ -76,7 +76,8 @@ Phases 1–3 core deliverables are complete. See [`docs/roadmap.md`](./docs/road
 | Brute-force protection + password reset | ✅ |
 | Admin E2E tests (157 Playwright specs) | ✅ |
 | Tier A — installer + release ZIP + operator docs | ✅ |
-| Phase 4 — upstream integrations | Planned |
+| Phase 4 — multi-tenancy (organizations, single/subdomain/path tenant resolution, superadmin) | ✅ (2026-05-29) |
+| Phase 5 — upstream integrations (NeNe Records) | Planned |
 
 See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 


### PR DESCRIPTION
Closes #335

## 変更内容

README の "Current Status" 節の事実訂正のみ（構成の全面改稿はしない）:

- 「Phases 1–3 core deliverables are complete」→「Phases 1–4 core deliverables are complete, including multi-tenancy」
- 表に **Phase 4 — multi-tenancy（organizations / single/subdomain/path tenant resolution / superadmin）✅ (2026-05-29)** の行を追加（出荷済み機能の記載漏れ是正）
- 「Phase 4 — upstream integrations | Planned」→「**Phase 5** — upstream integrations (NeNe Records) | Planned」にフェーズ番号を是正

## 根拠（source of truth）

- `docs/roadmap.md` — Phase 4: Multi-tenancy ✅ 完了 (2026-05-29) / Phase 5: Upstream Integrations
- `docs/todo/current.md` (2026-05-30) — Phase 4 — Multi-tenancy: 完了（2026-05-29）
- `CLAUDE.md` 現在の開発状況表

## セルフレビューチェックリスト

`docs/review/docs-policy.md` を実施:

- [x] source-of-truth（roadmap / current.md）は既に正しく、README 側を正本に合わせて訂正
- [x] プロジェクト状態の変更なし（docs 表現の同期のみ）のため roadmap / current.md の更新は不要
- [x] ADR 不要（アーキテクチャ変更なし）
- [x] 公開 docs は英語のまま・glossary の正式用語を使用（multi-tenancy / superadmin / upstream integrations）
- [x] Issue / PR 参照を記載（#335）
- [x] `git diff --check` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)