### PR TITLE
feat(http): X-Authorization フォールバック受け口を opt-in 有効化する (#343)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.4.1 <9.0",
-        "hideyukimori/nene2": "^1.8.2",
+        "hideyukimori/nene2": "^1.11",
         "phpmailer/phpmailer": "^7.1",
         "robmorgan/phinx": "^0.16.11",
         "smalot/pdfparser": "^2.12"
@@ -16,7 +16,7 @@
             "url": "../NENE2",
             "options": {
                 "versions": {
-                    "hideyukimori/nene2": "1.8.2"
+                    "hideyukimori/nene2": "1.11.0"
                 }
             }
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2695d5ed0ddfa3758e1bb6063461ef9",
+    "content-hash": "84b279d059f7fdca3a192d0f5695eaf2",
     "packages": [
         {
             "name": "cakephp/chronos",
@@ -394,11 +394,11 @@
         },
         {
             "name": "hideyukimori/nene2",
-            "version": "1.8.2",
+            "version": "1.11.0",
             "dist": {
                 "type": "path",
                 "url": "../NENE2",
-                "reference": "98869b1e494f6ec5c708694a3f3a51e923d43231"
+                "reference": "71651c457d48c1357b633bac51f1e7e26e6aad72"
             },
             "require": {
                 "monolog/monolog": "^3.0",

--- a/src/Http/RuntimeServiceProvider.php
+++ b/src/Http/RuntimeServiceProvider.php
@@ -289,6 +289,11 @@ final readonly class RuntimeServiceProvider implements ServiceProviderInterface
                         [],
                         [],
                         10 * 1024 * 1024,
+                        // Opt-in の X-Authorization フォールバック受け口（NENE2 #1558・ADR 0019）。
+                        // 前段 proxy が標準 Authorization を剥がす共有ホスティング（HETEML 型 Tier A）で、
+                        // nene2-js v1.1.0 が全リクエストに付与する `X-Authorization: Bearer` ミラーを
+                        // Authorization 不在/空のときのみ採用する。標準ヘッダが届く環境ではバイト不変。
+                        enableAuthorizationHeaderFallback: true,
                     );
                 },
             )

--- a/tests/Http/AuthorizationHeaderFallbackE2ETest.php
+++ b/tests/Http/AuthorizationHeaderFallbackE2ETest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Http;
+
+use Nene2\Auth\TokenIssuerInterface;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\AdminAuth\AdminAuthServiceProvider;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Tests\Support\AdminHttpTestSupport;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * End-to-end proof that the opt-in X-Authorization fallback receiver (NENE2 #1558 /
+ * ADR 0019) is wired into this product's runtime pipeline.
+ *
+ * Front-end fleet clients (`@hideyukimori/nene2-client` v1.1.0) mirror every bearer
+ * token into `X-Authorization: Bearer <token>` so that shared hosting (HETEML-type
+ * Tier A) — where an upstream proxy strips the standard `Authorization` header before
+ * PHP sees it — can still authenticate. `RuntimeServiceProvider` enables the receiver
+ * via `enableAuthorizationHeaderFallback: true`, so the framework's
+ * AuthorizationHeaderFallbackMiddleware restores `Authorization` from the mirror
+ * (only when `Authorization` is absent/empty) at the head of the auth stage, before
+ * `AdminBearerTokenMiddleware` runs.
+ *
+ * `GET /admin/superadmin/organizations` is bearer-protected but is one of
+ * `OrgResolverMiddleware::BYPASS_PREFIXES` (`/admin/superadmin/`), so these
+ * assertions isolate the credential-restoration behaviour without needing a
+ * seeded tenant. The token is issued directly via the admin JWT issuer service
+ * (bypassing the DB-backed login use case) with a `superadmin` role claim so the
+ * request also clears `SuperadminMiddleware`, which runs immediately after the
+ * bearer auth stage.
+ *
+ * The tests fail if the opt-in flag is removed from RuntimeServiceProvider: a
+ * mirror-only request would then never restore `Authorization` and would be
+ * rejected as `missing_token`.
+ */
+final class AuthorizationHeaderFallbackE2ETest extends TestCase
+{
+    private const PROTECTED_PATH = '/admin/superadmin/organizations';
+
+    private const JWT_SECRET = 'test-x-auth-fallback-jwt-secret';
+
+    private string $databasePath;
+
+    private RequestHandlerInterface $app;
+
+    private TokenIssuerInterface $issuer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-x-auth-fallback-' . uniqid('', true) . '.sqlite';
+
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = self::JWT_SECRET;
+        $_ENV['DB_ADAPTER'] = 'sqlite';
+        $_ENV['DB_NAME'] = $this->databasePath;
+        $_SERVER['DB_ADAPTER'] = 'sqlite';
+        $_SERVER['DB_NAME'] = $this->databasePath;
+
+        $container = (new RuntimeContainerFactory())->create();
+
+        $executor = $container->get(DatabaseQueryExecutorInterface::class);
+        self::assertInstanceOf(PdoDatabaseQueryExecutor::class, $executor);
+        AdminHttpTestSupport::seedCorpusSchema($executor);
+
+        $app = $container->get(RequestHandlerInterface::class);
+        self::assertInstanceOf(RequestHandlerInterface::class, $app);
+        $this->app = $app;
+
+        // Admin JWTs are issued under a named service id (not TokenIssuerInterface::class
+        // — see AdminAuthServiceProvider::TOKEN_ISSUER), so the LocalBearerTokenVerifier
+        // bound there is fetched directly rather than via the interface.
+        $issuer = $container->get(AdminAuthServiceProvider::TOKEN_ISSUER);
+        self::assertInstanceOf(TokenIssuerInterface::class, $issuer);
+        $this->issuer = $issuer;
+    }
+
+    protected function tearDown(): void
+    {
+        $_ENV['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        $_SERVER['NENE2_LOCAL_JWT_SECRET'] = 'phpunit-default-jwt-secret';
+        unset(
+            $_ENV['DB_ADAPTER'],
+            $_SERVER['DB_ADAPTER'],
+            $_ENV['DB_NAME'],
+            $_SERVER['DB_NAME'],
+        );
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+    }
+
+    /**
+     * The mirror end-to-end proof: a valid superadmin bearer token supplied ONLY in
+     * the `X-Authorization` header (no standard `Authorization`) is restored by the
+     * fallback receiver and accepted by the bearer auth stage — the request passes
+     * authentication.
+     *
+     * The bearer middleware is the only thing that issues a `WWW-Authenticate`
+     * challenge; its absence proves authentication succeeded (a non-2xx response
+     * here would be downstream — e.g. the org list handler itself — which is out of
+     * scope for this transport-level mirror proof).
+     */
+    public function test_valid_token_in_mirror_only_passes_authentication(): void
+    {
+        $token = $this->issueSuperadminToken();
+
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', self::PROTECTED_PATH)
+            ->withHeader('X-Authorization', 'Bearer ' . $token);
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(
+            '',
+            $response->getHeaderLine('WWW-Authenticate'),
+            'A valid token mirrored only into X-Authorization must pass the bearer auth stage (no challenge issued).',
+        );
+    }
+
+    /**
+     * The auth stage actually receives the mirrored credential: an INVALID token
+     * in `X-Authorization` only is rejected as `invalid_token` (the bearer
+     * middleware saw a token), NOT `missing_token` — which is only possible if the
+     * fallback receiver restored `Authorization` from the mirror before auth ran.
+     */
+    public function test_invalid_token_in_mirror_only_reaches_bearer_stage_as_invalid_not_missing(): void
+    {
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', self::PROTECTED_PATH)
+            ->withHeader('X-Authorization', 'Bearer not-a-real-token');
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+        $wwwAuth = $response->getHeaderLine('WWW-Authenticate');
+        self::assertStringContainsString('error="invalid_token"', $wwwAuth);
+        self::assertStringNotContainsString('error="missing_token"', $wwwAuth);
+    }
+
+    /**
+     * Baseline / control: with NO credential in either header, the auth stage
+     * reports `missing_token`. This is the response a mirror-only request would get
+     * if the opt-in fallback were disabled.
+     */
+    public function test_no_credential_yields_missing_token(): void
+    {
+        $request = (new Psr17Factory())->createServerRequest('GET', self::PROTECTED_PATH);
+
+        $response = $this->app->handle($request);
+
+        self::assertSame(401, $response->getStatusCode());
+        self::assertStringContainsString(
+            'error="missing_token"',
+            $response->getHeaderLine('WWW-Authenticate'),
+        );
+    }
+
+    /**
+     * The standard header still wins when both are present (byte-for-byte behaviour
+     * unchanged on hosting that delivers `Authorization`): a valid standard token
+     * authenticates even when an invalid mirror is also sent. If the receiver wrongly
+     * preferred the mirror, the bearer stage would reject the invalid token with an
+     * `invalid_token` challenge; its absence proves standard-header precedence.
+     */
+    public function test_standard_authorization_header_takes_precedence_over_mirror(): void
+    {
+        $token = $this->issueSuperadminToken();
+
+        $request = (new Psr17Factory())
+            ->createServerRequest('GET', self::PROTECTED_PATH)
+            ->withHeader('Authorization', 'Bearer ' . $token)
+            ->withHeader('X-Authorization', 'Bearer not-a-real-token');
+
+        $response = $this->app->handle($request);
+
+        self::assertSame('', $response->getHeaderLine('WWW-Authenticate'));
+    }
+
+    private function issueSuperadminToken(): string
+    {
+        $now = time();
+
+        return $this->issuer->issue([
+            'sub'    => 'x-auth-fallback-e2e',
+            'email'  => 'x-auth-fallback-e2e@example.com',
+            'role'   => 'superadmin',
+            'org_id' => null,
+            'iat'    => $now,
+            'exp'    => $now + 3600,
+        ]);
+    }
+}


### PR DESCRIPTION
## 目的

NENE2 #1558（`Nene2\Middleware\AuthorizationHeaderFallbackMiddleware`＋`RuntimeApplicationFactory` の opt-in フラグ `enableAuthorizationHeaderFallback`・ADR 0019）を本製品で有効化し、X-Auth ミラーを **E2E で実証**する（BE 配線波、field #98 / profile #116 と同じパターン）。

前段 proxy が標準 `Authorization` を PHP に渡す前に剥がす共有ホスティング（HETEML 型 Tier A）向けの受け口。FE は `@hideyukimori/nene2-client` v1.1.0 が全リクエストに `X-Authorization: Bearer <token>` ミラーを送出済み。BE がこの受け口を有効化して初めてミラーが E2E で効く。

Closes #343

## 変更点

- `composer.json` — `hideyukimori/nene2` 制約を `^1.8.2` → `^1.11`（受け口を含むリリース版を要求）。本リポは他フリート製品と異なり `../NENE2` への **path repository**（`options.versions` でバージョンを明示 pin）を使う構成のため、pin も `1.8.2` → `1.11.0` に同期。これは #324/#325 で確立済みの是正パターンと同一（`../NENE2` symlink 運用と `dist.reference`（main 追随）は維持、`composer.lock` も追随してコミット）
- `src/Http/RuntimeServiceProvider.php` — `RuntimeApplicationFactory` 構築に `enableAuthorizationHeaderFallback: true` を追加（opt-in 有効化）。本製品の呼び出しは全て位置引数のため、末尾に named argument として追加（PHP は位置引数の後に named 引数を続けられる）
- `tests/Http/AuthorizationHeaderFallbackE2ETest.php` — E2E 実証テスト（実 runtime を booting）。`GET /admin/superadmin/organizations`（bearer 保護・`OrgResolverMiddleware::BYPASS_PREFIXES` で org 解決 bypass）を使い、seed した tenant 無しでミラー挙動を isolate する。トークンは本製品の admin JWT 発行サービス（`AdminAuthServiceProvider::TOKEN_ISSUER` — `TokenIssuerInterface::class` ではなく名前付きサービス ID で束縛されている点に注意）から `role: superadmin` claim 付きで直接発行し、DB 経由のログインユースケースを迂回する:
  - **有効な token を X-Authorization だけに載せる** → 認証ステージを通過（bearer が challenge を出さない＝`WWW-Authenticate` 不在）
  - **無効な token を X-Authorization だけに載せる** → `error="invalid_token"`（ステージが token を**受け取った**証拠）であって `missing_token` ではない ← ミラーが Authorization を復元した E2E 証明
  - credential 無し → `error="missing_token"`（baseline）
  - 標準 Authorization ＋無効ミラー併存 → 標準優先（challenge 不在）

## 検証結果（実測・2026-07-15）

- 解決した nene2: **v1.11.0**（本リポの path repo 構成のため、CI と同じ手順で `../NENE2` を `git clone --depth=1 https://github.com/hideyukiMORI/NENE2.git` して symlink 経由で解決。実体は AuthorizationHeaderFallbackMiddleware を含む v1.11.0 リリース後の main）
- 追加 E2E テスト単体: **OK (4 tests, 19 assertions)**
- opt-in フラグを一時的に外した回帰確認: 4件中2件が想定どおり fail（`missing_token` — フラグを外すとミラーが復元されず認証ステージに届かないことを確認済み）。確認後フラグを復元し、再度緑を確認
- 全 phpunit スイート: **OK (422 tests, 1374 assertions)**（既存 418 tests, 1355 assertions は無傷）
- PHPStan: **No errors**（506 files）/ php-cs-fixer: **0 files to fix** / openapi: valid / mcp: valid / conformance: 0 findings
- `composer check` 全体: **exit 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)