### PR TITLE
docs: 実在しない CHANGELOG を「公開 docs の正本」と書いていたのを直す (#390)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the entry point for AI agents working on NeNe Corpus.
 
 ## Read First
 
-- **Current work & status:** private `nene-origin/internal-docs/corpus/todo/current.md` (operational logs moved to the private mirror — P3, 2026-07-18; public docs stay Diátaxis + ADR/CHANGELOG only)
+- **Current work & status:** private `nene-origin/internal-docs/corpus/todo/current.md` (operational logs moved to the private mirror — P3, 2026-07-18; public docs stay Diátaxis + ADR only — there is no `CHANGELOG.md` in this repo; see #390)
 - **Product vision:** `docs/explanation/product-vision.md`
 - **Glossary:** `docs/explanation/glossary.md`
 - **Naming conventions:** `docs/development/naming-conventions.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Ops / MCP         ────────────────────�
 
 ## 現在の開発状況
 
-> **運用ログ（`docs/todo`・`docs/daily`・field-trials 相当）は private `nene-origin/internal-docs/corpus/` に移設済み**（P3・2026-07-18）。最新の作業状況・申し送り・引き継ぎはそちらを読むこと。公開リポの docs は Diátaxis（tutorial/howto/reference/explanation）＋ADR/CHANGELOG のみを正とする。
+> **運用ログ（`docs/todo`・`docs/daily`・field-trials 相当）は private `nene-origin/internal-docs/corpus/` に移設済み**（P3・2026-07-18）。最新の作業状況・申し送り・引き継ぎはそちらを読むこと。公開リポの docs は Diátaxis（tutorial/howto/reference/explanation）＋ADR のみを正とする（**CHANGELOG.md はこのリポに存在しない**。フリートでも保有は42リポ中10でタグ数と無相関＝型が決まっていないため、要否は板 `(C) 2026-09-01 … due:2026-09-19` で判断する。#390）。
 > 最新の作業レーンと未処理タスクは private `nene-origin/internal-docs/corpus/todo/current.md` を先に読むこと。
 
 | フェーズ | 状態 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Ops / MCP         ────────────────────�
 
 ## 現在の開発状況
 
-> **運用ログ（`docs/todo`・`docs/daily`・field-trials 相当）は private `nene-origin/internal-docs/corpus/` に移設済み**（P3・2026-07-18）。最新の作業状況・申し送り・引き継ぎはそちらを読むこと。公開リポの docs は Diátaxis（tutorial/howto/reference/explanation）＋ADR のみを正とする（**CHANGELOG.md はこのリポに存在しない**。フリートでも保有は42リポ中10でタグ数と無相関＝型が決まっていないため、要否は板 `(C) 2026-09-01 … due:2026-09-19` で判断する。#390）。
+> **運用ログ（`docs/todo`・`docs/daily`・field-trials 相当）は private `nene-origin/internal-docs/corpus/` に移設済み**（P3・2026-07-18）。最新の作業状況・申し送り・引き継ぎはそちらを読むこと。公開リポの docs は Diátaxis（tutorial/howto/reference/explanation）＋ADR のみを正とする（**CHANGELOG.md はこのリポに存在しない**。フリートでも保有は42リポ中10でタグ数と無相関＝型が決まっていないため、要否は板の **`id:131`**（due 2026-09-19）で判断する。#390）。
 > 最新の作業レーンと未処理タスクは private `nene-origin/internal-docs/corpus/todo/current.md` を先に読むこと。
 
 | フェーズ | 状態 |


### PR DESCRIPTION
Closes #390

## 何が誤りだったか

`CLAUDE.md:26` と `AGENTS.md:7` が、公開 docs の正本を「Diátaxis ＋ **ADR/CHANGELOG**」と書いていた。**`CHANGELOG.md` はこのリポに実在しない**（実測 2026-09-01: `ls CHANGELOG.md` → No such file or directory）。

## なぜ直すか

🔴 **実在しないものを「正本」と書くと、次の人が探しに行く。**

#383 が直したのと**同じ種類**の齟齬。あちらは「実装済みを未実装と書く」、こちらは「**無いものを在ると書く**」——向きは逆だが、どちらも読んだ人の時間を燃やす。

⚠️ **これは「CHANGELOG を作るべきか」とは別の問題。** 作る／作らないの結論がどちらでも、**現時点の記述が事実と違う**ことは変わらない。⇒ 方針の裁定を待たずに文言だけ先行して直せる。

## 2箇所とも直した

日本語（`CLAUDE.md`）と英語（`AGENTS.md`）の両方に同じ主張があった。**片方だけ直すと次に読んだ人が食い違いを調べ直す**ので同便で揃えた。

## CHANGELOG は新設しない（hub 裁定・2026-09-01）

フリート42リポの実測で保有は **10**、しかも**タグ数と無相関**:

| リポ | タグ数 | CHANGELOG |
| --- | ---: | --- |
| nene-vault | 26 | 無し |
| nene-contact | 0 | **有り** |
| nene-corpus | 9 | 無し |
| nene-clear | 6 | **有り** |
| nene-records | 5 | **有り** |

⇒ 「配布物だから持つ」という規則は**成り立っていない**。現状は方針ではなく各艦の歴史的経緯。

🔑 **型が決まっていないものを1艦だけで新設すると、その艦だけ更新契機を持たない文書を抱える。** #389 で「2箇所で同じ情報を持てば必ず一方が腐る」を根拠に表を畳んだ直後に、更新契機のない CHANGELOG を新設するのは**同じ轍**。

⇒ フリート全体の要否は板 `(C) 2026-09-01 … due:2026-09-19` に預けた。**その旨を本文に1行残した**ので、次の人が「なぜ CHANGELOG が無いのか」を再調査しなくて済む。

## 品質ゲート

`composer check` 全通過（PHPUnit 425/425・PHPStan level8 No errors・CS-Fixer・OpenAPI valid・MCP valid・Conformance OK）。

## セルフレビューチェックリスト

`docs/review/docs-policy.md`。コード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnVt3Qps6q5SLjwnevm917
