### PR TITLE
docs(claude-md): frontend check コメントを実態（lint + typecheck + test）に合わせる (#347)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ frontend/
 
 ```bash
 composer check                         # PHPUnit + PHPStan level8 + CS-Fixer + OpenAPI + MCP
-npm run check --prefix frontend        # TypeScript + lint
+npm run check --prefix frontend        # lint (ESLint) + typecheck + test (vitest)
 docker compose up --build -d           # ローカルスタック確認
 curl -fsS http://localhost:8989/health
 ```


### PR DESCRIPTION
Closes #347

## 変更内容

CLAUDE.md 品質チェック節の `npm run check --prefix frontend` のコメントを
「TypeScript + lint」→「lint (ESLint) + typecheck + test (vitest)」へ実態合わせ。

## 根拠（実測）

- `frontend/package.json` の `check` = `npm run lint && npm run typecheck --workspaces --if-present && npm run test --workspaces --if-present`
- ローカルで `npm run check` を実行し lint 込みで exit 0（vitest 4 件 pass 含む）を確認
- 当初査定（発見13「lint 不在」）は #342 マージ前の時点測定で、現 main とは不一致（統合リナ承認済みの再定義）

## セルフレビューチェックリスト

- `docs/review/docs-policy.md` — ドキュメントのみの変更。コード・CI job 名・operationId に触れていない。記載内容が実測と一致することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)