### PR TITLE
chore(deps): bump js-yaml to 4.3.1 to clear GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6424,9 +6424,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bump `js-yaml` 4.3.0 → 4.3.1 in `frontend/package-lock.json` (lockfile only, no `package.json` change) to clear advisory https://github.com/advisories/GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, quadratic CPU consumption in `!!omap` resolution, high severity).
- Dependency path (measured via `npm ls js-yaml`): `eslint@9.39.5` → `@eslint/eslintrc@3.3.6` → `js-yaml`. The lockfile node is `dev: true` (devDependency chain, not part of the prod bundle).
- Achieved via `npm update js-yaml --package-lock-only` alone — the parent's semver range already permits 4.3.1, no `overrides` needed.
- Part of fleet-wide js-yaml cleanup wave 2 (hub directive 2026-08-12; 6 other ships already cleared today).

## Test plan
- [x] `npm audit --package-lock-only --audit-level=high` — 0 vulnerabilities (previously reported GHSA-5p4m-2wfm-xmqj)
- [x] `npm run audit` (audit-ci) — passed, 0 vulnerabilities
- [x] `git diff --name-only` — only `frontend/package-lock.json` changed
- [x] `npm ls js-yaml` reconfirmed post-update: version 4.3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)