### PR TITLE
test(install): .env 値の制御文字拒否を CR / CRLF / NUL まで広げる (#327)

### DIFF
--- a/tests/Install/EnvFileWriterTest.php
+++ b/tests/Install/EnvFileWriterTest.php
@@ -102,11 +102,28 @@ final class EnvFileWriterTest extends TestCase
         self::assertStringContainsString('# --- Admin auth', $content);
     }
 
-    public function test_value_with_newline_is_rejected(): void
+    #[DataProvider('controlCharacterValues')]
+    public function test_value_with_control_character_is_rejected(string $value): void
     {
         $this->expectException(InstallRuntimeException::class);
 
-        $this->writer()->write(['DB_PASSWORD' => "line1\nINJECTED=evil"]);
+        $this->writer()->write(['DB_PASSWORD' => $value]);
+    }
+
+    /**
+     * Every byte that could break out of a single `KEY=value` line. A line feed appends a
+     * forged assignment; a lone carriage return does the same on the parsers that split on
+     * it; a NUL byte truncates the value for C-level consumers while the rest of the line
+     * survives in the file.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function controlCharacterValues(): iterable
+    {
+        yield 'line feed' => ["line1\nINJECTED=evil"];
+        yield 'carriage return' => ["line1\rINJECTED=evil"];
+        yield 'crlf' => ["line1\r\nINJECTED=evil"];
+        yield 'nul byte' => ["secret\0INJECTED=evil"];
     }
 
     private function writer(): EnvFileWriter


### PR DESCRIPTION
`Closes #327`

## 経緯 — この issue の本体は既に実装済みだった

hub の着手 GO を受けて #326 / #327 に入ったところ、**両方とも PR #328（2026-07-06・commit `002bae4`）で実装・マージ済み**で、issue だけが 1 ヶ月 open のまま残っていたことが分かった。実測:

| #327 の受け入れ条件 | 実装 | テスト |
| --- | --- | --- |
| `.env` を 0640（world ビット 0）で書く | ✅ `EnvFileWriter` が `EnvironmentWriter` に委譲＋`@chmod($tmp, 0640)` | ✅ `test_env_is_written_non_world_readable` |
| `$` `"` 空白 `#` `\` を含む値が phpdotenv で verbatim に round-trip | ✅ | ✅ `test_values_round_trip_through_phpdotenv`（6 ケース） |
| テンプレートのコメント・既定キーが維持される | ✅ | ✅ `test_template_comments_are_preserved` |
| **改行 / NUL を含む値は拒否される** | ✅ `EnvironmentWriter` が `/[\r\n\0]/` で 3 種とも拒否 | ⚠️ **LF のみ検証。CR と NUL が未検証** |

**唯一埋まっていなかったのが最後の 1 行**なので、本 PR はそこだけを閉じる。

## 変更

`test_value_with_newline_is_rejected` をデータプロバイダ化して 4 ケースに広げた。

| ケース | 壊し方 |
| --- | --- |
| LF | 行を終わらせて偽の代入を継ぎ足す |
| CR | CR で行を分割するパーサに対して同じことをする |
| CRLF | 上記の組み合わせ |
| NUL | C レベルの消費側で値を切り詰めつつ、行の残りはファイルに残る |

**プロダクションコードの変更はない。** 実装がすでに保証していることに、テストの検証範囲を追いつかせるだけ。

## 検証

```
composer check
  → PHPUnit 425 tests / 1377 assertions OK
  → PHPStan level 8 No errors
  → CS-Fixer clean / OpenAPI valid / MCP valid / Conformance OK（0 findings）
```

## #326 について

`ListSources` / `ListChatSessions` / `ListChatSessionMessages` の 3 handler はいずれも `PaginationQueryParser::parse(..., maxLimit: 200)` を通しており、`tests/Http/AdminListPaginationTest.php` が「limit > 200 → 422」「limit < 1 → 422」「envelope 不変」を検証している（5 tests・実行して pass 確認済み）。**受け入れ条件を全て満たしているので、追加の変更なしで issue をクローズした**。

## セルフレビューチェックリスト

`docs/review/backend-api.md` — テストのみの変更。ハンドラー・UseCase・ルート・OpenAPI・DB に変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
