### PR TITLE
ci: 依存監査の検知器と notify-failure（論点1）＋ nanoid 3.3.18（論点2）＋ timeout-minutes（論点3）— #379

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -8,13 +8,32 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: 'Intentionally fail the job to verify the failure-notification path'
+        type: boolean
+        default: false
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    # 🔴 タイムアウトは検査ではなく損切り（板 L111）。値の正確さより「設定されていること」が効く。
+    # 既定は 360分（6時間）で、吊ったジョブがその間 PR をブロックし runner 時間を焼く。
+    # 発火実績: invoice / profile が `npx playwright install` の吊りで長時間ブロック（2026-08-19 深夜）。
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # 🔴 Checkout の「直後」に置く。literally first だと working tree が無くて落ち、
+      # 意図した exit 1 ではない別の失敗をリハーサルしてしまう。
+      # 🔴 逆に後ろへ置くのも駄目。前段のどれかが落ちると意図した exit 1 に到達せず、
+      # 「別の理由の赤」で notify が上がる＝陽性対照として何を確かめたのか分からなくなる。
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -59,3 +78,48 @@ jobs:
 
       - name: Run checks
         run: composer check
+
+  notify-failure:
+    name: Open an issue when an unattended run fails
+    # 🔴 通知する event ＝ **この workflow が「無人で走る」event を列挙する**（hub 裁定 2026-08-22・vault 発）。
+    # 参照実装（nene-serve/ci.yml）の条件を**文字列として**写さないこと。serve は schedule を持つので
+    # `schedule` だけで足りるが、schedule を持たない本艦へそのまま写すと
+    # **装置はあるのに原理的に赤にならない**ものが増える（＝きれいな inert）。
+    #   - `schedule`         … 常に無人。本艦は未導入（方式(c) の週次専用 workflow で入る）
+    #   - `push`             … main へのマージ後。マージした人が立ち去れば無人 ⇒ 含める
+    #   - `pull_request`     … 🔴 **含めない**。作者が見ているのでノイズになる
+    #   - `workflow_dispatch`… `simulate_failure` は陽性対照専用なので通す
+    if: >-
+      failure() && (github.event_name == 'push'
+      || inputs.simulate_failure)
+    needs: [check]
+    runs-on: ubuntu-latest
+    # gh の API 呼び出し2本だけなので短くてよい。ここが吊ると「赤が通知されない」に化ける。
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 nene-corpus: Backend CI（無人実行）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          # 🔴 --limit は 100 では足りない。open が 100 件を超えると同名を取りこぼして
+          #    重複起票へフォールバックする。壊れ方が悪い——壊れた側の挙動は「毎週新しい
+          #    issue が立つ」で一見すると装置が動いて見え、かつ発現条件（open 100 件超）は
+          #    「通知が読まれず溜まっている状態」そのもの。＝この仕掛けが守ろうとしている
+          #    ものを、最も必要なときに自分で壊す。
+          #    発見=nene-vault #379 / 起票=NENE2 #1656 / 参照実装の是正=nene-serve #218。
+          # 🔴 「直った」を確認するときは実値を抜いて数値で比較すること。
+          #    `grep -c -- '--limit 100'` は **`--limit 1000` に部分一致する**。
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="無人実行（${{ github.event_name }}）で CI が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -8,13 +8,32 @@ on:
     branches:
       - main
 
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: 'Intentionally fail the job to verify the failure-notification path'
+        type: boolean
+        default: false
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    # 🔴 タイムアウトは検査ではなく損切り（板 L111）。値の正確さより「設定されていること」が効く。
+    # 既定は 360分（6時間）で、吊ったジョブがその間 PR をブロックし runner 時間を焼く。
+    # 発火実績: invoice / profile が `npx playwright install` の吊りで長時間ブロック（2026-08-19 深夜）。
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # 🔴 Checkout の「直後」に置く。literally first だと working tree が無くて落ち、
+      # 意図した exit 1 ではない別の失敗をリハーサルしてしまう。
+      # 🔴 逆に後ろへ置くのも駄目。前段のどれかが落ちると意図した exit 1 に到達せず、
+      # 「別の理由の赤」で notify が上がる＝陽性対照として何を確かめたのか分からなくなる。
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -36,3 +55,59 @@ jobs:
       - name: Build
         working-directory: frontend
         run: npm run build
+
+      # 依存脆弱性ゲート（wave3）。設定・例外の作法は `frontend/audit-ci.jsonc` に書いてある。
+      # 🔴 **独立ステップにする**。他のコマンドへ畳み込むと、走ったかどうかがログから判別できない。
+      #    痕跡を残さない検査は、無い検査と区別がつかない。
+      # 🔴 `if: !cancelled()` — 既定の挙動（前段が赤なら skip）にしない。advisory は我々のコミット
+      #    ではなく向こう側の時計で公開されるので、コードの赤とは独立にこの信号を出したい。
+      #    `always()` ではなく `!cancelled()` を使う（cancel された run の無意味な赤を出さないため）。
+      - name: Audit (fail on high/critical)
+        if: ${{ !cancelled() }}
+        working-directory: frontend
+        run: npm run audit
+
+  notify-failure:
+    name: Open an issue when an unattended run fails
+    # 🔴 通知する event ＝ **この workflow が「無人で走る」event を列挙する**（hub 裁定 2026-08-22・vault 発）。
+    # 参照実装（nene-serve/ci.yml）の条件を**文字列として**写さないこと。serve は schedule を持つので
+    # `schedule` だけで足りるが、schedule を持たない本艦へそのまま写すと
+    # **装置はあるのに原理的に赤にならない**ものが増える（＝きれいな inert）。
+    #   - `schedule`         … 常に無人。本艦は未導入（方式(c) の週次専用 workflow で入る）
+    #   - `push`             … main へのマージ後。マージした人が立ち去れば無人 ⇒ 含める
+    #   - `pull_request`     … 🔴 **含めない**。作者が見ているのでノイズになる
+    #   - `workflow_dispatch`… `simulate_failure` は陽性対照専用なので通す
+    if: >-
+      failure() && (github.event_name == 'push'
+      || inputs.simulate_failure)
+    needs: [check]
+    runs-on: ubuntu-latest
+    # gh の API 呼び出し2本だけなので短くてよい。ここが吊ると「赤が通知されない」に化ける。
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 nene-corpus: Frontend CI（無人実行）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          # 🔴 --limit は 100 では足りない。open が 100 件を超えると同名を取りこぼして
+          #    重複起票へフォールバックする。壊れ方が悪い——壊れた側の挙動は「毎週新しい
+          #    issue が立つ」で一見すると装置が動いて見え、かつ発現条件（open 100 件超）は
+          #    「通知が読まれず溜まっている状態」そのもの。＝この仕掛けが守ろうとしている
+          #    ものを、最も必要なときに自分で壊す。
+          #    発見=nene-vault #379 / 起票=NENE2 #1656 / 参照実装の是正=nene-serve #218。
+          # 🔴 「直った」を確認するときは実値を抜いて数値で比較すること。
+          #    `grep -c -- '--limit 100'` は **`--limit 1000` に部分一致する**。
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="無人実行（${{ github.event_name }}）で CI が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   release-zip:
     runs-on: ubuntu-latest
+    # 🔴 タイムアウトは検査ではなく損切り（板 L111）。値の正確さより「設定されていること」が効く。
+    # 既定は 360分（6時間）で、吊ったジョブがその間 PR をブロックし runner 時間を焼く。
+    # 発火実績: invoice / profile が `npx playwright install` の吊りで長時間ブロック（2026-08-19 深夜）。
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7086,9 +7086,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes #379

フリート横断「週次再検査 第3波」の本艦ぶん。参照実装 = `nene-serve/.github/workflows/ci.yml`（`origin/main` = `a6e1d53`）から**意図を**写した（文字列ではなく）。

🔴 **3論点。DoD は論点ごとに分けて検収する**（hub 裁定 2026-08-22 で混載可。ただし**混ぜてよいのは実装であって検収ではない**）。

---

## 論点1: 依存監査の検知器と通知経路（wave3）

| workflow | 前 | 後 |
|---|---|---|
| `frontend-ci.yml` | npm 監査 **無し** | ✅ `Audit (fail on high/critical)` を**独立ステップ**で追加 |
| `backend-ci.yml` | notify 無し | ✅ `notify-failure` 追加（composer audit は元からあり） |
| `frontend-ci.yml` | notify 無し | ✅ `notify-failure` 追加 |

🔑 **npm 監査の道具は既に揃っていた。CI に繋がっていなかっただけ。**
`frontend/audit-ci.jsonc`（allowlist 空）・`audit-ci ^7.1.0`・`scripts.audit` はすべて実在。**新しい依存は増やしていない。**

**独立ステップにした理由**: 他のコマンドへ畳み込むと、走ったかどうかがログから判別できない。**痕跡を残さない検査は、無い検査と区別がつかない。**

### 🔴 週次 schedule は**入れていない**

本艦は `backend-ci.yml` / `frontend-ci.yml` の2本立てで、**composer audit は backend 側**。
ここに schedule を足すことは、フリートで審議中だった「PHP 監査を週次で再走させる方式」の**選択肢(a) を先取りして確定させる**行為になる。
方式は施主決定で **(c)＝週次専用 `weekly-audit.yml` を1本新設**に決着したため、**週次はその波で入る**。

### 🔴 通知する event は「無人で走る event」を列挙した（hub 裁定・vault 発）

| event | 無人か | 本 PR |
|---|---|---|
| `schedule` | 常に無人 | 本艦は未導入（方式(c) の波で） |
| `push`（main へのマージ後） | **マージした人が立ち去れば無人** | ✅ 含める |
| `pull_request` | 作者が見ている | ❌ 含めない（ノイズ） |
| `workflow_dispatch` の `simulate_failure` | 陽性対照専用 | ✅ 含める |

⇒ 条件は `failure() && (push || simulate_failure)`。ジョブ名も Issue 題も「**無人実行**」に合わせた。

**参照実装の `schedule` をそのまま写さなかったのが要点。** 写していたら、schedule を持たない本艦では
**装置はあるのに原理的に赤にならない**ものが1つ増えていた（＝きれいな inert）。**この判断を理由ごとコメントに常駐させてある**ので、次に写す人が再演できる。

---

## 🔴 論点2: `nanoid` 3.3.17 → 3.3.18 — **ゲートを緑で入れるための前提**

**配線前に実走したところ high が1件あった**（`GHSA-2v37-7h3g-55p8`・nanoid < 3.3.18）。

そのまま足すと「**ゲートを入れた瞬間に既存 advisory で赤くなる**」順序事故になる。
allowlist で逃がすと、フリートの**逃げ道ゼロ（0件 / 分母15）を自艦で崩す**。⇒ **倒してから入れた。**

### 判例44 の手順で実測（全数開示）

| # | 項目 | 実測 |
|---|---|---|
| ① | `packages` 件数 | **624 → 624**（不変） |
| ② | 版が動いたパッケージと向き | **`node_modules/nanoid` 3.3.17 → 3.3.18 の1件のみ**（昇格） |
| ③ | workspaces / 複数 lockfile | lockfile は `frontend/` と `tests/e2e/` の**2本**。**触ったのは frontend のみ** |
| ④ | 監査 | **high 1件 → 0件** |

- 🔴 **`npm audit fix` ではなく `npm update nanoid --package-lock-only` で狙い撃ち**（判例44 ⑧。`audit fix` は降格が混ざるので「版の向きの全数開示」に使わない）
- **`package.json` は触っていない**（lock only）

---

## 論点3: `timeout-minutes`（板 L111）

| workflow / job | 値 |
|---|---|
| `backend-ci.yml` / `check` | 10分 |
| `backend-ci.yml` / `notify-failure` | **5分** |
| `frontend-ci.yml` / `check` | 10分 |
| `frontend-ci.yml` / `notify-failure` | **5分** |
| `release-build.yml` / `release-zip` | 10分 |

既定は **360分（6時間）**。吊ったジョブがその間 PR をブロックし runner 時間を焼く。
発火実績 = invoice / profile が `npx playwright install` の吊りで長時間ブロック（2026-08-19 深夜）。
🔴 **タイムアウトは検査ではなく損切りなので、値の正確さより「設定されていること」が効く**（hub）。
notify を他より短くしたのは、**ここが吊ると「赤が通知されない」に化ける**ため（計器そのものが黙る場所）。

---

## 射程外として実測したもの（🔴 未計測と 0 を混ぜない）

`tests/e2e/package-lock.json` は **どの workflow からも呼ばれていない**（`grep -rl 'tests/e2e' .github/workflows/` が **0件**。CLAUDE.md の記述と一致）。
監査は**実走して 0件**。**本 PR では触っていない。**

---

## DoD

**論点1**
- [x] npm 監査が独立ステップとして存在する
- [ ] `notify-failure` が**発火する**（`simulate_failure` で観測）
- [ ] Issue が**新規作成**され、2回目は**コメント追記**（dedup）
- [ ] **`pull_request` では発火しない**（🔴 構造から自明でも「観測した」と書かない。**陰性対照を実測する**）

**論点2**
- [x] 判例44 の①〜④を全数開示（上表）
- [x] 監査が **0件**

**論点3**
- [x] 全 workflow の全ジョブに `timeout-minutes`（`yaml.safe_load` で確認）

## 🔴 観測できていないこと

| 経路 | 状態 |
|---|---|
| `push`（マージ後）での発火 | **未観測** — main へマージしないと取れない |
| `schedule` | 本艦は未導入 |

**「設定した」であって「発火した」ではない。**

## 既知の限界（参照実装のコメントごと写した・消さない）

GitHub は**リポジトリが60日間非アクティブだと scheduled workflow を自動で無効化する**。
休眠リポ＝この検知器が最も要るリポで静かに止まる。リポ内では直せないので fleet レベルの外部ポーラーが要る。

---
🔴 **マージは施主承認後**（配布レーンの規約）。
発信: nene2-fleet-tooling リナ（フリート配布レーン）
