### PR TITLE
docs(readme): 統一テンプレ適用（生数字撤去・Status同期・ports節）

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ curl -fsS http://localhost:8989/health
 
 > [`docs/deployment/shared-hosting.md`](./docs/deployment/shared-hosting.md)
 
+## Local ports
+
+NeNe Corpus owns the **`89**` port lane**; sibling products use their own lanes so several apps can run locally side by side (full port table: [`CLAUDE.md`](./CLAUDE.md#ローカル開発ポート固定)). Override the Docker ports via `NENE_CORPUS_PORT` / `NENE_CORPUS_MYSQL_PORT` in `.env`.
+
+| Service | Port |
+| --- | --- |
+| API / Web (Docker, Apache) | 8989 |
+| MySQL (Docker) | 3389 |
+| Vite admin SPA | 5289 |
+| Vite widget | 5290 |
+
 ## Architecture
 
 ```
@@ -62,7 +73,7 @@ Ops / AI (MCP)         ───────────────────
 - **Chat**: **sync JSON chat** + citations, rate limits; widget CSS for loading/motion UX
 - **Deploy**: dual path — [`docs/deployment/README.md`](./docs/deployment/README.md)
 
-## Current Status
+## Status
 
 Phases 1–4 core deliverables are complete, including multi-tenancy. See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 
@@ -74,10 +85,10 @@ Phases 1–4 core deliverables are complete, including multi-tenancy. See [`docs
 | Operator settings (LLM key, chat limits, notifications, appearance) | ✅ |
 | Conversation analytics dashboard + CSV export | ✅ |
 | Brute-force protection + password reset | ✅ |
-| Admin E2E tests (157 Playwright specs) | ✅ |
+| Admin E2E tests (comprehensive Playwright E2E suite) | ✅ |
 | Tier A — installer + release ZIP + operator docs | ✅ |
 | Phase 4 — multi-tenancy (organizations, single/subdomain/path tenant resolution, superadmin) | ✅ (2026-05-29) |
-| Phase 5 — upstream integrations (NeNe Records) | Planned |
+| Phase 5 — upstream integrations (NeNe Records) | 🔄 In progress |
 
 See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
 


### PR DESCRIPTION
Closes #337

## Summary

- Status 表の「Admin E2E tests (157 Playwright specs)」の生数字ハードコードを定性表現へ変更（テスト件数は変動するため）
- Status 表「Phase 5 — upstream integrations (NeNe Records) | Planned」を実態同期。`docs/todo/current.md`（2026-05-30更新）によれば Phase 5 P1「NeNe Records 読み取りクライアント」は #313 で着手・PR #315 でマージ済み（確認済み: `gh pr view 315` → MERGED, 2026-05-30）なので「🔄 In progress」に是正
- Local ports 節を新設（invoice 等の正典テンプレに存在するが本リポに無かった） — 自レーン表（`compose.yaml` の `NENE_CORPUS_PORT`=8989 / `NENE_CORPUS_MYSQL_PORT`=3389 既定値、Vite admin 5289 / widget 5290 は `CLAUDE.md` より）＋ `CLAUDE.md`「ローカル開発ポート（固定）」節へのアンカーリンク
- 見出し「Current Status」→「Status」（テンプレの節名に統一）

README.md のみの docs-only 変更。`_work/reports/2026-07-13-readme-unification-audit.md`（横断監査）の P1 項目に対応。

## 裏取り

- `docs/todo/current.md` の Phase 5 P1 記述・`gh pr view 315` / `gh issue view 313`（マージ済み確認）
- `compose.yaml`（ポート既定値）、`CLAUDE.md`「ローカル開発ポート（固定）」節
- リンクアンカー `#ローカル開発ポート固定` は同一見出しを持つ nene-invoice/CLAUDE.md の GitHub 実レンダリング（`id="user-content-ローカル開発ポート固定"`）で実在確認済み

## Test plan

- [x] docs-only 変更のため CI（backend-ci）への影響なし
- [x] README.md 以外に変更ファイルなし（`git diff --stat`）
- [x] Local ports の数値を `compose.yaml` / `CLAUDE.md` と突合済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)