### PR TITLE
docs(claude-md): 腐った「最近の主なマージ」表を畳み Phase 5 の過小表示を直す (#383)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,15 +34,16 @@ Ops / MCP         ────────────────────�
 | Phase 3 Admin UI・Widget・Tier A | ✅ 完了 |
 | **Phase 3+ オペレーター UX 改善** | ✅ 完了 |
 | **Phase 4 マルチテナント** | ✅ 完了 |
-| **Phase 5 外部連携（NeNe Records）** | 🔲 バックログ（Issue 化してから着手） |
+| **Phase 5 外部連携（NeNe Records）** | 🔄 進行中 — **P1 読み取りクライアントは完了**（#313 / PR #315・2026-05-30）。残りは #314 ほか |
 
-**最近の主なマージ:**
+**最近のマージ履歴はここに置かない。** 正本は private `nene-origin/internal-docs/corpus/todo/current.md`。
 
-| PR | Issue | 内容 |
-| --- | --- | --- |
-| #300 | — | v2 リデザイン全7画面 + 欠損機能8件 + レスポンシブ + ソース編集 API（PUT /admin/sources/{id} + note 列） |
-| #288 | #274–#280 | マルチテナント一式を main へ統合（organizations + system_config + 3-mode resolver + superadmin UI） |
-| #280 | #280 | マルチテナント Phase D（OpenAPI + ADR 0005 + docs + E2E spec） |
+> 🔴 **かつてここに「最近の主なマージ」表があったが、削除した（#383・2026-09-01）。**
+> 最新が **PR #300 / #288 / #280 のまま約3ヶ月更新されず**、その間に main へ載った #354〜#387 が
+> 1件も反映されていなかった。**private ミラーと同じ情報を2箇所で持つ限り、必ず一方が腐る**——
+> しかも腐るのは「入口だと自称している側」なので被害が大きい。
+> **再追加しないこと。** マージ履歴が要るなら `git log` と GitHub の PR 一覧が一次情報で、
+> 文脈つきの要約は private ミラーが持つ。
 
 ---
 
@@ -52,7 +53,7 @@ Ops / MCP         ────────────────────�
 
 | 優先 | 項目 | 概要 |
 | --- | --- | --- |
-| P1 | NeNe Records 読み取りクライアント | `src/Upstream/` に `NeneRecordsClientInterface` + `HttpNeneRecordsClient` 実装 |
+| ✅ 完了 | NeNe Records 読み取りクライアント | **実装済み**（#313 / PR #315・2026-05-30）。`src/Upstream/` に `NeneRecordsClientInterface` / `HttpNeneRecordsClient` / `NullNeneRecordsClient` / `NeneRecordsConfig` / `NeneRecordsEntity` / `UpstreamServiceProvider` が実在する。🔴 **これから作るものとして読まないこと**（二重実装の罠） |
 | P1 | Admin 設定 UI | `NENE_RECORDS_API_BASE_URL` / `NENE_RECORDS_BEARER_TOKEN` を `.env` 経由で設定 |
 | P2 | ローカル corpus + upstream 統合検索 | `search_corpus` ツール拡張：ローカル chunks + NeNe Records API 結果をマージ |
 | P3 | Webhook / ポーリング再インデックス | NeNe Records 更新時にローカル chunks を自動更新 |


### PR DESCRIPTION
Closes #383

## 要旨

`CLAUDE.md` は「**判断に迷ったらここに戻る**」と自称する入口文書だが、状態記述が2箇所とも実態から外れていた。しかも**向きが逆の2種類**が同時に出ていた。

## 1. 新しい成果が書かれていない（表が約3ヶ月停止）

「最近の主なマージ」表の最新が **PR #300 / #288 / #280** のままで、その間に `main` へ載った **#354〜#387 が1件も反映されていなかった**。

⇒ **表ごと削除し、正本（private ミラー）へのポインタに置き換えた。**

🔑 **private ミラーと同じ情報を2箇所で持つ限り、必ず一方が腐る**——しかも腐るのは「**入口だと自称している側**」なので被害が大きい。マージ履歴が要るなら `git log` と GitHub の PR 一覧が一次情報で、文脈つきの要約は private ミラーが持つ。**再追加を防ぐため、削除の理由を注記として残した。**

## 2. 実装済みのものを「これから作る」と書いていた（Phase 5 の過小表示）

| 記述 | 実測 |
| --- | --- |
| フェーズ表「Phase 5 : 🔲 **バックログ**（Issue 化してから着手）」 | **P1 は完了済み** |
| Phase 5 バックログ表「P1 \| 読み取りクライアント \| `src/Upstream/` に `NeneRecordsClientInterface` + `HttpNeneRecordsClient` 実装」＝これから作るものとして記載 | **6ファイルが実在**: `NeneRecordsClientInterface` / `HttpNeneRecordsClient` / `NullNeneRecordsClient` / `NeneRecordsConfig` / `NeneRecordsEntity` / `UpstreamServiceProvider` |
| — | **#313 CLOSED / PR #315 MERGED（2026-05-30）** ＝ 3ヶ月前に着地 |

🔴 **危険なのは、バックログ表が実装先のパス・インタフェース名・クラス名まで指定しており、それがそのまま実在すること。** 指示どおり作ろうとして初めて衝突に気づく形＝**二重実装の罠**だった。

⇒ 完了として書き直し、**「これから作るものとして読まないこと」**を明記した。

## README との食い違いも解消

`README.md:91` は「Phase 5 — upstream integrations | 🔄 In progress」で、**この件では README のほうが実態に近かった**。CLAUDE.md を直したことで両者が一致したので、**README は変更していない**（誤っていた側だけを直す）。

## 原因は1と2で共通

状態記述が更新されていないこと。`_work/advice.md` 2026-08-22 の「**腐るのは状態を名詞で書いた行**（〜待ち・未着手・バックログ）」がそのまま当たっている。

## 対になる作業

private ミラー側 = **nene-origin#782 / PR #783**（`current.md` が 2026-08-05 で停止・27日遅れ）。本 PR は**公開側のみ**。

`CHANGELOG.md` が実在しない件は #383 に記録済みで、新設要否は別判断（本 PR では触っていない）。

## 品質ゲート

`composer check` **全通過**（2026-09-01 実測）: PHPUnit 425/425・PHPStan level8 No errors・CS-Fixer・OpenAPI valid・MCP valid・Conformance OK。

## セルフレビューチェックリスト

`docs/review/docs-policy.md`（ドキュメント変更）。コード変更なしのため他は適用外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnVt3Qps6q5SLjwnevm917
