### PR TITLE
docs: 運用ログ移設に伴う生きた導線を private ミラーへ sweep する (#357)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Ops / AI (MCP)         ───────────────────
 
 ## Status
 
-Phases 1–4 core deliverables are complete, including multi-tenancy. See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
+Phases 1–4 core deliverables are complete, including multi-tenancy. See [`docs/roadmap.md`](./docs/roadmap.md). The operational task board moved to the private mirror `nene-origin/internal-docs/corpus/todo/current.md`.
 
 | Area | State |
 | --- | --- |
@@ -90,7 +90,7 @@ Phases 1–4 core deliverables are complete, including multi-tenancy. See [`docs
 | Phase 4 — multi-tenancy (organizations, single/subdomain/path tenant resolution, superadmin) | ✅ (2026-05-29) |
 | Phase 5 — upstream integrations (NeNe Records) | 🔄 In progress |
 
-See [`docs/roadmap.md`](./docs/roadmap.md) and [`docs/todo/current.md`](./docs/todo/current.md).
+See [`docs/roadmap.md`](./docs/roadmap.md). The operational task board moved to the private mirror `nene-origin/internal-docs/corpus/todo/current.md`.
 
 ## Non-goals
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ NeNe Corpus is built through small, Issue-driven changes. This document is the s
 | AI tools | `docs/integrations/ai-tools.md` |
 | Agent entry point | `AGENTS.md` |
 | Roadmap | `docs/roadmap.md` |
-| Current work | `docs/todo/current.md` |
+| Current work | private `nene-origin/internal-docs/corpus/todo/current.md` |
 
 ## Collaboration Policy
 
@@ -33,7 +33,7 @@ Follow [`docs/workflow.md`](workflow.md) — inherited from [NENE2](https://gith
 Phase 0 bootstrap (2026-05-24 — 2026-05-25) used direct `main` commits as a one-time exception. **Phase 1 onward uses Issue → PR → merge only.**
 
 - Use one branch and one PR per focused work unit.
-- Keep `docs/milestones/`, `docs/roadmap.md`, and `docs/todo/current.md` updated when direction changes.
+- Keep `docs/milestones/`, `docs/roadmap.md`, and private `nene-origin/internal-docs/corpus/todo/current.md` updated when direction changes.
 - Explain intent, impact, verification, and remaining risk in PRs.
 - Prefer documentation that helps the next developer or AI agent decide what to do without rereading chat history.
 

--- a/docs/development/adr.md
+++ b/docs/development/adr.md
@@ -12,7 +12,7 @@ Write an ADR when a decision affects:
 - release, versioning, or compatibility policy
 - long-term maintenance cost
 
-Do **not** use ADRs for routine task detail — use Issues, PRs, and `docs/todo/current.md`.
+Do **not** use ADRs for routine task detail — use Issues, PRs, and the private mirror `nene-origin/internal-docs/corpus/todo/current.md`.
 
 ## Directory and naming
 

--- a/docs/review/docs-policy.md
+++ b/docs/review/docs-policy.md
@@ -9,13 +9,13 @@ Source policies:
 - `docs/inheritance-from-nene2.md`
 - `docs/explanation/glossary.md`
 - `docs/development/naming-conventions.md`
-- `docs/todo/current.md`
+- private `nene-origin/internal-docs/corpus/todo/current.md`（運用ログは private へ移設）
 - `docs/roadmap.md`
 
 ## Checklist
 
 - [ ] The source-of-truth policy doc was updated instead of only adding a summary elsewhere.
-- [ ] `docs/roadmap.md` or `docs/todo/current.md` updated when project state changed.
+- [ ] `docs/roadmap.md` or private `nene-origin/internal-docs/corpus/todo/current.md` updated when project state changed.
 - [ ] Major architecture decisions considered whether an ADR is needed.
 - [ ] NENE2 inheritance changes reflected in `docs/inheritance-from-nene2.md`.
 - [ ] Public source-of-truth docs and OpenAPI text remain English unless policy allows otherwise.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -47,7 +47,7 @@ Goal: grounded Q&A with cited responses.
 - **sync JSON chat** endpoint (default for Tier A and Tier B)
 - **Citation** payload in responses
 - **Rate limit** per session/IP
-- **sync JSON chat** only — consumer UX via widget CSS (loading, bubble motion, scroll). **SSE streaming is a non-goal** (see ADR 0003 note in `docs/todo/current.md`)
+- **sync JSON chat** only — consumer UX via widget CSS (loading, bubble motion, scroll). **SSE streaming is a non-goal** (see ADR 0003 note in the private mirror `nene-origin/internal-docs/corpus/todo/current.md`)
 
 ## Phase 3: Admin UI & Widget
 
@@ -77,7 +77,7 @@ Goal: day-2 operations without SSH or hosting-panel `.env` edits where possible.
 - **Admin E2E test suite** ✅ — 157 Playwright specs covering all major flows (#250 #252)
 - **Persona UX scenario tests** ✅ — 200 personas × 10 patterns, 200/200 pass, UX analysis report (#253)
 
-詳細バックログ: [`docs/todo/current.md`](./todo/current.md).
+詳細バックログ: private `nene-origin/internal-docs/corpus/todo/current.md`（運用ログは private へ移設）。
 
 ## Phase 4: Multi-tenancy ✅ 完了
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -7,7 +7,7 @@ See also: `docs/inheritance-from-nene2.md`.
 ## Standard Flow
 
 1. Create or reuse a focused GitHub Issue.
-2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and `docs/todo/current.md`.
+2. Confirm context in `docs/roadmap.md`, `docs/milestones/`, and private `nene-origin/internal-docs/corpus/todo/current.md`.
 3. Create a branch from `main` named like `type/issue-number-summary`.
 4. Implement the smallest useful change.
 5. Update docs, roadmap, milestone, or TODO files when the decision or state changes.
@@ -44,7 +44,7 @@ Every PR should include:
 
 - `docs/roadmap.md`: long-lived direction and phases
 - `docs/milestones/`: medium-sized goals and acceptance criteria
-- `docs/todo/current.md`: current task board
+- private `nene-origin/internal-docs/corpus/todo/current.md`: current task board（運用ログは private へ移設）
 - `docs/adr/`: major architecture decisions
 - `docs/inheritance-from-nene2.md`: NENE2 governance inheritance map
 
@@ -67,7 +67,7 @@ When asked to complete work, AI agents should run the **full lifecycle** unless 
 - commit with `(#issue)` in the subject
 - push the branch and open a PR with checklist name and `Closes #number`
 - merge after checks pass and sync local `main`
-- update `docs/todo/current.md` and milestones when state changes
+- update private `nene-origin/internal-docs/corpus/todo/current.md` and milestones when state changes
 
 Direct pushes to `main` are **not** part of the normal agent workflow.
 


### PR DESCRIPTION
Closes #357

## 概要

P3 運用ログ移設 Phase 3 の**③生き導線 sweep**（②削除 #358 の後段・最終段）。公開 docs に残った `docs/todo/current.md` への**生きた参照**を、private ミラー `nene-origin/internal-docs/corpus/todo/current.md`（コードスパン）へ repoint する。手順正本 = `internal-docs/nene2/daily/2026-07-18.md`「明朝9艦展開の型」step 4。参照実装 = NENE2 #1603。

## repoint した生きた導線

| ファイル | 箇所 |
| --- | --- |
| `README.md` | Status セクション 2 箇所 |
| `docs/roadmap.md` | ADR 0003 note・詳細バックログ |
| `docs/workflow.md` | context 確認・task board・状態更新 |
| `docs/CONTRIBUTING.md` | Current work 表・direction changes |
| `docs/review/docs-policy.md` | SoT 一覧・チェックリスト |
| `docs/development/adr.md` | routine task detail の誘導先 |

## 放置（方針どおり・歴史 milestone は触らない）

- `docs/milestones/*`（歴史 milestone の達成記録）
- `docs/testing/2026-05-27-e2e-handoff.md`（歴史 handoff スナップショット）
- `docs/adr/0002-separate-from-nene-records.md`（**NeNe Records** リポの `docs/todo/current.md` を指す外部参照＝別リポ）

## 方針

- リンク化せず**コードスパン参照**（§7追補3 のリンク罠回避・internal-docs は別 private リポで相対リンク不能）。
- CI 緑で self-merge（hub 新ポリシー・2026-07-18）→ 事後報告（番号＋SHA）。

## セルフレビュー

- `docs/review/docs-policy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)