### PR TITLE
refactor(search): ChunkSearchResult の score を int から float に広げる (#384)

### DIFF
--- a/src/Search/ChunkSearchResult.php
+++ b/src/Search/ChunkSearchResult.php
@@ -10,7 +10,7 @@ final readonly class ChunkSearchResult
 {
     public function __construct(
         public Chunk $chunk,
-        public int $score,
+        public float $score,
     ) {
     }
 }

--- a/src/Search/PdoChunkSearchRepository.php
+++ b/src/Search/PdoChunkSearchRepository.php
@@ -80,7 +80,7 @@ final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryIn
         return array_map(
             fn (array $row): ChunkSearchResult => new ChunkSearchResult(
                 chunk: $this->mapRow($row),
-                score: (int) $row['relevance_score'],
+                score: (float) $row['relevance_score'],
             ),
             $rows,
         );

--- a/tests/Search/PdoChunkSearchRepositoryTest.php
+++ b/tests/Search/PdoChunkSearchRepositoryTest.php
@@ -89,7 +89,7 @@ final class PdoChunkSearchRepositoryTest extends TestCase
 
         self::assertCount(1, $results);
         self::assertSame('Equipment safety instructions for operators.', $results[0]->chunk->content);
-        self::assertSame(1, $results[0]->score);
+        self::assertSame(1.0, $results[0]->score);
     }
 
     public function test_search_ranks_chunks_by_matching_term_count(): void
@@ -111,9 +111,9 @@ final class PdoChunkSearchRepositoryTest extends TestCase
 
         self::assertCount(2, $results);
         self::assertSame('Equipment safety instructions for operators.', $results[0]->chunk->content);
-        self::assertSame(2, $results[0]->score);
+        self::assertSame(2.0, $results[0]->score);
         self::assertSame('Safety overview for operators.', $results[1]->chunk->content);
-        self::assertSame(1, $results[1]->score);
+        self::assertSame(1.0, $results[1]->score);
     }
 
     public function test_search_excludes_soft_deleted_source(): void

--- a/tests/Search/SearchChunksUseCaseTest.php
+++ b/tests/Search/SearchChunksUseCaseTest.php
@@ -35,7 +35,7 @@ final class SearchChunksUseCaseTest extends TestCase
         $search->expects(self::once())
             ->method('search')
             ->with('safety', 50)
-            ->willReturn([new ChunkSearchResult(chunk: $chunk, score: 1)]);
+            ->willReturn([new ChunkSearchResult(chunk: $chunk, score: 1.0)]);
 
         $results = (new SearchChunksUseCase($search))->execute(new SearchChunksInput(query: 'safety', limit: 999));
 


### PR DESCRIPTION
Closes #384

## 要旨

**`ChunkSearchResult::$score` を `int` → `float` に広げる。値は変わらない。**
`nene-recall` **ADR 0006 の先行依頼**（指示書 = `_work/handoff-corpus-2026-09-01-score-float-work-order.md`・board L132・due 2026-09-12）。

## 値が変わらないことの根拠

`PdoChunkSearchRepository` が返すのは `CASE WHEN … THEN 1 ELSE 0 END` の**合計＝整数値そのもの**。`float` に広げても `1` が `1.0` になるだけで、**振る舞いの変化はゼロ**。「無風で通せる窓が今」というのが本便の前提です。

## なぜ差し替えの前に単独でやるか

`nene-recall`（Go 製ハイブリッド検索）を検索バックエンドへ差し替える構想が Phase 2 にあり、**ベクトル類似度は float** なので差し替え時点で `int` が必ず障壁になります。

🔑 **差し替えと同時にやると、型変更とバックエンド交換が同じ PR に乗る。** 検索結果が変わったとき「型のせいか、バックエンドのせいか」の切り分けができなくなります。

## 変更（6箇所・実測した全数）

| ファイル:行 | 変更 |
|---|---|
| `src/Search/ChunkSearchResult.php:13` | `public int $score` → `public float $score` |
| `src/Search/PdoChunkSearchRepository.php:83` | `(int)` → `(float)` |
| `tests/Search/PdoChunkSearchRepositoryTest.php:92/114/116` | `assertSame(1/2/1, …)` → `1.0/2.0/1.0` |
| `tests/Search/SearchChunksUseCaseTest.php:38` | `score: 1` → `score: 1.0` |

残る5行（`PdoChunkSearchRepository.php:46,54,66,70,75`）は `$scoreParts` / `relevance_score` の**列名と SQL 組み立て**で型に触りません。`assertCount` の `1` / `2` は**件数であって score ではない**ので触っていません。

## `assertSame` のまま直しました（`assertEquals` へ逃げていない）

`assertSame` は `===` 比較なので **`1.0 === 1` は `false`**。float 化で3件落ちるのは想定内であり、**型が実際に広がった証拠**でもあります。緩い比較へ逃げると、次に float が壊れても気づけません。

🔑 裏を返すと、**更新後のテストが `1.0` で通ること自体が、型が広がったことの証拠**になっています。

## 外部契約は変わりません（実測）

`score` が HTTP 応答の JSON に出る経路は **0件**（`frontend/src` と `docs/openapi` への grep がいずれも 0 ヒット）。⇒ **OpenAPI の変更は不要・API の破壊的変更ではない。**

## 触っていないもの

- **検索ロジック（`LIKE '%term%'` の部分一致スコア）には一切触っていません。** 筋の悪い実装なのは承知の上ですが、それを置き換えるのが Recall の仕事で、**本便のスコープは型だけ**。ここを一緒に直すと「値が変わらない」という本便の最大の利点が消えます。
- `SearchChunksUseCase` / `ChunkSearchRepositoryInterface` の**シグネチャも変えていません**（Phase 2 の差し替えはこの2つを無傷で行える設計）。

## 品質ゲート

`composer check` **全通過**（2026-09-01 実測）:

- PHPUnit **425 tests / 1,377 assertions・OK**
- PHPStan **level8 — No errors**（506 ファイル）
- PHP CS Fixer — 修正対象なし
- OpenAPI contract valid / MCP tool catalog valid / Conformance OK（0 suppressed）

## セルフレビューチェックリスト

- `docs/review/backend-api.md`（UseCase 層の DTO 変更）
- `docs/review/database.md`（`Pdo*Repository` の cast 変更）

`docs/review/openapi-contract.md` は**適用外**（上記のとおり OpenAPI に `score` は存在せず、変更もありません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnVt3Qps6q5SLjwnevm917
