### PR TITLE
feat(build): widget バンドルのサイズラチェットを追加する (#374)

### DIFF
--- a/docs/development/frontend-gates.md
+++ b/docs/development/frontend-gates.md
@@ -12,6 +12,7 @@
 | テスト | `npm run test` | vitest |
 | 依存の脆弱性 | `npm run audit` | `audit-ci`（high/critical・allowlist は advisory 単位） |
 | ビルド出力 | `npm run verify:build` | ビルドが web ルートを壊していないこと（`build` / `build:release` の後段） |
+| widget のサイズ | `npm run size:check` | 第三者ページへ配信されるバンドルが太っていない／中身が落ちていないこと（`verify:build` に同乗） |
 
 ---
 
@@ -74,6 +75,29 @@ npm run lint:baseline -- --update    # 3 つのベースラインをまとめて
 
 ---
 
+## widget バンドルのサイズラチェット（`size:check`）
+
+`verify:build` に同乗して両ビルド経路で走る。ベースラインは `frontend/widget-size-baseline.json`（`widget.js` / `widget.css` の**生サイズと gzip サイズ**）。
+
+**増加も減少も赤にする。** 許容幅は ±1%。
+
+| 方向 | なぜ赤にするか |
+| --- | --- |
+| 増えた | widget は**第三者のホームページに `<script>` で配信される**。admin コードや Tailwind の preflight が紛れ込んでも、ビルドは成功しテストも CI も緑のまま通る（#368 の `publicDir` と同じ「静かに壊れる」型） |
+| 減った | **widget が壊れて中身が落ちてもサイズは減る。** 「静かに何もしない」の逆向きなので、動くことを確認してからベースラインを下げる |
+
+gzip 側も見るのは、**実際にネットワークを流れるのがそちら**で、生サイズだけだと圧縮率の変化（＝中身の性質の変化）を見逃すため。
+
+意図した変化なら:
+
+```bash
+npm run size:baseline -- --update    # 数字を更新（差分をコミットに含める）
+```
+
+数字がコミットに現れることそのものが目的でもある——レビューで「なぜ増えたのか」が問える形になる。
+
+---
+
 ## 陽性対照（ゲートが生きていることの実証）
 
 導入時に確認済み（#370）。ゲートを触ったら再確認すること。
@@ -86,6 +110,8 @@ npm run lint:baseline -- --update    # 3 つのベースラインをまとめて
 | ビルド出力 | `public_html/` 直下に favicon を置く | 「見知らぬ生成物」で exit 1 |
 | ビルド出力 | `public_html/.htaccess` を消す | 「消えています」で exit 1 |
 | ビルド出力（release） | `public_html/admin/index.html` を消して `verify:build:release` | 「無いか空です」で exit 1 |
+| widget サイズ（増加） | `widget.js` に 9 kB 追記（+2.2%） | 「増えました」で exit 1 |
+| widget サイズ（減少） | `widget.js` を切り詰め（-3.1%） | 「減りました・壊れて中身が落ちても減ります」で exit 1 |
 
 ---
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "build:widget": "vite build --config vite.widget.config.ts",
     "build:release": "npm run build:release:admin && npm run build:widget && node ../scripts/build-guide.mjs && node ../scripts/build-howto.mjs && npm run verify:build:release",
     "build:release:admin": "NENE_CORPUS_ADMIN_OUT=../public_html/admin npm run build:admin",
-    "verify:build": "node ../tools/verify-build-output.mjs",
+    "verify:build": "node ../tools/verify-build-output.mjs && npm run size:check",
     "dev": "vite",
     "dev:admin": "vite",
     "dev:widget": "vite --config vite.widget.config.ts",
@@ -20,7 +20,9 @@
     "lint:baseline": "node ../tools/lint-ratchet.mjs",
     "knip": "knip",
     "audit": "audit-ci --config audit-ci.jsonc",
-    "verify:build:release": "node ../tools/verify-build-output.mjs --release"
+    "verify:build:release": "node ../tools/verify-build-output.mjs --release && npm run size:check",
+    "size:check": "node ../tools/widget-size-ratchet.mjs",
+    "size:baseline": "node ../tools/widget-size-ratchet.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/frontend/widget-size-baseline.json
+++ b/frontend/widget-size-baseline.json
@@ -1,0 +1,10 @@
+{
+  "widget.js": {
+    "bytes": 412744,
+    "gzip": 119404
+  },
+  "widget.css": {
+    "bytes": 8523,
+    "gzip": 1986
+  }
+}

--- a/tools/widget-size-ratchet.mjs
+++ b/tools/widget-size-ratchet.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// embed widget のバンドルサイズのラチェット（#374・設計ノート #361 の R1）。
+//
+// widget は**第三者のホームページに <script> で配信される**。admin のコードや Tailwind の
+// preflight が紛れ込んでも、ビルドは成功しテストも通り CI も緑のまま——#368 の publicDir と
+// 同じ「静かに壊れる」型なので、サイズという別の軸で見張る。
+//
+// 見ているのは 2 方向。増加だけでなく**減少も赤にする**のがこのラチェットの肝で、
+// widget が壊れて中身が落ちてもサイズは減るため（「静かに何もしない」の逆向き）。
+// どちらに動いてもベースラインの更新＝レビューで数字が見える形にする。
+//
+// gzip 側も併せて見る。実際にネットワークを流れるのはこちらで、生サイズだけだと
+// 圧縮率の変化（= 中身の性質の変化）を見逃す。
+//
+// 使い方: npm run verify:build に同乗（build / build:release の両経路で走る）
+//         npm run size:baseline -- --update  でベースラインを更新する
+import { gzipSync } from 'node:zlib';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const baselinePath = resolve(projectRoot, 'frontend/widget-size-baseline.json');
+const update = process.argv.includes('--update');
+
+/** 許容幅。これを超える変化はベースラインの更新（＝レビューで数字が見えること）を要求する。 */
+const TOLERANCE = 0.01;
+
+const ARTIFACTS = ['widget.js', 'widget.css'];
+
+const measured = {};
+
+for (const artifact of ARTIFACTS) {
+  const path = resolve(projectRoot, 'public_html', artifact);
+
+  if (!existsSync(path)) {
+    console.error(`✗ public_html/${artifact} がありません（ビルドしてから実行してください）。`);
+    process.exit(1);
+  }
+
+  const buffer = readFileSync(path);
+  measured[artifact] = { bytes: buffer.length, gzip: gzipSync(buffer).length };
+}
+
+const format = (n) => `${(n / 1024).toFixed(2)} kB`;
+
+if (update) {
+  writeFileSync(baselinePath, `${JSON.stringify(measured, null, 2)}\n`);
+  console.log('✓ widget-size-baseline.json を更新しました:');
+
+  for (const artifact of ARTIFACTS) {
+    console.log(
+      `    ${artifact}  ${format(measured[artifact].bytes)}  (gzip ${format(measured[artifact].gzip)})`,
+    );
+  }
+
+  process.exit(0);
+}
+
+if (!existsSync(baselinePath)) {
+  console.error('✗ widget-size-baseline.json がありません。npm run size:baseline -- --update で作成してください。');
+  process.exit(1);
+}
+
+const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+const failures = [];
+
+for (const artifact of ARTIFACTS) {
+  for (const metric of ['bytes', 'gzip']) {
+    const before = baseline[artifact]?.[metric];
+    const after = measured[artifact][metric];
+
+    if (typeof before !== 'number') {
+      failures.push(`${artifact} の ${metric} がベースラインにありません。--update で作り直してください。`);
+      continue;
+    }
+
+    const delta = after - before;
+    const ratio = delta / before;
+    const label = `${artifact} ${metric === 'gzip' ? '(gzip)' : '(raw)'}`;
+
+    if (ratio > TOLERANCE) {
+      failures.push(
+        `${label} が ${format(before)} → ${format(after)} に増えました（+${(ratio * 100).toFixed(1)}%）。` +
+          '\n      第三者ページに配信される物なので、増えた中身を確認してください' +
+          '（admin コードや Tailwind の混入が典型）。' +
+          '\n      意図した増加なら npm run size:baseline -- --update で数字を更新し、差分をコミットに含める。',
+      );
+    } else if (ratio < -TOLERANCE) {
+      failures.push(
+        `${label} が ${format(before)} → ${format(after)} に減りました（${(ratio * 100).toFixed(1)}%）。` +
+          '\n      **widget が壊れて中身が落ちても減ります。** 実際に動くことを確認してから' +
+          '\n      npm run size:baseline -- --update で更新してください。',
+      );
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('✗ widget バンドルのサイズがベースラインから外れました:');
+
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+
+  process.exit(1);
+}
+
+console.log(
+  `✓ widget のサイズは据え置き: ` +
+    ARTIFACTS.map(
+      (a) => `${a} ${format(measured[a].bytes)}/gzip ${format(measured[a].gzip)}`,
+    ).join('  '),
+);


### PR DESCRIPTION
`Closes #374`（設計ノート #361 の **R1 を機械で守る**・hub 着手 GO）

## なぜ

R1（バンドル肥大）は設計ノートで**最も影響の大きいリスク**として挙げてあったが、実態は #363 で測った数字を**ベースラインとして記録しただけ**で、増えても誰も気づけなかった。今日ずっと踏んできた「**装置はあるが効いていない**」そのもの。

widget は **第三者のホームページに `<script>` で配信される**。admin コードや Tailwind の preflight が紛れ込んでも、**ビルドは成功しテストも通り CI も緑のまま**通る — #368 の `publicDir` と同じ「静かに壊れる」型なので、サイズという別の軸で見張る。

## 実装

`tools/widget-size-ratchet.mjs` を `verify:build` に同乗させ、**両ビルド経路**で走らせる。P3 で作った装置の再利用なので新しい仕掛けは無い。

ベースライン `frontend/widget-size-baseline.json`:

| | 生サイズ | gzip |
| --- | ---: | ---: |
| `widget.js` | 412,744 B (403.07 kB) | 119,404 B (116.61 kB) |
| `widget.css` | 8,523 B (8.32 kB) | 1,986 B (1.94 kB) |

### 増加も減少も赤にする（許容幅 ±1%）

| 方向 | なぜ |
| --- | --- |
| **増えた** | admin コードや Tailwind の混入。第三者ページに配信される物なので実害 |
| **減った** | **widget が壊れて中身が落ちてもサイズは減る。** 「静かに何もしない」の逆向き。動くことを確認してからベースラインを下げる |

**gzip 側も見る**のは、実際にネットワークを流れるのがそちらで、生サイズだけだと**圧縮率の変化（＝中身の性質の変化）を見逃す**ため。

意図した変化なら `npm run size:baseline -- --update` で数字を更新して差分をコミットに含める。**数字がコミットに現れること自体が目的**でもある — レビューで「なぜ増えたのか」が問える形になる。

## 陽性対照（両方向）

| 壊し方 | 結果 |
| --- | --- |
| `widget.js` に 9 kB 追記（+2.2%） | 「増えました」で exit 1 ✅ |
| `widget.js` を切り詰め（-3.1%） | 「減りました・**壊れて中身が落ちても減ります**」で exit 1、**gzip 側も同時に検出** ✅ |
| 復旧後 | 緑 ✅ |

## P4 で一番効く

`shared/` を admin と widget で共有した瞬間に tree-shaking が外れて admin コードが widget バンドルへ流れ込むが、**それをその PR で止められる**。R1 の緩和策として設計ノートに書いた「サイズ上限チェックを CI に入れる」がこれで実装済みになる。

## 検証

```
npm run build --prefix frontend          # 成功（サイズ検査込み）
npm run build:release --prefix frontend  # 成功（同上）
npm run check --prefix frontend          # green
cd tests/e2e && npx playwright test      # 103 passed (59.4s)
```

## セルフレビューチェックリスト

`docs/review/docs-policy.md` — ビルドゲートの追加とドキュメント。バックエンド・API・DB・OpenAPI・ミドルウェアに変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
