### PR TITLE
docs(claude-md): E2E が叩く対象は「コミット済み静的ビルド」でないと訂正する (#365)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,7 @@ curl -fsS http://localhost:8989/health
 Playwright の 2 スイート。**npm workspaces（`frontend/`）の外**にあり、**どの CI workflow からも呼ばれていない**（merge ゲートではない）。API は全て `page.route()` でモックし、`public_html/` の静的ビルドを `python3 -m http.server 3001` で配信する方式（実バックエンド・LLM 不要）。
 
 ```bash
+npm run build:release --prefix frontend                    # ★先に必須（下記「叩く対象」参照）
 cd tests/e2e && npm install
 npx playwright install chromium                            # 初回のみ
 npx playwright test                                        # widget スイート（specs/ 103 テスト・約1分）
@@ -311,8 +312,13 @@ npx playwright test --config playwright.admin.config.ts    # admin スイート�
 | widget（`specs/`） | ✅ 103/103 pass（約1.1分） | 生きている |
 | admin（`admin/specs/`） | ❌ 226/373 pass・147 fail（約58分） | spec が現行 admin UI と乖離（最新ビルドでも `01-auth` は 3/17。例: email prefill 期待が現 UI に無い） |
 
-- admin スイートの対象は `public_html/admin/` の**コミット済み静的ビルド**。ソース変更後は `npm run build:release --prefix frontend` しないと反映されない（自動更新されない）。
-- **CI 配線と admin spec の現行 UI への再整備は今後の課題**（着手時は Issue 化してから）。CI 未配線のため drift が検知されない状態が続いている点に注意。
+**叩く対象は「ローカルでビルドした未追跡の成果物」（#365 で訂正）:**
+
+- admin スイートの対象は `public_html/admin/` の静的ビルドだが、これは**コミットされていない**。`.gitignore` が `/public_html/admin/*`（`!.htaccess` のみ例外）なので、**追跡されているのは `.htaccess` 1 ファイルだけ**。`index.html` / `assets/` は各マシンのローカルビルド成果物。
+- したがって **E2E を回す前に `npm run build:release --prefix frontend` が必須**。ビルドしていない checkout には対象そのものが存在せず、古いビルドが残っていれば**古い UI に対してテストしている**ことになる。
+- この性質上、**「N/M pass」という数字は必ず「どの時点のビルドに対する測定か」とセットでしか意味を持たない**。上表の 2026-07-18 実測も同様。
+- **CI 配線（#352）にはビルドステップが要る。** CI は fresh checkout なので `public_html/admin/` は `.htaccess` しか無く、「コミット済みビルドを配信するだけ」では動かない。
+- **CI 配線と admin spec の現行 UI への再整備は今後の課題**（着手時は Issue 化してから。#351 → #352・順序固定。#351 の受入条件には**基準ビルドの固定**を入れる）。CI 未配線のため drift が検知されない状態が続いている点に注意。
 
 ## セルフレビューチェックリスト（PR 本文に記載）
 


### PR DESCRIPTION
`Closes #365`

## 事実

`CLAUDE.md` は admin E2E の対象を `public_html/admin/` の**コミット済み静的ビルド**と書いていたが、実際は追跡されていない。

```
# .gitignore:11-12
/public_html/admin/*
!/public_html/admin/.htaccess

$ git ls-files public_html/admin
public_html/admin/.htaccess      # ← 1件のみ
```

`index.html` / `assets/` / favicon 群は各マシンの**ローカルビルド成果物**（未追跡）。

## 誤りが実害を持つ 2 箇所

1. **測定の意味が不定になる。** ビルドせずに回すと対象そのものが存在せず、古いビルドが残っていれば古い UI に対してテストしている。「226/373 pass」という数字も、どの時点のビルドに対する測定なのか記述から特定できなかった。
2. **#352（CI 配線）が前提から成立しない。** CI は fresh checkout なので `public_html/admin/` には `.htaccess` しか無い。「コミット済みビルドを配信するだけ」では動かず、実行前に `npm run build:release --prefix frontend` を挟む必要がある。

## 変更

- 実行手順の先頭に `npm run build:release --prefix frontend` を**必須**として追加
- 「コミット済み静的ビルド」→ **ローカルでビルドした未追跡の成果物**へ訂正し、`.gitignore` の実態を明記
- 「N/M pass はどの時点のビルドに対する測定かとセットでしか意味を持たない」を明記
- #352 にビルドステップが要ること、#351 の受入条件に**基準ビルドの固定**を入れることを記載

## 経緯

A2 の P0/P1 実装中（#361 → PR #362 / #364）に、設計ノート自身が同じ誤った前提（R4/R5）に立っていたことに気づいて起票したもの。fleet の横断実測でも **8 艦が dev サーバ E2E で本番バンドルを一度も叩いていない**ことが判明し、corpus 型（事前生成物を叩く）と合わせて「**E2E が何に対して緑なのか固定されていない**」という同型の穴として整理された。フェーズ2 の L3 ハーネス要件に「本番ビルドを自分で作ってから叩く」が入っている。

## セルフレビューチェックリスト

`docs/review/docs-policy.md` — ドキュメントのみの変更。コード・API・DB・ミドルウェアに変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
