### PR TITLE
ci(frontend): Audit ステップに install 成功を条件として足す (#386)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -42,7 +42,9 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
+      # id は下の Audit ステップの `if:` から outcome を参照するために要る。
       - name: Install dependencies
+        id: install
         working-directory: frontend
         run: npm ci
 
@@ -62,8 +64,16 @@ jobs:
       # 🔴 `if: !cancelled()` — 既定の挙動（前段が赤なら skip）にしない。advisory は我々のコミット
       #    ではなく向こう側の時計で公開されるので、コードの赤とは独立にこの信号を出したい。
       #    `always()` ではなく `!cancelled()` を使う（cancel された run の無意味な赤を出さないため）。
+      # 🔴 `steps.install.outcome == 'success'` を **併せて** 要求する（#386）。`!cancelled()` だけだと、
+      #    前段が落ちて `npm ci` が skip された木でもこのステップが走り、`audit-ci: not found` で
+      #    **2つ目の赤**を出す。実害が出るのは `simulate_failure` の陽性対照で、
+      #    「意図した exit 1」以外の赤が混ざって**何を確かめたのか分からなくなる**
+      #    ——L30-33 が Simulate の位置で避けたはずの形を、ここで作り直していた。
+      #    ⚠️ 逆に「Simulate を npm ci の後ろへ移す」で直してはいけない（L32-33 が却下済み）。
+      #    install が成功して check / build が落ちた**通常の赤では Audit は走る**ので、
+      #    上の「コードの赤とは独立に信号を出す」意図はこの条件でも損なわれない。
       - name: Audit (fail on high/critical)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         working-directory: frontend
         run: npm run audit
 


### PR DESCRIPTION
Closes #386

## 要旨

**陽性対照リハーサルが意図しない2つ目の赤を出していた。** `Audit` ステップに `steps.install.outcome == 'success'` を足して直す。

## 何が起きていたか（実測・run `32577120628`）

`simulate_failure=true` の dispatch で、job `check` の失敗ステップが **2つ**あった:

1. `Simulate failure (rehearsal only)` ← **意図した赤**
2. `Audit (fail on high/critical)` ← **意図しない赤**

2 の原因はログに明示されている:

```
sh: 1: audit-ci: not found
```

⇒ **advisory ではない。** devDependency のバイナリが入っていないだけ。

## 構造

`Simulate failure`(L34) が `npm ci`(L45) より**前**にあり、中間ステップは既定の `success()` で skip される。しかし `Audit` は `if: ${{ !cancelled() }}` なので **node_modules が無い木で走ってしまう**。

`backend-ci.yml` の `composer audit` は `if:` を持たない（既定 `success()`）ため skip され、**backend では起きない**。この非対称が frontend だけで出る理由。

## なぜ直すか

`frontend-ci.yml` の **L30-33 のコメント自身**が、`Simulate` の位置を決めた理由をこう書いている:

> 🔴 Checkout の「直後」に置く。literally first だと working tree が無くて落ち、**意図した exit 1 ではない別の失敗をリハーサルしてしまう**。

🔑 **`Audit` の `!cancelled()` が、その避けたかった形を1ステップ後ろで作り直していた。** 陽性対照は「何を確かめたのか」が一目で分かることに価値があるので、赤が2つ出ると装置の検証ログとして読めない。

## 直し方（hub 裁定 2026-09-01）

**却下案**: 「`Simulate` を `npm ci` の後ろへ移す」——L32-33 が「後ろへ置くと前段のどれかが落ちて意図した exit 1 に到達しない」と**明示的に却下した形**。却下済みの案に戻すのは判断の後退なので採らない。

**採用案**: `Audit` 側に条件を足す。

```yaml
      - name: Install dependencies
        id: install                       # ← 追加
        working-directory: frontend
        run: npm ci

      - name: Audit (fail on high/critical)
        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
```

`!cancelled()` の**本来の意図は完全に保たれる**（advisory は向こう側の時計で公開されるので、コードの赤とは独立に信号を出したい）。install が成功して check / build が落ちた**通常の赤では Audit は走り**、install に到達しなかった run でだけ skip される。

条件の理由は**コメントとして常駐させた**。理由が消えると次の人が `!cancelled()` だけに戻すので、**却下済みの案も含めて**書いてある。

## ⚠️ 射程（誇張しないための明記）

**本番の赤では無害だった。** 実際のコード failure は `npm ci` の**後**に起きるので、`Audit` は node_modules がある状態で走り意味のある信号を出していた。
⇒ **壊れていたのは陽性対照の可読性だけで、カバレッジでもセキュリティの穴でもない。**

## フリート波及

`frontend-ci.yml` に `!cancelled()` を持つのは **corpus と nene-profile の2艦のみ**（hub の全艦 grep・corpus レーンでも `git -C … show origin/main:` で独立確認）。profile は `Simulate`=L57 が `npm ci`=L69 より前・`cancelled`=L106 で**同型**。
**profile へは hub から別便。本 PR は corpus 分のみ。**

## 検証

- [x] YAML パース＋ステップ構造を確認（`id=install` が付き、`Audit` の `if:` が意図どおり・`notify-failure` の `if:` は無変更）
- [x] **この PR 実行で `Audit` が skip に化けていないこと**をログで確認 ← この修正で最も危険な壊れ方なので必須
- [ ] **マージ後に陽性対照を取り直す**: `simulate_failure=true` で dispatch し、失敗ステップが `Simulate failure` の**1つだけ**になること・notify-failure が発火することを実測（#386 の受入条件）

## セルフレビューチェックリスト

`docs/review/middleware-security.md`（CI ゲートの発火条件変更）。アプリコードの変更はないため backend-api / database / openapi-contract は適用外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnVt3Qps6q5SLjwnevm917
