### PR TITLE
feat(search): 検索バックエンドを NeNe Recall に差し替え可能にする (#392)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,23 @@ NOTIFY_DAILY_REPORT_TOKEN=
 NENE_RECORDS_API_BASE_URL=
 NENE_RECORDS_BEARER_TOKEN=
 
+# --- Optional search backend (NeNe Recall) — ADR 0007 ---
+# Leave NENE_RECALL_BASE_URL empty to keep the built-in LIKE search. When it is
+# set, chunk search goes through NeNe Recall and ingestion mirrors chunks to it.
+NENE_RECALL_BASE_URL=
+# Shared token. Must match RECALL_API_TOKEN on the Recall side; leave empty when
+# Recall runs without authentication. Never commit a real token.
+NENE_RECALL_BEARER_TOKEN=
+# Request timeout in seconds (default 10). Applies to search and to the writes
+# ingestion makes.
+NENE_RECALL_TIMEOUT_SECONDS=10
+# Weight between the two halves of Recall's score, 0.0-1.0. Empty = let Recall
+# use its own default. Values outside the range are ignored.
+NENE_RECALL_SEARCH_ALPHA=
+# 1 = a search failure raises an error instead of falling back to LIKE search.
+# Default 0: fall back, and log a warning.
+NENE_RECALL_STRICT=0
+
 # --- Database (host / PHPUnit default: SQLite) ---
 DATABASE_URL=
 DB_ENV=local

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -7,13 +7,16 @@ use PhpCsFixer\Finder;
 
 $finder = Finder::create()
     ->in([
+        __DIR__ . '/bin',
         __DIR__ . '/public_html',
         __DIR__ . '/src',
         __DIR__ . '/tests',
         __DIR__ . '/tools',
         __DIR__ . '/database',
     ])
-    ->name('*.php');
+    // bin/console is an executable without a .php suffix; it is still PHP and
+    // still has to pass the same style gate.
+    ->name(['*.php', 'console']);
 
 return (new Config())
     ->setRiskyAllowed(true)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,12 @@ Handler → UseCase → RepositoryInterface → PdoRepository
 | Handler | HTTP パース・DTO 構築・UseCase 呼び出し・JSON レスポンス | SQL・ビジネスロジック・LLM 直呼び出し |
 | UseCase | ビジネスロジック・オーケストレーション | `$_SERVER`・PDO・生 HTTP クライアント |
 | Repository | SQL / 永続化のみ | HTTP・セッションロジック |
+| 上流クライアント (`Upstream/` `Recall/`) | 外部 API の HTTP 呼び出し | SQL・ドメインロジック |
 | Llm アダプター (`Llm/`) | Claude API 呼び出し | ドメイン不変条件 |
+
+**Repository は上流クライアント interface を呼んでよい（ADR 0007）。** 禁止しているのは Repository が
+HTTP を直に叩くことであって、上流クライアント（`Upstream/` `Recall/`）に委譲することではない。
+実例は `RecallChunkSearchRepository`（SQL を1行も持たず、上流クライアントと `PdoChunkSearchGuard` を合成する）。
 
 **全 PHP ファイルに `declare(strict_types=1);`。クラスは `final readonly` 推奨。**
 
@@ -115,7 +120,8 @@ src/
   Chat/           # sync JSON chat（SendChatMessageUseCase）
   Session/        # チャットセッション管理
   Message/        # チャットメッセージ管理
-  Search/         # 全文検索（LIKE + スコアリング）
+  Search/         # 全文検索（LIKE + スコアリング。設定時は Recall へ委譲 — ADR 0007）
+  Recall/         # 任意の検索バックエンド NeNe Recall の上流クライアント（ADR 0007）
   Llm/            # Claude API オーケストレーション（tool_use、最大 3 ラウンド）
   RateLimit/      # レートリミット（セッション / IP）
   Appearance/     # ウィジェット外観設定

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,44 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Operator command line for NeNe Corpus.
+ *
+ * Deliberately thin: it boots the same container the HTTP front controller uses
+ * and hands argv to a command object in src/, so the behaviour is covered by
+ * `composer check` (this file is a wiring shim, not logic).
+ *
+ * Commands:
+ *   recall:reindex [--org=<id>]   Rebuild the NeNe Recall index (ADR 0007)
+ */
+
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Recall\RecallReindexCommand;
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$arguments = array_slice($argv, 1);
+$command = array_shift($arguments);
+
+$out = static function (string $line): void {
+    fwrite(STDOUT, $line . PHP_EOL);
+};
+
+if ($command !== RecallReindexCommand::NAME) {
+    fwrite(STDERR, 'Available commands:' . PHP_EOL);
+    fwrite(STDERR, '  ' . RecallReindexCommand::USAGE . PHP_EOL);
+
+    exit(1);
+}
+
+$container = (new RuntimeContainerFactory(dirname(__DIR__)))->create();
+$reindex = $container->get(RecallReindexCommand::class);
+assert($reindex instanceof RecallReindexCommand);
+
+exit($reindex->run($arguments, $out));

--- a/docs/adr/0007-recall-search-backend.md
+++ b/docs/adr/0007-recall-search-backend.md
@@ -1,0 +1,108 @@
+# ADR 0007: 検索バックエンドを NeNe Recall に差し替え可能にする（設定で切替・未設定なら従来の LIKE 検索）
+
+## Status
+
+Proposed（2026-09-02）
+
+## Context
+
+`ChunkSearchRepositoryInterface::search()` の唯一の実装 `PdoChunkSearchRepository` は、空白区切りの語の `LIKE` 一致数を
+スコアにする検索である。意味の近い言い換えは拾えず、Claude ツール `search_corpus` の根拠の質を制限している。
+
+[NeNe Recall](https://github.com/hideyukiMORI/nene-recall)（Go・自己ホスト・費用0円）は、ベクトル類似度と語彙一致の
+ハイブリッド検索を HTTP API で提供する。日本語の評価セット（259 チャンク・58 クエリ）で `recall@10` は LIKE 相当の語彙のみ 0.62 に対し
+ハイブリッド 0.72（Recall 側 ADR 0015）。Recall 側の契約は Recall ADR 0020 で確定した（`external_id`・文書単位の削除・Bearer・同期書き込み）。
+
+Corpus 側の制約:
+- 依存方向は「Corpus → 上流 API」（ADR 0002）。Recall は Corpus を呼ばない
+- 設定は `.env`（ADR 0004）。`NeneRecordsConfig` / `AnthropicConfig` と同じ `fromEnvironment()` / `isConfigured()` の型
+- 層規約: UseCase から生 HTTP を呼ばない。SQL は `Pdo*Repository` の中だけ。**Repository の禁止事項に HTTP がある**
+- 全 Repository は org scoped。`RequestScopedOrgIdHolder::getId()` から取る
+- 用語: chunk を "embedding row" と呼ばない
+
+## Decision
+
+### 1. `src/Recall/` に上流クライアント層を置く（`src/Upstream/` と同じ位置づけ）
+
+- `RecallConfig`（`NENE_RECALL_BASE_URL` / `NENE_RECALL_BEARER_TOKEN` / `NENE_RECALL_TIMEOUT_SECONDS`（既定 10）/ `NENE_RECALL_SEARCH_ALPHA`（任意）/
+  `NENE_RECALL_STRICT`（既定 0））。`isConfigured()` は base URL の有無。
+- `RecallClientInterface`（`search(int $orgId, string $query, int $limit): list<RecallSearchHit>`、`putChunks(int $orgId, list<RecallChunkInput>): void`、
+  `deleteByDocument(int $orgId, int $documentId): void`、`deleteBySource(int $orgId, int $sourceId): void`）。
+- `HttpRecallClient`（curl・タイムアウト・Bearer・非 2xx と接続失敗は `RecallUnavailableException`）と `NullRecallClient`（未設定時）。
+  🔴 HTTP の実行だけを `RecallHttpTransportInterface`（`post/delete(url, headers, body): RecallHttpResponse`）に分離し、テストで差し替える
+  （`HttpNeneRecordsClient` にテストが無い原因が「差し替え点が無いこと」だった）。
+
+### 2. 検索は `RecallChunkSearchRepository implements ChunkSearchRepositoryInterface`
+
+**層規約との整合**: この Repository は SQL を持たず、`RecallClientInterface`（上流層）と `PdoChunkSearchGuard`（`Pdo*` 層・生存フィルタ）を
+合成する。「Repository が HTTP を直接叩く」のではなく「上流クライアントを呼ぶ」。表の禁止事項（Repository の HTTP 直叩き）には触れない。
+CLAUDE.md の層の表に「Repository は上流クライアント interface を呼んでよい」を1行足す（本 ADR が根拠）。
+
+- org は `RequestScopedOrgIdHolder::getId()`。未解決は既存と同じ `LogicException`。
+- Recall の結果（`external_id` = Corpus の `chunks.id`）を `PdoChunkSearchGuard::filterAlive(list<int> $chunkIds): array<int, Chunk>` に通す。
+  1本の SQL: `chunks c JOIN sources s ON … AND s.is_deleted = 0 JOIN documents d ON … AND d.is_deleted = 0 WHERE c.id IN (…) AND c.organization_id = ?`。
+  返る `Chunk` は DB 行（`createdAt`/`updatedAt`/`tokenCount` が埋まる）。id をキーにした配列で返し、Recall の順位は呼び出し側が
+  `ChunkSearchResult(chunk, score)` の並びとして復元する。
+  🔴 **org を引数で受け取らず、ガード自身が `RequestScopedOrgIdHolder` から引く。** CLAUDE.md の絶対禁止パターンに
+  「`Pdo*Repository` で `RequestScopedOrgIdHolder` を経由しない SQL」があり、org を引数にすると
+  「どこかで正しい org が渡されている」という前提が SQL の外に出てしまう。同一リクエスト内で holder は1つなので、
+  検索要求に使う org とフィルタの org がずれることはない。
+- **`external_id` が無い結果（Recall 単体で投入された行）は捨てる**（Corpus の chunk ではない）。
+- 失敗時: `RecallUnavailableException` を捕まえ、`NENE_RECALL_STRICT=0` なら `PdoChunkSearchRepository` に**フォールバックして warning ログ**、
+  `=1` なら例外をそのまま投げる。
+
+### 3. 同期は `IndexedChunkRepository implements ChunkRepositoryInterface`（デコレータ）
+
+`PdoChunkRepository` を包み、`save()` 後に `putChunks`（`external_id` = 採番された id）、`deleteByDocumentId` / `deleteBySourceId` 後に対応する DELETE。
+Recall の失敗は **fail-loud**（`RecallUnavailableException` をそのまま投げる。取り込みは管理操作）。
+`CreatePdfSourceUseCase` の `Closure` ファクトリにもデコレータを掛ける（配線点で包む）。
+
+### 4. 再索引コマンド `bin/console recall:reindex [--org=<id>]`
+
+全 chunks（生きている source/document のもの）を Recall へ `putChunks`（1,000 件バッチ・keyset ページング）。Corpus に無い
+`external_id` の掃除は Recall 側に一覧 API が無いので **`deleteBySource` を全 source について先に打ってから投入する**
+（source 単位で作り直す）。`--org` 省略時は `OrganizationRepositoryInterface::listAll()` の全 org。進捗と件数を stdout。
+
+🔴 **`bin/console` はこの ADR で新設する。** 本リポには CLI の入口が1つも無かった（`tools/*.php` は composer script
+から呼ぶ開発者向けの検査で、運用コマンドの置き場ではない）。実体は薄い配線だけにし、引数解釈と処理は
+`src/Recall/RecallReindexCommand.php` / `RecallReindexer.php` に置く。あわせて **`bin/console` を
+PHPStan と CS-Fixer の対象に追加した**——ゲートの外に置いた入口は、いずれ検査されていないことを忘れられる。
+
+読み取りの SQL は `src/Recall/PdoRecallReindexReader.php`（`Pdo` 接頭辞・holder 経由の org スコープ）。
+`ChunkRepositoryInterface` に全走査を足さなかったのは、そこに足すと**全実装（PDO・デコレータ）に、
+運用コマンドのためだけのメソッドが増える**からである。再索引は保守作業であって chunk の永続化の契約ではない。
+
+### 5. DI は `SearchServiceProvider` / `ChunkServiceProvider` の設定分岐
+
+`RecallConfig::isConfigured()` なら `RecallChunkSearchRepository` と `IndexedChunkRepository`、でなければ従来どおり。
+`UpstreamServiceProvider` / `LlmServiceProvider` と同じ形。Recall 自体の束は `src/Recall/RecallServiceProvider.php`。
+
+🔴 **配線点は2つある。** コンテナの `ChunkRepositoryInterface` 束縛だけでは足りず、
+`IngestionServiceProvider::chunkRepositoryFactory()` の `Closure`（トランザクションの executor を受けて
+その場で組む経路）にも同じデコレータを掛ける。片方だけ包むと **PDF 取り込みの chunk だけが索引に載らない**——
+検索が静かに欠けるだけなので、症状が出るまで気づけない。
+
+## Consequences
+
+- 未設定なら**振る舞いは 1 ミリも変わらない**（従来の LIKE 検索・同期なし）。
+- 設定すると `search_corpus` の根拠がハイブリッド検索になり、取り込み時に Recall への往復が増える（取り込み 1 件あたり数十 ms）。
+- Recall が落ちていると取り込みは失敗する（fail-loud）。検索はフォールバックする（strict でなければ）。
+- `/health` に Recall の到達性を足す（任意・別 Issue でもよい）。
+- テスト: `RecallHttpTransportInterface` の fake で HTTP を、SQLite `:memory:` で `PdoChunkSearchGuard` を、`createMock` で UseCase を。
+  **org 分離のテスト**（別 org の `external_id` を Recall が返してもガードで落ちる）を必ず含める。
+
+## 却下した選択肢
+
+| 選択肢 | 却下の理由 |
+| --- | --- |
+| Recall の結果をそのまま `Chunk` に組み立てる（DB を見ない） | soft delete の保険が消える。`createdAt` 等が埋まらない |
+| 検索失敗で空を返す（Records クライアントの先例） | Claude が根拠なしで答える。フォールバックの方が正直 |
+| Webhook / ポーリング | 依存方向の逆流（ADR 0002）。Recall ADR 0020 の却下表と同じ |
+| `PdoChunkRepository` の中に HTTP を書く | 層規約違反。デコレータなら PDO 側は無傷 |
+| Guzzle / PSR-18 を導入 | 依存追加。curl で足り、既存2クライアントも標準関数 |
+
+## Related
+
+- Recall ADR 0020（契約の正本）・Recall OpenAPI `docs/openapi/openapi.yaml`
+- 本リポ ADR 0002（依存方向）・ADR 0004（設定は `.env`）
+- `src/Upstream/HttpNeneRecordsClient.php`・`NeneRecordsConfig.php`（先例）

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 parameters:
   level: 8
   paths:
+    - bin/console
     - src
     - tests
     - tools

--- a/src/ApplicationServiceProvider.php
+++ b/src/ApplicationServiceProvider.php
@@ -45,6 +45,7 @@ use NeneCorpus\Notification\NotificationServiceProvider;
 use NeneCorpus\Organization\OrganizationRouteRegistrar;
 use NeneCorpus\Organization\OrganizationServiceProvider;
 use NeneCorpus\RateLimit\RateLimitServiceProvider;
+use NeneCorpus\Recall\RecallServiceProvider;
 use NeneCorpus\Search\SearchServiceProvider;
 use NeneCorpus\Session\AdminChatRouteRegistrar;
 use NeneCorpus\Session\SessionServiceProvider;
@@ -91,6 +92,7 @@ final readonly class ApplicationServiceProvider implements ServiceProviderInterf
             ->addProvider(new SystemConfigServiceProvider())
             ->addProvider(new TenancyServiceProvider())
             ->addProvider(new UpstreamServiceProvider())
+            ->addProvider(new RecallServiceProvider())
             ->set(
                 self::ROUTE_REGISTRARS,
                 static function (ContainerInterface $container): array {

--- a/src/Chunk/ChunkServiceProvider.php
+++ b/src/Chunk/ChunkServiceProvider.php
@@ -9,6 +9,7 @@ use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
 use Nene2\Http\ClockInterface;
+use NeneCorpus\Recall\RecallServiceProvider;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
 
@@ -36,7 +37,19 @@ final readonly class ChunkServiceProvider implements ServiceProviderInterface
                     throw new LogicException('Clock service is invalid.');
                 }
 
-                return new PdoChunkRepository($query, $orgIdHolder, $clock);
+                $chunks = new PdoChunkRepository($query, $orgIdHolder, $clock);
+
+                // Undecorated unless Recall is configured, so a deployment
+                // without it performs no upstream writes at all (ADR 0007).
+                if (!RecallServiceProvider::config($container)->isConfigured()) {
+                    return $chunks;
+                }
+
+                return new IndexedChunkRepository(
+                    $chunks,
+                    RecallServiceProvider::client($container),
+                    $orgIdHolder,
+                );
             },
         );
     }

--- a/src/Chunk/IndexedChunkRepository.php
+++ b/src/Chunk/IndexedChunkRepository.php
@@ -22,8 +22,22 @@ use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
  * point at the cause. Recovery is `recall:reindex`, not a silent retry.
  *
  * The write order is database first, Recall second — the database is the record.
- * When Recall then fails inside an ingestion transaction, the rollback leaves
- * both sides consistent.
+ * What a failure leaves behind depends on the ingestion path, and only one of
+ * them is transactional:
+ *
+ * - **PDF** ({@see \NeneCorpus\Ingestion\CreatePdfSourceUseCase}) runs inside
+ *   `DatabaseTransactionManagerInterface::transactional()`, so a Recall failure
+ *   rolls the chunk rows back and both sides stay consistent.
+ * - **text and CSV** ({@see \NeneCorpus\Ingestion\CreateTextSourceUseCase},
+ *   {@see \NeneCorpus\Ingestion\CreateCsvSourceUseCase}) have no transaction.
+ *   They mark the source `failed` and rethrow, but chunk rows already committed
+ *   stay in Corpus with no counterpart in Recall — including the row of the very
+ *   save that failed, because the database write precedes the Recall call.
+ *
+ * That drift is expected, not a hole: it is exactly what `recall:reindex`
+ * exists to collect (ADR 0007 Decision 4). Do not paper over it by catching the
+ * exception here — a half-indexed source that reports success is worse than one
+ * that reports failure.
  */
 final readonly class IndexedChunkRepository implements ChunkRepositoryInterface
 {

--- a/src/Chunk/IndexedChunkRepository.php
+++ b/src/Chunk/IndexedChunkRepository.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Chunk;
+
+use LogicException;
+use NeneCorpus\Recall\RecallChunkInput;
+use NeneCorpus\Recall\RecallClientInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+
+/**
+ * Keeps NeNe Recall in step with the chunks table (ADR 0007 Decision 3).
+ *
+ * A decorator rather than a change to {@see PdoChunkRepository}: the PDO
+ * repository stays SQL-only, and a deployment without Recall configured runs the
+ * undecorated one, so its behaviour is untouched.
+ *
+ * 🔴 Failures are **not** swallowed. Ingestion is an administrative action a
+ * person is watching; a chunk that is saved but never indexed produces a corpus
+ * that answers as if the document were never uploaded, and nothing would ever
+ * point at the cause. Recovery is `recall:reindex`, not a silent retry.
+ *
+ * The write order is database first, Recall second — the database is the record.
+ * When Recall then fails inside an ingestion transaction, the rollback leaves
+ * both sides consistent.
+ */
+final readonly class IndexedChunkRepository implements ChunkRepositoryInterface
+{
+    public function __construct(
+        private ChunkRepositoryInterface $inner,
+        private RecallClientInterface $recall,
+        private RequestScopedOrgIdHolder $orgIdHolder,
+    ) {
+    }
+
+    public function findById(int $id): ?Chunk
+    {
+        return $this->inner->findById($id);
+    }
+
+    /** @return list<Chunk> */
+    public function findByDocumentId(int $documentId): array
+    {
+        return $this->inner->findByDocumentId($documentId);
+    }
+
+    public function save(Chunk $chunk): int
+    {
+        $id = $this->inner->save($chunk);
+
+        $this->recall->putChunks($this->orgId(), [RecallChunkInput::fromChunk($id, $chunk)]);
+
+        return $id;
+    }
+
+    public function deleteByDocumentId(int $documentId): void
+    {
+        $this->inner->deleteByDocumentId($documentId);
+        $this->recall->deleteByDocument($this->orgId(), $documentId);
+    }
+
+    public function deleteBySourceId(int $sourceId): void
+    {
+        $this->inner->deleteBySourceId($sourceId);
+        $this->recall->deleteBySource($this->orgId(), $sourceId);
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
+    }
+}

--- a/src/Ingestion/IngestionServiceProvider.php
+++ b/src/Ingestion/IngestionServiceProvider.php
@@ -14,10 +14,12 @@ use Nene2\Error\ProblemDetailsResponseFactory;
 use Nene2\Http\ClockInterface;
 use Nene2\Http\JsonResponseFactory;
 use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Chunk\IndexedChunkRepository;
 use NeneCorpus\Chunk\PdoChunkRepository;
 use NeneCorpus\Document\DocumentRepositoryInterface;
 use NeneCorpus\Document\PdoDocumentRepository;
 use NeneCorpus\Http\RuntimeServiceProvider;
+use NeneCorpus\Recall\RecallServiceProvider;
 use NeneCorpus\Source\PdoSourceRepository;
 use NeneCorpus\Source\SourceRepositoryInterface;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
@@ -361,7 +363,21 @@ final readonly class IngestionServiceProvider implements ServiceProviderInterfac
         $orgIdHolder = self::orgIdHolder($container);
         $clock = self::clock($container);
 
-        return static fn (DatabaseQueryExecutorInterface $executor): ChunkRepositoryInterface => new PdoChunkRepository($executor, $orgIdHolder, $clock);
+        // The repository built here is transaction-scoped (it is handed the
+        // transaction's executor), so the container binding cannot be reused —
+        // the Recall decorator has to be applied at this seam as well, or PDF
+        // ingestion would write chunks that never reach the index (ADR 0007).
+        if (!RecallServiceProvider::config($container)->isConfigured()) {
+            return static fn (DatabaseQueryExecutorInterface $executor): ChunkRepositoryInterface => new PdoChunkRepository($executor, $orgIdHolder, $clock);
+        }
+
+        $recall = RecallServiceProvider::client($container);
+
+        return static fn (DatabaseQueryExecutorInterface $executor): ChunkRepositoryInterface => new IndexedChunkRepository(
+            new PdoChunkRepository($executor, $orgIdHolder, $clock),
+            $recall,
+            $orgIdHolder,
+        );
     }
 
     private static function csvValidator(ContainerInterface $container): CsvUploadValidator

--- a/src/Recall/CurlRecallHttpTransport.php
+++ b/src/Recall/CurlRecallHttpTransport.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+/**
+ * curl-backed transport. Same shape as {@see \NeneCorpus\Llm\HttpClaudeMessagesClient},
+ * which is why no HTTP client library is pulled in (ADR 0007, rejected options).
+ */
+final readonly class CurlRecallHttpTransport implements RecallHttpTransportInterface
+{
+    public function __construct(
+        private int $timeoutSeconds = RecallConfig::DEFAULT_TIMEOUT_SECONDS,
+    ) {
+    }
+
+    public function post(string $url, array $headers, string $body): RecallHttpResponse
+    {
+        return $this->send($url, $headers, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+        ]);
+    }
+
+    public function delete(string $url, array $headers): RecallHttpResponse
+    {
+        return $this->send($url, $headers, [
+            CURLOPT_CUSTOMREQUEST => 'DELETE',
+        ]);
+    }
+
+    /**
+     * @param list<string>        $headers
+     * @param array<int, mixed>   $methodOptions
+     */
+    private function send(string $url, array $headers, array $methodOptions): RecallHttpResponse
+    {
+        $handle = curl_init($url);
+
+        if ($handle === false) {
+            throw RecallUnavailableException::transport('request', 'the HTTP client could not be initialised.');
+        }
+
+        curl_setopt_array($handle, $methodOptions + [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => $headers,
+            // Connect timeout is separate so an unreachable host fails fast
+            // instead of burning the whole budget on the TCP handshake.
+            CURLOPT_CONNECTTIMEOUT => max(1, min(5, $this->timeoutSeconds)),
+            CURLOPT_TIMEOUT => $this->timeoutSeconds,
+        ]);
+
+        $responseBody = curl_exec($handle);
+        $statusCode = (int) curl_getinfo($handle, CURLINFO_RESPONSE_CODE);
+        $error = curl_error($handle);
+        curl_close($handle);
+
+        if (!is_string($responseBody)) {
+            throw RecallUnavailableException::transport('request', $error !== '' ? $error : 'unknown transport error.');
+        }
+
+        return new RecallHttpResponse($statusCode, $responseBody);
+    }
+}

--- a/src/Recall/HttpRecallClient.php
+++ b/src/Recall/HttpRecallClient.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use JsonException;
+
+/**
+ * Talks to the NeNe Recall HTTP API (its `docs/openapi/openapi.yaml`).
+ *
+ * Failure handling differs from {@see \NeneCorpus\Upstream\HttpNeneRecordsClient},
+ * which returns empty results on error: here an empty result is indistinguishable
+ * from "nothing matched", and Claude would answer with no evidence. Every failure
+ * therefore raises {@see RecallUnavailableException} and the caller decides
+ * (ADR 0007 Decision 2 / Decision 3).
+ */
+final readonly class HttpRecallClient implements RecallClientInterface
+{
+    public function __construct(
+        private RecallConfig $config,
+        private RecallHttpTransportInterface $transport,
+    ) {
+    }
+
+    public function search(int $orgId, string $query, int $limit): array
+    {
+        $payload = [
+            'org_id' => $orgId,
+            'query' => $query,
+            'limit' => $limit,
+        ];
+
+        if ($this->config->searchAlpha !== null) {
+            $payload['alpha'] = $this->config->searchAlpha;
+        }
+
+        $decoded = $this->exchange('search', $this->config->endpoint('/v1/search'), $payload);
+        $results = $decoded['results'] ?? [];
+
+        if (!is_array($results)) {
+            throw RecallUnavailableException::malformedResponse('search');
+        }
+
+        $hits = [];
+
+        foreach ($results as $result) {
+            if (!is_array($result)) {
+                continue;
+            }
+
+            $chunkId = $result['chunk_id'] ?? null;
+            $score = $result['score'] ?? null;
+
+            if (!is_int($chunkId) || !is_numeric($score)) {
+                continue;
+            }
+
+            $hits[] = new RecallSearchHit(
+                chunkId: $chunkId,
+                externalId: is_int($result['external_id'] ?? null) ? (int) $result['external_id'] : null,
+                score: (float) $score,
+                vectorScore: is_numeric($result['vector_score'] ?? null) ? (float) $result['vector_score'] : null,
+                lexicalScore: is_numeric($result['lexical_score'] ?? null) ? (float) $result['lexical_score'] : null,
+            );
+        }
+
+        return $hits;
+    }
+
+    public function putChunks(int $orgId, array $chunks): void
+    {
+        if ($chunks === []) {
+            return;
+        }
+
+        $this->exchange('putChunks', $this->config->endpoint('/v1/chunks'), [
+            'org_id' => $orgId,
+            'chunks' => array_map(
+                static fn (RecallChunkInput $chunk): array => $chunk->toPayload(),
+                $chunks,
+            ),
+        ]);
+    }
+
+    public function deleteByDocument(int $orgId, int $documentId): void
+    {
+        $this->requestDelete(
+            'deleteByDocument',
+            $this->config->endpoint('/v1/documents/' . $documentId . '/chunks'),
+            $orgId,
+        );
+    }
+
+    public function deleteBySource(int $orgId, int $sourceId): void
+    {
+        $this->requestDelete(
+            'deleteBySource',
+            $this->config->endpoint('/v1/sources/' . $sourceId . '/chunks'),
+            $orgId,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function exchange(string $operation, string $url, array $payload): array
+    {
+        try {
+            $body = json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        } catch (JsonException $exception) {
+            throw RecallUnavailableException::transport($operation, 'the request body could not be encoded.');
+        }
+
+        $response = $this->transport->post($url, $this->headers(withBody: true), $body);
+
+        return $this->decode($operation, $response);
+    }
+
+    private function requestDelete(string $operation, string $url, int $orgId): void
+    {
+        // org_id travels as a query parameter on DELETE, exactly as Recall's
+        // source-scoped delete already does (Recall OpenAPI, ADR 0003).
+        $response = $this->transport->delete(
+            $url . '?' . http_build_query(['org_id' => $orgId]),
+            $this->headers(withBody: false),
+        );
+
+        $this->decode($operation, $response);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(string $operation, RecallHttpResponse $response): array
+    {
+        if (!$response->isSuccessful()) {
+            // The body may echo the request; only the status code is reported so
+            // that nothing from the exchange can leak into logs.
+            throw RecallUnavailableException::status($operation, $response->statusCode);
+        }
+
+        if (trim($response->body) === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($response->body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw RecallUnavailableException::malformedResponse($operation);
+        }
+
+        if (!is_array($decoded)) {
+            throw RecallUnavailableException::malformedResponse($operation);
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function headers(bool $withBody): array
+    {
+        $headers = ['Accept: application/json'];
+
+        if ($withBody) {
+            $headers[] = 'Content-Type: application/json';
+        }
+
+        if ($this->config->bearerToken !== null) {
+            $headers[] = 'Authorization: Bearer ' . $this->config->bearerToken;
+        }
+
+        return $headers;
+    }
+}

--- a/src/Recall/NullRecallClient.php
+++ b/src/Recall/NullRecallClient.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+/**
+ * Used when NENE_RECALL_BASE_URL is empty, so that nothing has to be nullable.
+ *
+ * It is never reached in practice: the service providers only wire the Recall
+ * search repository and the indexing decorator when the config is present. It
+ * exists so `RecallClientInterface` can always be resolved from the container
+ * (same pattern as {@see \NeneCorpus\Upstream\NullNeneRecordsClient}).
+ */
+final readonly class NullRecallClient implements RecallClientInterface
+{
+    public function search(int $orgId, string $query, int $limit): array
+    {
+        return [];
+    }
+
+    public function putChunks(int $orgId, array $chunks): void
+    {
+    }
+
+    public function deleteByDocument(int $orgId, int $documentId): void
+    {
+    }
+
+    public function deleteBySource(int $orgId, int $sourceId): void
+    {
+    }
+}

--- a/src/Recall/PdoRecallReindexReader.php
+++ b/src/Recall/PdoRecallReindexReader.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+
+/**
+ * SQL for `recall:reindex`. Org-scoped through {@see RequestScopedOrgIdHolder}
+ * like every other Pdo* class, so the reindex of one tenant can never read
+ * another one's chunks.
+ */
+final readonly class PdoRecallReindexReader implements RecallReindexReaderInterface
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        c.id, c.document_id, c.source_id, c.chunk_index, c.content, c.page_number, c.section_label,
+        c.token_count, c.created_at, c.updated_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
+    ) {
+    }
+
+    /** @return list<int> */
+    public function listAliveSourceIds(): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT id FROM sources WHERE organization_id = ? AND is_deleted = 0 ORDER BY id ASC',
+            [$this->orgId()],
+        );
+
+        return array_map(static fn (array $row): int => (int) $row['id'], $rows);
+    }
+
+    /** @return list<Chunk> */
+    public function listAliveChunks(int $afterId, int $limit): array
+    {
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ' '
+            . 'FROM chunks c '
+            . 'INNER JOIN sources s ON s.id = c.source_id AND s.is_deleted = 0 '
+            . 'INNER JOIN documents d ON d.id = c.document_id AND d.is_deleted = 0 '
+            . 'WHERE c.organization_id = ? AND c.id > ? '
+            . 'ORDER BY c.id ASC '
+            . 'LIMIT ?',
+            [$this->orgId(), $afterId, $limit],
+        );
+
+        return array_map(fn (array $row): Chunk => $this->mapRow($row), $rows);
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Set it before reindexing.');
+        }
+
+        return $id;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): Chunk
+    {
+        return new Chunk(
+            documentId: (int) $row['document_id'],
+            sourceId: (int) $row['source_id'],
+            content: (string) $row['content'],
+            chunkIndex: (int) $row['chunk_index'],
+            pageNumber: isset($row['page_number']) ? (int) $row['page_number'] : null,
+            sectionLabel: isset($row['section_label']) ? (string) $row['section_label'] : null,
+            tokenCount: isset($row['token_count']) ? (int) $row['token_count'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Recall/RecallChunkInput.php
+++ b/src/Recall/RecallChunkInput.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use NeneCorpus\Chunk\Chunk;
+
+/**
+ * A chunk on its way into Recall.
+ *
+ * 🔴 The Corpus id travels as `external_id`, never as `chunk_id`: Recall's own
+ * `chunk_id` is its identity column, and writing a foreign id into it would stop
+ * its sequence from advancing (Recall ADR 0020 Decision 1).
+ */
+final readonly class RecallChunkInput
+{
+    public function __construct(
+        public int $externalId,
+        public int $documentId,
+        public int $sourceId,
+        public int $chunkIndex,
+        public string $content,
+        public ?int $pageNumber = null,
+        public ?string $sectionLabel = null,
+    ) {
+    }
+
+    public static function fromChunk(int $externalId, Chunk $chunk): self
+    {
+        return new self(
+            externalId: $externalId,
+            documentId: $chunk->documentId,
+            sourceId: $chunk->sourceId,
+            chunkIndex: $chunk->chunkIndex,
+            content: $chunk->content,
+            pageNumber: $chunk->pageNumber,
+            sectionLabel: $chunk->sectionLabel,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPayload(): array
+    {
+        return [
+            'external_id' => $this->externalId,
+            'document_id' => $this->documentId,
+            'source_id' => $this->sourceId,
+            'chunk_index' => $this->chunkIndex,
+            'content' => $this->content,
+            'page_number' => $this->pageNumber,
+            'section_label' => $this->sectionLabel,
+        ];
+    }
+}

--- a/src/Recall/RecallClientInterface.php
+++ b/src/Recall/RecallClientInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+/**
+ * Upstream client for NeNe Recall (ADR 0007 Decision 1).
+ *
+ * `$orgId` is passed explicitly on every call because Recall enforces tenant
+ * isolation on its own side too (Recall ADR 0003) — there is no server-side
+ * default, and there must not be one here either.
+ */
+interface RecallClientInterface
+{
+    /**
+     * @return list<RecallSearchHit> Recall's own ranking, best first
+     *
+     * @throws RecallUnavailableException
+     */
+    public function search(int $orgId, string $query, int $limit): array;
+
+    /**
+     * @param list<RecallChunkInput> $chunks
+     *
+     * @throws RecallUnavailableException
+     */
+    public function putChunks(int $orgId, array $chunks): void;
+
+    /**
+     * @throws RecallUnavailableException
+     */
+    public function deleteByDocument(int $orgId, int $documentId): void;
+
+    /**
+     * @throws RecallUnavailableException
+     */
+    public function deleteBySource(int $orgId, int $sourceId): void;
+}

--- a/src/Recall/RecallConfig.php
+++ b/src/Recall/RecallConfig.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+/**
+ * Settings for the optional NeNe Recall search backend (ADR 0007).
+ *
+ * Everything is read from `.env` (ADR 0004) and every value is optional: when
+ * `NENE_RECALL_BASE_URL` is empty the whole integration stays off and Corpus
+ * behaves exactly as before (LIKE search, no upstream writes).
+ */
+final readonly class RecallConfig
+{
+    public const DEFAULT_TIMEOUT_SECONDS = 10;
+
+    public function __construct(
+        public ?string $baseUrl,
+        public ?string $bearerToken = null,
+        public int $timeoutSeconds = self::DEFAULT_TIMEOUT_SECONDS,
+        public ?float $searchAlpha = null,
+        public bool $strict = false,
+    ) {
+    }
+
+    public static function fromEnvironment(): self
+    {
+        return new self(
+            baseUrl: self::readEnv('NENE_RECALL_BASE_URL'),
+            bearerToken: self::readEnv('NENE_RECALL_BEARER_TOKEN'),
+            timeoutSeconds: self::readTimeoutSeconds(),
+            searchAlpha: self::readSearchAlpha(),
+            strict: self::readEnv('NENE_RECALL_STRICT') === '1',
+        );
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->baseUrl !== null && $this->baseUrl !== '';
+    }
+
+    /**
+     * Base URL without a trailing slash, so callers can concatenate paths.
+     */
+    public function endpoint(string $path): string
+    {
+        return rtrim((string) $this->baseUrl, '/') . $path;
+    }
+
+    private static function readTimeoutSeconds(): int
+    {
+        $raw = self::readEnv('NENE_RECALL_TIMEOUT_SECONDS');
+
+        if ($raw === null || !ctype_digit($raw)) {
+            return self::DEFAULT_TIMEOUT_SECONDS;
+        }
+
+        $seconds = (int) $raw;
+
+        // A zero timeout means "wait forever" in curl, which would hang ingestion
+        // on an unresponsive Recall. Treat it as "not configured" instead.
+        return $seconds > 0 ? $seconds : self::DEFAULT_TIMEOUT_SECONDS;
+    }
+
+    private static function readSearchAlpha(): ?float
+    {
+        $raw = self::readEnv('NENE_RECALL_SEARCH_ALPHA');
+
+        if ($raw === null || !is_numeric($raw)) {
+            return null;
+        }
+
+        $alpha = (float) $raw;
+
+        // Out-of-range values are dropped rather than clamped: sending them would
+        // make Recall answer 400 and take the whole search down with it.
+        return ($alpha >= 0.0 && $alpha <= 1.0) ? $alpha : null;
+    }
+
+    private static function readEnv(string $key): ?string
+    {
+        $value = $_ENV[$key] ?? $_SERVER[$key] ?? null;
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/src/Recall/RecallHttpResponse.php
+++ b/src/Recall/RecallHttpResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+final readonly class RecallHttpResponse
+{
+    public function __construct(
+        public int $statusCode,
+        public string $body,
+    ) {
+    }
+
+    public function isSuccessful(): bool
+    {
+        return $this->statusCode >= 200 && $this->statusCode < 300;
+    }
+}

--- a/src/Recall/RecallHttpTransportInterface.php
+++ b/src/Recall/RecallHttpTransportInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+/**
+ * The HTTP execution of a Recall call, and nothing else.
+ *
+ * 🔴 This seam exists so the client is testable. `HttpNeneRecordsClient` has no
+ * tests for exactly one reason — there is no place to substitute the network in
+ * it — and repeating that shape here would repeat the gap (ADR 0007 Decision 1).
+ *
+ * Building URLs, headers and bodies, and deciding what a status code means, all
+ * belong to {@see HttpRecallClient}; an implementation of this interface only
+ * moves bytes.
+ */
+interface RecallHttpTransportInterface
+{
+    /**
+     * @param list<string> $headers Fully formed header lines ("Name: value")
+     *
+     * @throws RecallUnavailableException when the request could not be completed at all
+     */
+    public function post(string $url, array $headers, string $body): RecallHttpResponse;
+
+    /**
+     * @param list<string> $headers
+     *
+     * @throws RecallUnavailableException
+     */
+    public function delete(string $url, array $headers): RecallHttpResponse;
+}

--- a/src/Recall/RecallReindexCommand.php
+++ b/src/Recall/RecallReindexCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use Closure;
+use NeneCorpus\Organization\OrganizationRepositoryInterface;
+
+/**
+ * `recall:reindex [--org=<id>]` — argument parsing and reporting.
+ *
+ * The work itself is in {@see RecallReindexer}; keeping the console entry point
+ * free of logic is what makes this testable without a terminal.
+ */
+final readonly class RecallReindexCommand
+{
+    public const NAME = 'recall:reindex';
+
+    public const USAGE = 'Usage: bin/console recall:reindex [--org=<id>]';
+
+    public function __construct(
+        private RecallConfig $config,
+        private RecallReindexer $reindexer,
+        private OrganizationRepositoryInterface $organizations,
+    ) {
+    }
+
+    /**
+     * @param list<string>        $arguments Arguments after the command name
+     * @param Closure(string): void $out
+     *
+     * @return int Process exit code
+     */
+    public function run(array $arguments, Closure $out): int
+    {
+        if (!$this->config->isConfigured()) {
+            $out('NENE_RECALL_BASE_URL is not set — nothing to reindex.');
+
+            return 1;
+        }
+
+        $organizationId = null;
+
+        foreach ($arguments as $argument) {
+            if (str_starts_with($argument, '--org=')) {
+                $value = substr($argument, strlen('--org='));
+
+                if (!ctype_digit($value) || (int) $value < 1) {
+                    $out('--org must be a positive integer.');
+                    $out(self::USAGE);
+
+                    return 1;
+                }
+
+                $organizationId = (int) $value;
+
+                continue;
+            }
+
+            $out(sprintf('Unknown argument: %s', $argument));
+            $out(self::USAGE);
+
+            return 1;
+        }
+
+        $organizationIds = $organizationId !== null
+            ? [$organizationId]
+            : $this->allOrganizationIds();
+
+        if ($organizationIds === []) {
+            $out('No organizations found.');
+
+            return 1;
+        }
+
+        try {
+            foreach ($organizationIds as $id) {
+                $report = $this->reindexer->reindex($id, $out);
+
+                $out(sprintf(
+                    'org %d: done — %d source(s) cleared, %d chunk(s) indexed.',
+                    $report->organizationId,
+                    $report->clearedSources,
+                    $report->indexedChunks,
+                ));
+            }
+        } catch (RecallUnavailableException $exception) {
+            // Stop at the first failure: continuing would leave later
+            // organizations half-cleared without saying so.
+            $out('Reindex aborted: ' . $exception->getMessage());
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function allOrganizationIds(): array
+    {
+        $ids = [];
+
+        foreach ($this->organizations->listAll() as $organization) {
+            if ($organization->id !== null) {
+                $ids[] = $organization->id;
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/src/Recall/RecallReindexReaderInterface.php
+++ b/src/Recall/RecallReindexReaderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use NeneCorpus\Chunk\Chunk;
+
+/**
+ * The read side of `recall:reindex`, scoped to the current organization.
+ *
+ * Kept separate from {@see \NeneCorpus\Chunk\ChunkRepositoryInterface} because a
+ * full-corpus, keyset-paged scan is a maintenance concern; adding it to the chunk
+ * repository would put it behind the indexing decorator as well.
+ */
+interface RecallReindexReaderInterface
+{
+    /**
+     * Sources that still exist (not soft-deleted) in this organization.
+     *
+     * @return list<int>
+     */
+    public function listAliveSourceIds(): array;
+
+    /**
+     * Chunks belonging to live sources and documents, ordered by id.
+     *
+     * Keyset pagination (`id > $afterId`) rather than OFFSET: the scan stays
+     * correct on large corpora and does not slow down as it advances.
+     *
+     * @return list<Chunk>
+     */
+    public function listAliveChunks(int $afterId, int $limit): array;
+}

--- a/src/Recall/RecallReindexReport.php
+++ b/src/Recall/RecallReindexReport.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+final readonly class RecallReindexReport
+{
+    public function __construct(
+        public int $organizationId,
+        public int $clearedSources,
+        public int $indexedChunks,
+    ) {
+    }
+}

--- a/src/Recall/RecallReindexer.php
+++ b/src/Recall/RecallReindexer.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use Closure;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+
+/**
+ * Rebuilds one organization's index in Recall (ADR 0007 Decision 4).
+ *
+ * This is the recovery path for everything the write-through decorator can miss:
+ * a database transaction that rolled back after Recall had already accepted the
+ * chunk, an ingestion run against a Recall that was down, or a Recall restored
+ * from an older backup.
+ *
+ * 🔴 Stale rows are cleared **per source, before writing**, not by diffing.
+ * Recall exposes no "list every external_id you hold", so the only way to be sure
+ * an id that no longer exists in Corpus is gone is to drop each live source's
+ * chunks and write them again. Sources that Corpus has already forgotten
+ * entirely are outside this command's reach — that is why the ingestion path
+ * deletes eagerly instead of leaving it to the reindex.
+ */
+final readonly class RecallReindexer
+{
+    public const BATCH_SIZE = 1000;
+
+    public function __construct(
+        private RecallClientInterface $recall,
+        private RecallReindexReaderInterface $reader,
+        private RequestScopedOrgIdHolder $orgIdHolder,
+    ) {
+    }
+
+    /**
+     * @param Closure(string): void|null $progress
+     */
+    public function reindex(int $organizationId, ?Closure $progress = null): RecallReindexReport
+    {
+        $this->orgIdHolder->setId($organizationId);
+
+        $sourceIds = $this->reader->listAliveSourceIds();
+
+        foreach ($sourceIds as $sourceId) {
+            $this->recall->deleteBySource($organizationId, $sourceId);
+        }
+
+        $this->report($progress, sprintf('org %d: cleared %d source(s) in Recall', $organizationId, count($sourceIds)));
+
+        $afterId = 0;
+        $indexed = 0;
+
+        while (true) {
+            $chunks = $this->reader->listAliveChunks($afterId, self::BATCH_SIZE);
+
+            if ($chunks === []) {
+                break;
+            }
+
+            $batch = [];
+
+            foreach ($chunks as $chunk) {
+                // Every chunk read from the database has an id; the null in the
+                // entity is for chunks that have not been saved yet.
+                $chunkId = $chunk->id ?? 0;
+                $afterId = max($afterId, $chunkId);
+                $batch[] = RecallChunkInput::fromChunk($chunkId, $chunk);
+            }
+
+            $this->recall->putChunks($organizationId, $batch);
+            $indexed += count($batch);
+
+            $this->report($progress, sprintf('org %d: indexed %d chunk(s)', $organizationId, $indexed));
+
+            if (count($chunks) < self::BATCH_SIZE) {
+                break;
+            }
+        }
+
+        return new RecallReindexReport(
+            organizationId: $organizationId,
+            clearedSources: count($sourceIds),
+            indexedChunks: $indexed,
+        );
+    }
+
+    /**
+     * @param Closure(string): void|null $progress
+     */
+    private function report(?Closure $progress, string $message): void
+    {
+        if ($progress !== null) {
+            $progress($message);
+        }
+    }
+}

--- a/src/Recall/RecallSearchHit.php
+++ b/src/Recall/RecallSearchHit.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+/**
+ * One row of a Recall search response.
+ *
+ * `$externalId` is the Corpus `chunks.id` that was sent when the chunk was
+ * indexed. It is nullable because Recall can also be used standalone, and rows
+ * that were put there by something other than Corpus have no Corpus id —
+ * those are dropped by the search repository (ADR 0007 Decision 2).
+ */
+final readonly class RecallSearchHit
+{
+    public function __construct(
+        public int $chunkId,
+        public ?int $externalId,
+        public float $score,
+        public ?float $vectorScore = null,
+        public ?float $lexicalScore = null,
+    ) {
+    }
+}

--- a/src/Recall/RecallServiceProvider.php
+++ b/src/Recall/RecallServiceProvider.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use LogicException;
+use Nene2\Config\AppConfig;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use Nene2\DependencyInjection\ContainerBuilder;
+use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneCorpus\Organization\OrganizationRepositoryInterface;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Wiring for the optional Recall backend, in the shape of
+ * {@see \NeneCorpus\Upstream\UpstreamServiceProvider}: the config decides which
+ * client is bound, and nothing else in the container has to know.
+ */
+final readonly class RecallServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerBuilder $builder): void
+    {
+        $builder
+            ->set(
+                RecallConfig::class,
+                static function (ContainerInterface $container): RecallConfig {
+                    // Resolving AppConfig is what loads `.env` into $_ENV
+                    // (ConfigLoader::load()). Recall's settings are not part of
+                    // AppConfig, so without this the console entry point — which
+                    // reaches Recall before anything else touches AppConfig —
+                    // would read an unpopulated environment and quietly decide
+                    // that Recall is not configured.
+                    $container->get(AppConfig::class);
+
+                    return RecallConfig::fromEnvironment();
+                },
+            )
+            ->set(
+                RecallHttpTransportInterface::class,
+                static function (ContainerInterface $container): RecallHttpTransportInterface {
+                    return new CurlRecallHttpTransport(self::config($container)->timeoutSeconds);
+                },
+            )
+            ->set(
+                RecallClientInterface::class,
+                static function (ContainerInterface $container): RecallClientInterface {
+                    $config = self::config($container);
+
+                    if (!$config->isConfigured()) {
+                        return new NullRecallClient();
+                    }
+
+                    $transport = $container->get(RecallHttpTransportInterface::class);
+
+                    if (!$transport instanceof RecallHttpTransportInterface) {
+                        throw new LogicException('Recall HTTP transport service is invalid.');
+                    }
+
+                    return new HttpRecallClient($config, $transport);
+                },
+            )
+            ->set(
+                RecallReindexReaderInterface::class,
+                static function (ContainerInterface $container): RecallReindexReaderInterface {
+                    $query = $container->get(DatabaseQueryExecutorInterface::class);
+
+                    if (!$query instanceof DatabaseQueryExecutorInterface) {
+                        throw new LogicException('Database query executor service is invalid.');
+                    }
+
+                    return new PdoRecallReindexReader($query, self::orgIdHolder($container));
+                },
+            )
+            ->set(
+                RecallReindexer::class,
+                static function (ContainerInterface $container): RecallReindexer {
+                    $client = $container->get(RecallClientInterface::class);
+                    $reader = $container->get(RecallReindexReaderInterface::class);
+
+                    if (!$client instanceof RecallClientInterface) {
+                        throw new LogicException('Recall client service is invalid.');
+                    }
+
+                    if (!$reader instanceof RecallReindexReaderInterface) {
+                        throw new LogicException('Recall reindex reader service is invalid.');
+                    }
+
+                    return new RecallReindexer($client, $reader, self::orgIdHolder($container));
+                },
+            )
+            ->set(
+                RecallReindexCommand::class,
+                static function (ContainerInterface $container): RecallReindexCommand {
+                    $reindexer = $container->get(RecallReindexer::class);
+                    $organizations = $container->get(OrganizationRepositoryInterface::class);
+
+                    if (!$reindexer instanceof RecallReindexer) {
+                        throw new LogicException('Recall reindexer service is invalid.');
+                    }
+
+                    if (!$organizations instanceof OrganizationRepositoryInterface) {
+                        throw new LogicException('Organization repository service is invalid.');
+                    }
+
+                    return new RecallReindexCommand(self::config($container), $reindexer, $organizations);
+                },
+            );
+    }
+
+    public static function config(ContainerInterface $container): RecallConfig
+    {
+        $config = $container->get(RecallConfig::class);
+
+        if (!$config instanceof RecallConfig) {
+            throw new LogicException('Recall config service is invalid.');
+        }
+
+        return $config;
+    }
+
+    public static function client(ContainerInterface $container): RecallClientInterface
+    {
+        $client = $container->get(RecallClientInterface::class);
+
+        if (!$client instanceof RecallClientInterface) {
+            throw new LogicException('Recall client service is invalid.');
+        }
+
+        return $client;
+    }
+
+    private static function orgIdHolder(ContainerInterface $container): RequestScopedOrgIdHolder
+    {
+        $holder = $container->get(RequestScopedOrgIdHolder::class);
+
+        if (!$holder instanceof RequestScopedOrgIdHolder) {
+            throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
+        }
+
+        return $holder;
+    }
+}

--- a/src/Recall/RecallUnavailableException.php
+++ b/src/Recall/RecallUnavailableException.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Recall;
+
+use RuntimeException;
+
+/**
+ * The Recall backend could not be reached, or answered something unusable.
+ *
+ * Search catches this and falls back to LIKE search (unless NENE_RECALL_STRICT=1);
+ * ingestion deliberately does not catch it — a silently missing index is worse
+ * than a failed admin operation (ADR 0007 Decision 3).
+ *
+ * 🔴 Never put the bearer token (or the whole config object) into the message:
+ * these messages travel into logs and into API error responses.
+ */
+final class RecallUnavailableException extends RuntimeException
+{
+    public static function status(string $operation, int $statusCode): self
+    {
+        return new self(sprintf('NeNe Recall %s returned HTTP %d.', $operation, $statusCode));
+    }
+
+    public static function transport(string $operation, string $detail): self
+    {
+        return new self(sprintf('NeNe Recall %s failed: %s', $operation, $detail));
+    }
+
+    public static function malformedResponse(string $operation): self
+    {
+        return new self(sprintf('NeNe Recall %s returned a malformed JSON body.', $operation));
+    }
+}

--- a/src/Search/PdoChunkSearchGuard.php
+++ b/src/Search/PdoChunkSearchGuard.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+use LogicException;
+use Nene2\Database\DatabaseQueryExecutorInterface;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+
+/**
+ * Turns chunk ids coming back from an external search backend into chunks that
+ * are actually still readable in this organization.
+ *
+ * Two things are checked here rather than trusted upstream (ADR 0007 Decision 2,
+ * Recall ADR 0020 Decision 6):
+ *
+ * 1. **Tenant isolation.** `organization_id = ?` is applied on our side as well.
+ *    A backend that returned another tenant's id — by bug, by a stale index, or
+ *    because someone pointed two deployments at one Recall — must not be able to
+ *    put that content into an answer.
+ * 2. **Soft deletes.** sources and documents are soft-deleted while chunks are
+ *    hard-deleted, and the delete is pushed to Recall separately. If that push is
+ *    ever missed, deleted material would come back; the `is_deleted = 0` joins
+ *    are the second line of defence, matching {@see PdoChunkSearchRepository}.
+ *
+ * Both faults are invisible in single-tenant development, which is exactly why
+ * the filter is not optional.
+ */
+final readonly class PdoChunkSearchGuard
+{
+    private const SELECT_COLUMNS = <<<'SQL'
+        c.id, c.document_id, c.source_id, c.chunk_index, c.content, c.page_number, c.section_label,
+        c.token_count, c.created_at, c.updated_at
+        SQL;
+
+    public function __construct(
+        private DatabaseQueryExecutorInterface $query,
+        private RequestScopedOrgIdHolder $orgIdHolder,
+    ) {
+    }
+
+    /**
+     * @param list<int> $chunkIds
+     *
+     * @return array<int, Chunk> Surviving chunks keyed by id; caller restores the ranking
+     */
+    public function filterAlive(array $chunkIds): array
+    {
+        if ($chunkIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($chunkIds), '?'));
+        $params = $chunkIds;
+        $params[] = $this->orgId();
+
+        $rows = $this->query->fetchAll(
+            'SELECT ' . self::SELECT_COLUMNS . ' '
+            . 'FROM chunks c '
+            . 'INNER JOIN sources s ON s.id = c.source_id AND s.is_deleted = 0 '
+            . 'INNER JOIN documents d ON d.id = c.document_id AND d.is_deleted = 0 '
+            . 'WHERE c.id IN (' . $placeholders . ') AND c.organization_id = ?',
+            $params,
+        );
+
+        $alive = [];
+
+        foreach ($rows as $row) {
+            $chunk = $this->mapRow($row);
+            $alive[(int) $chunk->id] = $chunk;
+        }
+
+        return $alive;
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function mapRow(array $row): Chunk
+    {
+        return new Chunk(
+            documentId: (int) $row['document_id'],
+            sourceId: (int) $row['source_id'],
+            content: (string) $row['content'],
+            chunkIndex: (int) $row['chunk_index'],
+            pageNumber: isset($row['page_number']) ? (int) $row['page_number'] : null,
+            sectionLabel: isset($row['section_label']) ? (string) $row['section_label'] : null,
+            tokenCount: isset($row['token_count']) ? (int) $row['token_count'] : null,
+            id: (int) $row['id'],
+            createdAt: (string) $row['created_at'],
+            updatedAt: (string) $row['updated_at'],
+        );
+    }
+}

--- a/src/Search/RecallChunkSearchRepository.php
+++ b/src/Search/RecallChunkSearchRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Search;
+
+use LogicException;
+use NeneCorpus\Recall\RecallClientInterface;
+use NeneCorpus\Recall\RecallUnavailableException;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Hybrid search through NeNe Recall, with the LIKE search kept as a fallback.
+ *
+ * This repository holds no SQL. It composes the upstream client (the Recall
+ * layer) with {@see PdoChunkSearchGuard} (the PDO layer), so the layer rule
+ * "repositories do not speak HTTP" still holds — the HTTP lives upstream, as it
+ * does for NeNe Records. ADR 0007 Decision 2 is the record of that reading.
+ */
+final readonly class RecallChunkSearchRepository implements ChunkSearchRepositoryInterface
+{
+    public function __construct(
+        private RecallClientInterface $recall,
+        private PdoChunkSearchGuard $guard,
+        private ChunkSearchRepositoryInterface $fallback,
+        private RequestScopedOrgIdHolder $orgIdHolder,
+        private LoggerInterface $logger,
+        private bool $strict = false,
+    ) {
+    }
+
+    public function search(string $query, int $limit): array
+    {
+        try {
+            $hits = $this->recall->search($this->orgId(), $query, $limit);
+        } catch (RecallUnavailableException $exception) {
+            if ($this->strict) {
+                throw $exception;
+            }
+
+            // Returning nothing would let the chat answer with no evidence at all,
+            // which reads as "the corpus has nothing on this". Degrading to LIKE
+            // search is the honest failure — but it must never be silent.
+            $this->logger->warning(
+                'NeNe Recall search failed; falling back to LIKE search.',
+                ['reason' => $exception->getMessage()],
+            );
+
+            return $this->fallback->search($query, $limit);
+        }
+
+        $ranked = [];
+
+        foreach ($hits as $hit) {
+            // No external_id means the chunk was indexed by something other than
+            // this Corpus (Recall can be used standalone). We cannot cite it,
+            // because the text of record lives in our database.
+            if ($hit->externalId === null) {
+                continue;
+            }
+
+            $ranked[$hit->externalId] = $hit->score;
+        }
+
+        if ($ranked === []) {
+            return [];
+        }
+
+        $alive = $this->guard->filterAlive(array_keys($ranked));
+
+        $results = [];
+
+        foreach ($ranked as $chunkId => $score) {
+            if (!isset($alive[$chunkId])) {
+                continue;
+            }
+
+            $results[] = new ChunkSearchResult(chunk: $alive[$chunkId], score: $score);
+        }
+
+        return $results;
+    }
+
+    private function orgId(): int
+    {
+        $id = $this->orgIdHolder->getId();
+
+        if ($id === null) {
+            throw new LogicException('Organization ID is not resolved. Check OrgResolverMiddleware setup.');
+        }
+
+        return $id;
+    }
+}

--- a/src/Search/SearchServiceProvider.php
+++ b/src/Search/SearchServiceProvider.php
@@ -8,8 +8,10 @@ use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use Nene2\DependencyInjection\ContainerBuilder;
 use Nene2\DependencyInjection\ServiceProviderInterface;
+use NeneCorpus\Recall\RecallServiceProvider;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 final readonly class SearchServiceProvider implements ServiceProviderInterface
 {
@@ -30,7 +32,29 @@ final readonly class SearchServiceProvider implements ServiceProviderInterface
                         throw new LogicException('RequestScopedOrgIdHolder service is invalid.');
                     }
 
-                    return new PdoChunkSearchRepository($query, $orgIdHolder);
+                    $likeSearch = new PdoChunkSearchRepository($query, $orgIdHolder);
+                    $recallConfig = RecallServiceProvider::config($container);
+
+                    // Without NENE_RECALL_BASE_URL the LIKE search is the whole
+                    // search stack, exactly as before this integration existed.
+                    if (!$recallConfig->isConfigured()) {
+                        return $likeSearch;
+                    }
+
+                    $logger = $container->get(LoggerInterface::class);
+
+                    if (!$logger instanceof LoggerInterface) {
+                        throw new LogicException('Logger service is invalid.');
+                    }
+
+                    return new RecallChunkSearchRepository(
+                        recall: RecallServiceProvider::client($container),
+                        guard: new PdoChunkSearchGuard($query, $orgIdHolder),
+                        fallback: $likeSearch,
+                        orgIdHolder: $orgIdHolder,
+                        logger: $logger,
+                        strict: $recallConfig->strict,
+                    );
                 },
             )
             ->set(

--- a/tests/Chunk/IndexedChunkRepositoryTest.php
+++ b/tests/Chunk/IndexedChunkRepositoryTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Chunk;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\IndexedChunkRepository;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Recall\RecallUnavailableException;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\FakeRecallClient;
+use NeneCorpus\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class IndexedChunkRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
+
+    private FakeRecallClient $recall;
+
+    private IndexedChunkRepository $repository;
+
+    private PdoChunkRepository $inner;
+
+    private int $sourceId;
+
+    private int $documentId;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(7);
+        $this->recall = new FakeRecallClient();
+        $this->inner = new PdoChunkRepository($this->executor, $this->orgIdHolder, new FixedClock());
+        $this->repository = new IndexedChunkRepository($this->inner, $this->recall, $this->orgIdHolder);
+
+        $this->sourceId = (new PdoSourceRepository($this->executor, $this->orgIdHolder, new FixedClock()))->save(new Source(
+            name: 'Manual',
+            sourceType: SourceType::Text,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/manual.txt',
+        ));
+
+        $this->documentId = (new PdoDocumentRepository($this->executor, $this->orgIdHolder, new FixedClock()))->save(new Document(
+            sourceId: $this->sourceId,
+            title: 'Safety guide',
+            position: 0,
+        ));
+    }
+
+    private function chunk(int $index = 0): Chunk
+    {
+        return new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: '安全手順の説明',
+            chunkIndex: $index,
+            pageNumber: 4,
+            sectionLabel: '2.1',
+        );
+    }
+
+    public function test_save_indexes_the_chunk_under_its_generated_id(): void
+    {
+        $id = $this->repository->save($this->chunk());
+
+        self::assertCount(1, $this->recall->puts);
+        self::assertSame(7, $this->recall->puts[0]['org_id']);
+
+        $sent = $this->recall->puts[0]['chunks'][0];
+        // The id Recall gets back is the one the database just generated —
+        // annotating anything else would make the index unciteable.
+        self::assertSame($id, $sent->externalId);
+        self::assertSame('安全手順の説明', $sent->content);
+        self::assertSame(4, $sent->pageNumber);
+        self::assertSame('2.1', $sent->sectionLabel);
+    }
+
+    public function test_save_still_writes_to_the_database(): void
+    {
+        $id = $this->repository->save($this->chunk());
+
+        $stored = $this->inner->findById($id);
+
+        self::assertNotNull($stored);
+        self::assertSame('安全手順の説明', $stored->content);
+    }
+
+    public function test_delete_by_document_is_propagated(): void
+    {
+        $id = $this->repository->save($this->chunk());
+
+        $this->repository->deleteByDocumentId($this->documentId);
+
+        self::assertSame([['org_id' => 7, 'document_id' => $this->documentId]], $this->recall->documentDeletes);
+        self::assertNull($this->inner->findById($id));
+    }
+
+    public function test_delete_by_source_is_propagated(): void
+    {
+        $this->repository->save($this->chunk());
+
+        $this->repository->deleteBySourceId($this->sourceId);
+
+        self::assertSame([['org_id' => 7, 'source_id' => $this->sourceId]], $this->recall->sourceDeletes);
+        self::assertSame([], $this->inner->findByDocumentId($this->documentId));
+    }
+
+    public function test_reads_are_delegated_unchanged(): void
+    {
+        $id = $this->repository->save($this->chunk());
+
+        self::assertSame($id, $this->repository->findById($id)?->id);
+        self::assertCount(1, $this->repository->findByDocumentId($this->documentId));
+    }
+
+    public function test_recall_failure_on_save_is_not_swallowed(): void
+    {
+        $this->recall->willFail('NeNe Recall putChunks returned HTTP 503.');
+
+        // Ingestion must stop: a chunk that is stored but never indexed makes the
+        // corpus answer as if the document had never been uploaded.
+        $this->expectException(RecallUnavailableException::class);
+
+        $this->repository->save($this->chunk());
+    }
+
+    public function test_recall_failure_on_delete_is_not_swallowed(): void
+    {
+        $this->repository->save($this->chunk());
+        $this->recall->willFail('NeNe Recall deleteBySource returned HTTP 503.');
+
+        $this->expectException(RecallUnavailableException::class);
+
+        $this->repository->deleteBySourceId($this->sourceId);
+    }
+}

--- a/tests/Recall/HttpRecallClientTest.php
+++ b/tests/Recall/HttpRecallClientTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Recall;
+
+use NeneCorpus\Recall\HttpRecallClient;
+use NeneCorpus\Recall\RecallChunkInput;
+use NeneCorpus\Recall\RecallConfig;
+use NeneCorpus\Recall\RecallHttpResponse;
+use NeneCorpus\Recall\RecallUnavailableException;
+use NeneCorpus\Tests\Support\FakeRecallHttpTransport;
+use PHPUnit\Framework\TestCase;
+
+final class HttpRecallClientTest extends TestCase
+{
+    private const TOKEN = 'super-secret-recall-token';
+
+    private function config(?string $token = null, ?float $alpha = null, bool $strict = false): RecallConfig
+    {
+        return new RecallConfig(
+            baseUrl: 'http://recall.local:8080/',
+            bearerToken: $token,
+            timeoutSeconds: 10,
+            searchAlpha: $alpha,
+            strict: $strict,
+        );
+    }
+
+    public function test_search_maps_results_in_recall_order(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson(<<<'JSON'
+            {
+              "results": [
+                {"chunk_id": 91, "external_id": 12, "score": 0.81, "vector_score": 0.9, "lexical_score": 0.4},
+                {"chunk_id": 92, "external_id": 7, "score": 0.62}
+              ],
+              "embedder_id": "bge-m3:1024"
+            }
+            JSON);
+
+        $hits = (new HttpRecallClient($this->config(), $transport))->search(1, 'safety', 10);
+
+        self::assertCount(2, $hits);
+        self::assertSame(12, $hits[0]->externalId);
+        self::assertSame(91, $hits[0]->chunkId);
+        self::assertSame(0.81, $hits[0]->score);
+        self::assertSame(0.9, $hits[0]->vectorScore);
+        self::assertSame(7, $hits[1]->externalId);
+        self::assertNull($hits[1]->vectorScore);
+
+        $request = $transport->requests[0];
+        self::assertSame('POST', $request['method']);
+        self::assertSame('http://recall.local:8080/v1/search', $request['url']);
+        self::assertSame(
+            ['org_id' => 1, 'query' => 'safety', 'limit' => 10],
+            json_decode((string) $request['body'], true, 512, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function test_search_keeps_null_external_id(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson(
+            '{"results": [{"chunk_id": 5, "external_id": null, "score": 0.5}]}',
+        );
+
+        $hits = (new HttpRecallClient($this->config(), $transport))->search(1, 'safety', 10);
+
+        // Dropping it is the search repository's job; the client reports what came back.
+        self::assertCount(1, $hits);
+        self::assertNull($hits[0]->externalId);
+    }
+
+    public function test_search_sends_alpha_only_when_configured(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{"results": []}');
+
+        (new HttpRecallClient($this->config(alpha: 0.5), $transport))->search(3, 'safety', 4);
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) $transport->requests[0]['body'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(0.5, $payload['alpha']);
+    }
+
+    public function test_put_chunks_sends_corpus_id_as_external_id(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{"accepted": 1, "chunk_ids": [77]}');
+
+        (new HttpRecallClient($this->config(), $transport))->putChunks(2, [
+            new RecallChunkInput(
+                externalId: 41,
+                documentId: 8,
+                sourceId: 3,
+                chunkIndex: 0,
+                content: '安全手順',
+                pageNumber: 2,
+                sectionLabel: null,
+            ),
+        ]);
+
+        $request = $transport->requests[0];
+        self::assertSame('http://recall.local:8080/v1/chunks', $request['url']);
+
+        /** @var array{org_id: int, chunks: list<array<string, mixed>>} $payload */
+        $payload = json_decode((string) $request['body'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(2, $payload['org_id']);
+        self::assertSame(41, $payload['chunks'][0]['external_id']);
+        self::assertSame(2, $payload['chunks'][0]['page_number']);
+        self::assertNull($payload['chunks'][0]['section_label']);
+        // chunk_id belongs to Recall's own identity column and must never be sent.
+        self::assertArrayNotHasKey('chunk_id', $payload['chunks'][0]);
+    }
+
+    public function test_put_chunks_skips_the_call_when_there_is_nothing_to_send(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{}');
+
+        (new HttpRecallClient($this->config(), $transport))->putChunks(1, []);
+
+        self::assertSame([], $transport->requests);
+    }
+
+    public function test_delete_by_document_targets_the_document_scoped_route(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{"deleted": 3}');
+
+        (new HttpRecallClient($this->config(), $transport))->deleteByDocument(4, 19);
+
+        $request = $transport->requests[0];
+        self::assertSame('DELETE', $request['method']);
+        self::assertSame('http://recall.local:8080/v1/documents/19/chunks?org_id=4', $request['url']);
+    }
+
+    public function test_delete_by_source_targets_the_source_scoped_route(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{"deleted": 9}');
+
+        (new HttpRecallClient($this->config(), $transport))->deleteBySource(4, 21);
+
+        self::assertSame('http://recall.local:8080/v1/sources/21/chunks?org_id=4', $transport->requests[0]['url']);
+    }
+
+    public function test_bearer_header_is_sent_when_a_token_is_configured(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{"results": []}');
+
+        (new HttpRecallClient($this->config(self::TOKEN), $transport))->search(1, 'safety', 10);
+
+        self::assertContains('Authorization: Bearer ' . self::TOKEN, $transport->requests[0]['headers']);
+        self::assertContains('Content-Type: application/json', $transport->requests[0]['headers']);
+        self::assertContains('Accept: application/json', $transport->requests[0]['headers']);
+    }
+
+    public function test_no_authorization_header_without_a_token(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{"results": []}');
+
+        (new HttpRecallClient($this->config(), $transport))->search(1, 'safety', 10);
+
+        foreach ($transport->requests[0]['headers'] as $header) {
+            self::assertStringStartsNotWith('Authorization:', $header);
+        }
+    }
+
+    public function test_unauthorized_raises_unavailable_without_leaking_the_token(): void
+    {
+        $transport = new FakeRecallHttpTransport(
+            new RecallHttpResponse(401, '{"error": {"code": "unauthorized", "message": "bad token"}}'),
+        );
+
+        try {
+            (new HttpRecallClient($this->config(self::TOKEN), $transport))->search(1, 'safety', 10);
+            self::fail('Expected RecallUnavailableException.');
+        } catch (RecallUnavailableException $exception) {
+            self::assertStringContainsString('401', $exception->getMessage());
+            // The message reaches logs and operator-facing output; a token in it
+            // would be copied around forever.
+            self::assertStringNotContainsString(self::TOKEN, $exception->getMessage());
+        }
+    }
+
+    public function test_server_error_raises_unavailable(): void
+    {
+        $transport = new FakeRecallHttpTransport(new RecallHttpResponse(503, '{"error": {"code": "embedder_down"}}'));
+
+        $this->expectException(RecallUnavailableException::class);
+        $this->expectExceptionMessage('NeNe Recall search returned HTTP 503.');
+
+        (new HttpRecallClient($this->config(), $transport))->search(1, 'safety', 10);
+    }
+
+    public function test_connection_failure_raises_unavailable(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{}');
+        $transport->failWith('Could not resolve host: recall.local');
+
+        $this->expectException(RecallUnavailableException::class);
+
+        (new HttpRecallClient($this->config(), $transport))->putChunks(1, [
+            new RecallChunkInput(externalId: 1, documentId: 1, sourceId: 1, chunkIndex: 0, content: 'x'),
+        ]);
+    }
+
+    public function test_malformed_json_raises_unavailable(): void
+    {
+        $transport = FakeRecallHttpTransport::respondingJson('{"results": [');
+
+        $this->expectException(RecallUnavailableException::class);
+        $this->expectExceptionMessage('malformed JSON');
+
+        (new HttpRecallClient($this->config(), $transport))->search(1, 'safety', 10);
+    }
+
+    public function test_empty_body_on_delete_is_accepted(): void
+    {
+        $transport = new FakeRecallHttpTransport(new RecallHttpResponse(204, ''));
+
+        (new HttpRecallClient($this->config(), $transport))->deleteBySource(1, 2);
+
+        self::assertCount(1, $transport->requests);
+    }
+}

--- a/tests/Recall/RecallConfigTest.php
+++ b/tests/Recall/RecallConfigTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Recall;
+
+use NeneCorpus\Recall\RecallConfig;
+use PHPUnit\Framework\TestCase;
+
+final class RecallConfigTest extends TestCase
+{
+    /** @var array<string, string|null> */
+    private array $saved = [];
+
+    private const KEYS = [
+        'NENE_RECALL_BASE_URL',
+        'NENE_RECALL_BEARER_TOKEN',
+        'NENE_RECALL_TIMEOUT_SECONDS',
+        'NENE_RECALL_SEARCH_ALPHA',
+        'NENE_RECALL_STRICT',
+    ];
+
+    protected function setUp(): void
+    {
+        foreach (self::KEYS as $key) {
+            $value = $_ENV[$key] ?? null;
+            $this->saved[$key] = is_string($value) ? $value : null;
+            unset($_ENV[$key], $_SERVER[$key]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (self::KEYS as $key) {
+            unset($_ENV[$key], $_SERVER[$key]);
+
+            if ($this->saved[$key] !== null) {
+                $_ENV[$key] = $this->saved[$key];
+            }
+        }
+    }
+
+    public function test_is_not_configured_without_a_base_url(): void
+    {
+        self::assertFalse(RecallConfig::fromEnvironment()->isConfigured());
+    }
+
+    public function test_blank_base_url_is_not_configured(): void
+    {
+        $_ENV['NENE_RECALL_BASE_URL'] = '   ';
+
+        self::assertFalse(RecallConfig::fromEnvironment()->isConfigured());
+    }
+
+    public function test_reads_every_setting(): void
+    {
+        $_ENV['NENE_RECALL_BASE_URL'] = 'http://127.0.0.1:8080';
+        $_ENV['NENE_RECALL_BEARER_TOKEN'] = 'devtoken';
+        $_ENV['NENE_RECALL_TIMEOUT_SECONDS'] = '3';
+        $_ENV['NENE_RECALL_SEARCH_ALPHA'] = '0.8';
+        $_ENV['NENE_RECALL_STRICT'] = '1';
+
+        $config = RecallConfig::fromEnvironment();
+
+        self::assertTrue($config->isConfigured());
+        self::assertSame('devtoken', $config->bearerToken);
+        self::assertSame(3, $config->timeoutSeconds);
+        self::assertSame(0.8, $config->searchAlpha);
+        self::assertTrue($config->strict);
+        self::assertSame('http://127.0.0.1:8080/v1/search', $config->endpoint('/v1/search'));
+    }
+
+    public function test_trailing_slash_does_not_double_up(): void
+    {
+        $config = new RecallConfig(baseUrl: 'http://127.0.0.1:8080/');
+
+        self::assertSame('http://127.0.0.1:8080/v1/chunks', $config->endpoint('/v1/chunks'));
+    }
+
+    public function test_zero_timeout_falls_back_to_the_default(): void
+    {
+        $_ENV['NENE_RECALL_BASE_URL'] = 'http://127.0.0.1:8080';
+        $_ENV['NENE_RECALL_TIMEOUT_SECONDS'] = '0';
+
+        // curl reads 0 as "wait forever", which would hang ingestion.
+        self::assertSame(RecallConfig::DEFAULT_TIMEOUT_SECONDS, RecallConfig::fromEnvironment()->timeoutSeconds);
+    }
+
+    public function test_out_of_range_alpha_is_dropped(): void
+    {
+        $_ENV['NENE_RECALL_BASE_URL'] = 'http://127.0.0.1:8080';
+        $_ENV['NENE_RECALL_SEARCH_ALPHA'] = '1.4';
+
+        // Sending it would make Recall answer 400 and take search down with it.
+        self::assertNull(RecallConfig::fromEnvironment()->searchAlpha);
+    }
+
+    public function test_strict_defaults_to_off(): void
+    {
+        $_ENV['NENE_RECALL_BASE_URL'] = 'http://127.0.0.1:8080';
+
+        self::assertFalse(RecallConfig::fromEnvironment()->strict);
+    }
+}

--- a/tests/Recall/RecallReindexTest.php
+++ b/tests/Recall/RecallReindexTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Recall;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Organization\Organization;
+use NeneCorpus\Organization\OrganizationRepositoryInterface;
+use NeneCorpus\Recall\PdoRecallReindexReader;
+use NeneCorpus\Recall\RecallConfig;
+use NeneCorpus\Recall\RecallReindexCommand;
+use NeneCorpus\Recall\RecallReindexer;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\FakeRecallClient;
+use NeneCorpus\Tests\Support\FixedClock;
+use PHPUnit\Framework\TestCase;
+
+final class RecallReindexTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
+
+    private FakeRecallClient $recall;
+
+    private RecallReindexer $reindexer;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->recall = new FakeRecallClient();
+        $this->reindexer = new RecallReindexer(
+            $this->recall,
+            new PdoRecallReindexReader($this->executor, $this->orgIdHolder),
+            $this->orgIdHolder,
+        );
+    }
+
+    private function seedSource(int $orgId, string $name, bool $deleted = false): int
+    {
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId($orgId);
+
+        $sources = new PdoSourceRepository($this->executor, $holder, new FixedClock());
+        $sourceId = $sources->save(new Source(
+            name: $name,
+            sourceType: SourceType::Text,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/' . $name . '.txt',
+        ));
+
+        if ($deleted) {
+            $sources->softDelete($sourceId, '2026-09-02 12:00:00');
+        }
+
+        return $sourceId;
+    }
+
+    private function seedChunk(int $orgId, int $sourceId, string $content): int
+    {
+        $holder = new RequestScopedOrgIdHolder();
+        $holder->setId($orgId);
+
+        $documents = new PdoDocumentRepository($this->executor, $holder, new FixedClock());
+        $documentId = $documents->save(new Document(
+            sourceId: $sourceId,
+            title: $content,
+            position: 0,
+        ));
+
+        return (new PdoChunkRepository($this->executor, $holder, new FixedClock()))->save(new Chunk(
+            documentId: $documentId,
+            sourceId: $sourceId,
+            content: $content,
+        ));
+    }
+
+    public function test_reindex_clears_each_live_source_before_writing(): void
+    {
+        $sourceId = $this->seedSource(1, 'manual');
+        $chunkId = $this->seedChunk(1, $sourceId, '安全手順');
+
+        $report = $this->reindexer->reindex(1);
+
+        // Clearing first is the only way to drop ids Corpus no longer has:
+        // Recall exposes no "list every external_id you hold".
+        self::assertSame([['org_id' => 1, 'source_id' => $sourceId]], $this->recall->sourceDeletes);
+        self::assertSame(1, $report->clearedSources);
+        self::assertSame(1, $report->indexedChunks);
+        self::assertSame($chunkId, $this->recall->puts[0]['chunks'][0]->externalId);
+    }
+
+    public function test_reindex_skips_soft_deleted_sources(): void
+    {
+        $live = $this->seedSource(1, 'manual');
+        $this->seedChunk(1, $live, '生きている');
+
+        $archived = $this->seedSource(1, 'archived', deleted: true);
+        $this->seedChunk(1, $archived, '消したはずの内容');
+
+        $report = $this->reindexer->reindex(1);
+
+        self::assertSame(1, $report->clearedSources);
+        self::assertSame(1, $report->indexedChunks);
+        self::assertSame('生きている', $this->recall->puts[0]['chunks'][0]->content);
+    }
+
+    public function test_reindex_never_reads_another_org(): void
+    {
+        $mine = $this->seedSource(1, 'mine');
+        $this->seedChunk(1, $mine, '自組織の内容');
+
+        $theirs = $this->seedSource(2, 'theirs');
+        $this->seedChunk(2, $theirs, '他組織の内容');
+
+        $report = $this->reindexer->reindex(1);
+
+        self::assertSame(1, $report->indexedChunks);
+        self::assertSame('自組織の内容', $this->recall->puts[0]['chunks'][0]->content);
+        self::assertSame([['org_id' => 1, 'source_id' => $mine]], $this->recall->sourceDeletes);
+    }
+
+    public function test_reindex_reports_nothing_for_an_empty_org(): void
+    {
+        $report = $this->reindexer->reindex(9);
+
+        self::assertSame(9, $report->organizationId);
+        self::assertSame(0, $report->clearedSources);
+        self::assertSame(0, $report->indexedChunks);
+        self::assertSame([], $this->recall->puts);
+    }
+
+    public function test_command_reindexes_only_the_requested_org(): void
+    {
+        $mine = $this->seedSource(1, 'mine');
+        $this->seedChunk(1, $mine, '自組織の内容');
+        $this->seedChunk(2, $this->seedSource(2, 'theirs'), '他組織の内容');
+
+        $lines = [];
+        $exitCode = $this->command()->run(['--org=1'], static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        self::assertSame(0, $exitCode);
+        self::assertSame([1], array_column($this->recall->puts, 'org_id'));
+        self::assertNotSame([], $lines);
+    }
+
+    public function test_command_rejects_a_non_numeric_org(): void
+    {
+        $lines = [];
+        $exitCode = $this->command()->run(['--org=all'], static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        self::assertSame(1, $exitCode);
+        self::assertSame([], $this->recall->puts);
+        self::assertStringContainsString('--org must be a positive integer.', $lines[0]);
+    }
+
+    public function test_command_refuses_to_run_when_recall_is_not_configured(): void
+    {
+        $lines = [];
+        $exitCode = $this->command(configured: false)->run([], static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        self::assertSame(1, $exitCode);
+        self::assertSame([], $this->recall->sourceDeletes);
+        self::assertStringContainsString('NENE_RECALL_BASE_URL is not set', $lines[0]);
+    }
+
+    public function test_command_stops_at_the_first_failure(): void
+    {
+        $this->seedChunk(1, $this->seedSource(1, 'manual'), '安全手順');
+        $this->recall->willFail('NeNe Recall deleteBySource returned HTTP 503.');
+
+        $lines = [];
+        $exitCode = $this->command()->run([], static function (string $line) use (&$lines): void {
+            $lines[] = $line;
+        });
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Reindex aborted', $lines[count($lines) - 1]);
+    }
+
+    private function command(bool $configured = true): RecallReindexCommand
+    {
+        $organizations = $this->createStub(OrganizationRepositoryInterface::class);
+        $organizations->method('listAll')->willReturn([
+            new Organization(name: 'One', slug: 'one', plan: 'free', isActive: true, id: 1),
+        ]);
+
+        return new RecallReindexCommand(
+            new RecallConfig(baseUrl: $configured ? 'http://127.0.0.1:8080' : null),
+            $this->reindexer,
+            $organizations,
+        );
+    }
+}

--- a/tests/Recall/RecallWiringTest.php
+++ b/tests/Recall/RecallWiringTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Recall;
+
+use NeneCorpus\Chunk\ChunkRepositoryInterface;
+use NeneCorpus\Chunk\IndexedChunkRepository;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Http\RuntimeContainerFactory;
+use NeneCorpus\Recall\HttpRecallClient;
+use NeneCorpus\Recall\NullRecallClient;
+use NeneCorpus\Recall\RecallClientInterface;
+use NeneCorpus\Search\ChunkSearchRepositoryInterface;
+use NeneCorpus\Search\PdoChunkSearchRepository;
+use NeneCorpus\Search\RecallChunkSearchRepository;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * The switch itself, asserted through the real container.
+ *
+ * The promise of ADR 0007 is that an installation which never sets
+ * NENE_RECALL_BASE_URL keeps the search and ingestion it already had. That
+ * promise lives entirely in two service providers, so it is worth pinning: a
+ * future refactor that binds the Recall repository unconditionally would start
+ * making HTTP calls on every ingest of every existing deployment.
+ */
+final class RecallWiringTest extends TestCase
+{
+    private const KEYS = ['NENE_RECALL_BASE_URL', 'NENE_RECALL_BEARER_TOKEN', 'DB_ADAPTER', 'DB_NAME'];
+
+    /** @var array<string, string|null> */
+    private array $saved = [];
+
+    private string $databasePath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (self::KEYS as $key) {
+            $value = $_ENV[$key] ?? null;
+            $this->saved[$key] = is_string($value) ? $value : null;
+        }
+
+        $this->databasePath = sys_get_temp_dir() . '/nene-corpus-recall-wiring-' . uniqid('', true) . '.sqlite';
+
+        $this->setEnv('DB_ADAPTER', 'sqlite');
+        $this->setEnv('DB_NAME', $this->databasePath);
+        // Empty rather than unset: `.env` is loaded with Dotenv's immutable
+        // loader, which will not overwrite a key that is already present. A
+        // developer whose own `.env` points at a Recall instance must not make
+        // the "unconfigured" case silently test the configured one.
+        $this->setEnv('NENE_RECALL_BASE_URL', '');
+        $this->setEnv('NENE_RECALL_BEARER_TOKEN', '');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (self::KEYS as $key) {
+            $this->setEnv($key, $this->saved[$key]);
+        }
+
+        if (is_file($this->databasePath)) {
+            unlink($this->databasePath);
+        }
+
+        parent::tearDown();
+    }
+
+    private function setEnv(string $key, ?string $value): void
+    {
+        if ($value === null) {
+            unset($_ENV[$key], $_SERVER[$key]);
+
+            return;
+        }
+
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+
+    private function container(): ContainerInterface
+    {
+        return (new RuntimeContainerFactory())->create();
+    }
+
+    public function test_without_a_base_url_nothing_changes(): void
+    {
+        $container = $this->container();
+
+        self::assertInstanceOf(PdoChunkSearchRepository::class, $container->get(ChunkSearchRepositoryInterface::class));
+        self::assertInstanceOf(PdoChunkRepository::class, $container->get(ChunkRepositoryInterface::class));
+        self::assertInstanceOf(NullRecallClient::class, $container->get(RecallClientInterface::class));
+    }
+
+    public function test_a_base_url_swaps_both_the_search_and_the_write_path(): void
+    {
+        $this->setEnv('NENE_RECALL_BASE_URL', 'http://127.0.0.1:8080');
+
+        $container = $this->container();
+
+        self::assertInstanceOf(RecallChunkSearchRepository::class, $container->get(ChunkSearchRepositoryInterface::class));
+        self::assertInstanceOf(IndexedChunkRepository::class, $container->get(ChunkRepositoryInterface::class));
+        self::assertInstanceOf(HttpRecallClient::class, $container->get(RecallClientInterface::class));
+    }
+}

--- a/tests/Search/RecallChunkSearchRepositoryTest.php
+++ b/tests/Search/RecallChunkSearchRepositoryTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Search;
+
+use Nene2\Config\DatabaseConfig;
+use Nene2\Database\PdoConnectionFactory;
+use Nene2\Database\PdoDatabaseQueryExecutor;
+use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Chunk\PdoChunkRepository;
+use NeneCorpus\Document\Document;
+use NeneCorpus\Document\PdoDocumentRepository;
+use NeneCorpus\Recall\RecallSearchHit;
+use NeneCorpus\Recall\RecallUnavailableException;
+use NeneCorpus\Search\PdoChunkSearchGuard;
+use NeneCorpus\Search\PdoChunkSearchRepository;
+use NeneCorpus\Search\RecallChunkSearchRepository;
+use NeneCorpus\Source\PdoSourceRepository;
+use NeneCorpus\Source\Source;
+use NeneCorpus\Source\SourceStatus;
+use NeneCorpus\Source\SourceType;
+use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
+use NeneCorpus\Tests\Support\CorpusSchemaSetup;
+use NeneCorpus\Tests\Support\FakeRecallClient;
+use NeneCorpus\Tests\Support\FixedClock;
+use NeneCorpus\Tests\Support\RecordingLogger;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class RecallChunkSearchRepositoryTest extends TestCase
+{
+    private PdoDatabaseQueryExecutor $executor;
+
+    private RequestScopedOrgIdHolder $orgIdHolder;
+
+    private FakeRecallClient $recall;
+
+    private int $sourceId;
+
+    private int $documentId;
+
+    protected function setUp(): void
+    {
+        $this->executor = new PdoDatabaseQueryExecutor(new PdoConnectionFactory(new DatabaseConfig(
+            null,
+            'test',
+            'sqlite',
+            'localhost',
+            1,
+            ':memory:',
+            'nene_corpus',
+            '',
+            'utf8',
+        )));
+
+        CorpusSchemaSetup::create($this->executor);
+
+        $this->orgIdHolder = new RequestScopedOrgIdHolder();
+        $this->orgIdHolder->setId(1);
+        $this->recall = new FakeRecallClient();
+
+        $sources = new PdoSourceRepository($this->executor, $this->orgIdHolder, new FixedClock());
+        $this->sourceId = $sources->save(new Source(
+            name: 'Manual',
+            sourceType: SourceType::Pdf,
+            status: SourceStatus::Ready,
+            storagePath: 'storage/uploads/manual.pdf',
+        ));
+
+        $documents = new PdoDocumentRepository($this->executor, $this->orgIdHolder, new FixedClock());
+        $this->documentId = $documents->save(new Document(
+            sourceId: $this->sourceId,
+            title: 'Safety guide',
+            position: 0,
+        ));
+    }
+
+    private function saveChunk(string $content, int $index = 0, ?RequestScopedOrgIdHolder $holder = null): int
+    {
+        $repository = new PdoChunkRepository($this->executor, $holder ?? $this->orgIdHolder, new FixedClock());
+
+        return $repository->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: $content,
+            chunkIndex: $index,
+        ));
+    }
+
+    private function repository(bool $strict = false, ?RecordingLogger $logger = null): RecallChunkSearchRepository
+    {
+        return new RecallChunkSearchRepository(
+            recall: $this->recall,
+            guard: new PdoChunkSearchGuard($this->executor, $this->orgIdHolder),
+            fallback: new PdoChunkSearchRepository($this->executor, $this->orgIdHolder),
+            orgIdHolder: $this->orgIdHolder,
+            logger: $logger ?? new NullLogger(),
+            strict: $strict,
+        );
+    }
+
+    public function test_search_keeps_recall_ranking_not_database_order(): void
+    {
+        $first = $this->saveChunk('Equipment safety instructions.', 0);
+        $second = $this->saveChunk('Maintenance schedule.', 1);
+
+        // Recall ranks the second-inserted chunk highest.
+        $this->recall->willReturn([
+            new RecallSearchHit(chunkId: 900, externalId: $second, score: 0.91),
+            new RecallSearchHit(chunkId: 901, externalId: $first, score: 0.42),
+        ]);
+
+        $results = $this->repository()->search('安全', 10);
+
+        self::assertCount(2, $results);
+        self::assertSame($second, $results[0]->chunk->id);
+        self::assertSame(0.91, $results[0]->score);
+        self::assertSame($first, $results[1]->chunk->id);
+        self::assertSame(0.42, $results[1]->score);
+
+        // The chunk body comes from the database, not from the search backend.
+        self::assertSame('Maintenance schedule.', $results[0]->chunk->content);
+        self::assertNotNull($results[0]->chunk->createdAt);
+    }
+
+    public function test_search_passes_the_resolved_org_id_upstream(): void
+    {
+        $this->orgIdHolder->setId(42);
+        $this->recall->willReturn([]);
+
+        $this->repository()->search('安全', 5);
+
+        self::assertSame([['org_id' => 42, 'query' => '安全', 'limit' => 5]], $this->recall->searches);
+    }
+
+    public function test_results_without_external_id_are_dropped(): void
+    {
+        $id = $this->saveChunk('Equipment safety instructions.');
+
+        $this->recall->willReturn([
+            new RecallSearchHit(chunkId: 900, externalId: null, score: 0.99),
+            new RecallSearchHit(chunkId: 901, externalId: $id, score: 0.42),
+        ]);
+
+        $results = $this->repository()->search('安全', 10);
+
+        self::assertCount(1, $results);
+        self::assertSame($id, $results[0]->chunk->id);
+    }
+
+    public function test_soft_deleted_source_is_filtered_out(): void
+    {
+        $id = $this->saveChunk('Equipment safety instructions.');
+
+        (new PdoSourceRepository($this->executor, $this->orgIdHolder, new FixedClock()))
+            ->softDelete($this->sourceId, '2026-09-02 12:00:00');
+
+        $this->recall->willReturn([new RecallSearchHit(chunkId: 900, externalId: $id, score: 0.9)]);
+
+        self::assertSame([], $this->repository()->search('安全', 10));
+    }
+
+    public function test_soft_deleted_document_is_filtered_out(): void
+    {
+        $id = $this->saveChunk('Equipment safety instructions.');
+
+        (new PdoDocumentRepository($this->executor, $this->orgIdHolder, new FixedClock()))
+            ->softDelete($this->documentId, '2026-09-02 12:00:00');
+
+        $this->recall->willReturn([new RecallSearchHit(chunkId: 900, externalId: $id, score: 0.9)]);
+
+        self::assertSame([], $this->repository()->search('安全', 10));
+    }
+
+    public function test_chunk_of_another_org_is_dropped_even_when_recall_returns_it(): void
+    {
+        $otherOrg = new RequestScopedOrgIdHolder();
+        $otherOrg->setId(2);
+
+        $ownChunkId = $this->saveChunk('Org one safety manual.', 0);
+        $foreignChunkId = $this->saveChunk('Org two salary table.', 1, $otherOrg);
+
+        // A backend bug, a stale index, or two deployments sharing one Recall all
+        // look like this. The guard is the reason it cannot become an answer.
+        $this->recall->willReturn([
+            new RecallSearchHit(chunkId: 900, externalId: $foreignChunkId, score: 0.99),
+            new RecallSearchHit(chunkId: 901, externalId: $ownChunkId, score: 0.10),
+        ]);
+
+        $results = $this->repository()->search('安全', 10);
+
+        self::assertCount(1, $results);
+        self::assertSame($ownChunkId, $results[0]->chunk->id);
+    }
+
+    public function test_failure_falls_back_to_like_search_and_logs_a_warning(): void
+    {
+        $this->saveChunk('Equipment safety instructions.');
+        $this->recall->willFail();
+
+        $logger = new RecordingLogger();
+        $results = $this->repository(strict: false, logger: $logger)->search('safety', 10);
+
+        self::assertCount(1, $results);
+        self::assertSame(1.0, $results[0]->score);
+        self::assertTrue($logger->hasWarningContaining('falling back to LIKE search'));
+    }
+
+    public function test_failure_is_raised_when_strict_is_on(): void
+    {
+        $this->saveChunk('Equipment safety instructions.');
+        $this->recall->willFail();
+
+        $this->expectException(RecallUnavailableException::class);
+
+        $this->repository(strict: true)->search('safety', 10);
+    }
+
+    public function test_empty_recall_result_does_not_touch_the_database(): void
+    {
+        $this->saveChunk('Equipment safety instructions.');
+        $this->recall->willReturn([]);
+
+        // An empty hybrid result means "nothing matched" — it must not silently
+        // become a LIKE search, or the two backends would be indistinguishable.
+        self::assertSame([], $this->repository()->search('safety', 10));
+    }
+}

--- a/tests/Support/FakeRecallClient.php
+++ b/tests/Support/FakeRecallClient.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use NeneCorpus\Recall\RecallChunkInput;
+use NeneCorpus\Recall\RecallClientInterface;
+use NeneCorpus\Recall\RecallSearchHit;
+use NeneCorpus\Recall\RecallUnavailableException;
+
+/**
+ * Stands in for a Recall server in repository-level tests.
+ */
+final class FakeRecallClient implements RecallClientInterface
+{
+    /** @var list<RecallSearchHit> */
+    private array $hits = [];
+
+    private ?string $failure = null;
+
+    /** @var list<array{org_id: int, query: string, limit: int}> */
+    public array $searches = [];
+
+    /** @var list<array{org_id: int, chunks: list<RecallChunkInput>}> */
+    public array $puts = [];
+
+    /** @var list<array{org_id: int, document_id: int}> */
+    public array $documentDeletes = [];
+
+    /** @var list<array{org_id: int, source_id: int}> */
+    public array $sourceDeletes = [];
+
+    /**
+     * @param list<RecallSearchHit> $hits
+     */
+    public function willReturn(array $hits): void
+    {
+        $this->hits = $hits;
+    }
+
+    public function willFail(string $message = 'NeNe Recall search returned HTTP 503.'): void
+    {
+        $this->failure = $message;
+    }
+
+    public function search(int $orgId, string $query, int $limit): array
+    {
+        $this->searches[] = ['org_id' => $orgId, 'query' => $query, 'limit' => $limit];
+
+        $this->guard();
+
+        return $this->hits;
+    }
+
+    public function putChunks(int $orgId, array $chunks): void
+    {
+        $this->puts[] = ['org_id' => $orgId, 'chunks' => $chunks];
+
+        $this->guard();
+    }
+
+    public function deleteByDocument(int $orgId, int $documentId): void
+    {
+        $this->documentDeletes[] = ['org_id' => $orgId, 'document_id' => $documentId];
+
+        $this->guard();
+    }
+
+    public function deleteBySource(int $orgId, int $sourceId): void
+    {
+        $this->sourceDeletes[] = ['org_id' => $orgId, 'source_id' => $sourceId];
+
+        $this->guard();
+    }
+
+    private function guard(): void
+    {
+        if ($this->failure !== null) {
+            throw new RecallUnavailableException($this->failure);
+        }
+    }
+}

--- a/tests/Support/FakeRecallHttpTransport.php
+++ b/tests/Support/FakeRecallHttpTransport.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use NeneCorpus\Recall\RecallHttpResponse;
+use NeneCorpus\Recall\RecallHttpTransportInterface;
+use NeneCorpus\Recall\RecallUnavailableException;
+
+/**
+ * Records what the client sent and replays canned responses.
+ *
+ * This is the substitution point that ADR 0007 required the client to have; it
+ * is what lets the HTTP contract be tested without a Recall server.
+ */
+final class FakeRecallHttpTransport implements RecallHttpTransportInterface
+{
+    /** @var list<array{method: string, url: string, headers: list<string>, body: ?string}> */
+    public array $requests = [];
+
+    /** @var list<RecallHttpResponse> */
+    private array $responses = [];
+
+    private ?string $failure = null;
+
+    public function __construct(RecallHttpResponse ...$responses)
+    {
+        $this->responses = array_values($responses);
+    }
+
+    public static function respondingJson(string $json, int $statusCode = 200): self
+    {
+        return new self(new RecallHttpResponse($statusCode, $json));
+    }
+
+    /**
+     * Makes every call fail the way an unreachable host does.
+     */
+    public function failWith(string $detail): void
+    {
+        $this->failure = $detail;
+    }
+
+    public function post(string $url, array $headers, string $body): RecallHttpResponse
+    {
+        return $this->record('POST', $url, $headers, $body);
+    }
+
+    public function delete(string $url, array $headers): RecallHttpResponse
+    {
+        return $this->record('DELETE', $url, $headers, null);
+    }
+
+    /**
+     * @param list<string> $headers
+     */
+    private function record(string $method, string $url, array $headers, ?string $body): RecallHttpResponse
+    {
+        $this->requests[] = ['method' => $method, 'url' => $url, 'headers' => $headers, 'body' => $body];
+
+        if ($this->failure !== null) {
+            throw RecallUnavailableException::transport('request', $this->failure);
+        }
+
+        return array_shift($this->responses) ?? new RecallHttpResponse(200, '{}');
+    }
+}

--- a/tests/Support/RecordingLogger.php
+++ b/tests/Support/RecordingLogger.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NeneCorpus\Tests\Support;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+/**
+ * Minimal PSR-3 spy. psr/log 3 dropped its own `TestLogger`, and a warning that
+ * has to be observable ("the search silently degraded") deserves an assertion
+ * rather than a NullLogger.
+ */
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var list<array{level: string, message: string, context: array<mixed>}> */
+    public array $records = [];
+
+    /**
+     * @param mixed         $level
+     * @param array<mixed>  $context
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => is_scalar($level) ? (string) $level : 'unknown',
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    public function hasWarningContaining(string $needle): bool
+    {
+        foreach ($this->records as $record) {
+            if ($record['level'] === 'warning' && str_contains($record['message'], $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #392

検索バックエンドを **NeNe Recall**（Go・自己ホスト・費用0円）に差し替えられるようにする。設計は本 PR で追加する **ADR 0007**、契約の正本は Recall 側 [ADR 0020](https://github.com/hideyukiMORI/nene-recall/blob/main/docs/adr/0020-phase2-corpus-integration-contract.md)。

## 🔴 未設定なら振る舞いは 1 ミリも変わらない

`NENE_RECALL_BASE_URL` が空なら、従来どおり `PdoChunkSearchRepository`（LIKE 検索）と素の `PdoChunkRepository` が束縛される。上流への書き込みは一切発生しない。この約束は2つの Service Provider にしか無いので、**実コンテナに対するテスト**（`RecallWiringTest`）で固定した。

## 変更の中身

| 追加 | 役割 |
| --- | --- |
| `src/Recall/` | `RecallConfig` / `RecallClientInterface` / `HttpRecallClient` / `NullRecallClient` / `CurlRecallHttpTransport` / `RecallUnavailableException` ほか。`src/Upstream/` と同じ位置づけ |
| `src/Search/RecallChunkSearchRepository` ＋ `PdoChunkSearchGuard` | Recall の順位を保ったまま `external_id` を **org スコープと soft delete の join** に通す |
| `src/Chunk/IndexedChunkRepository` | `save` / `deleteByDocumentId` / `deleteBySourceId` を Recall へ同期書き込みするデコレータ |
| `bin/console recall:reindex [--org=<id>]` | 取りこぼしの回収経路 |

### 設計上の要点

- 🔴 **HTTP の実行だけを `RecallHttpTransportInterface` に分離した。** `HttpNeneRecordsClient` にテストが1本も無い原因は「差し替え点が無いこと」で、同じ形をもう一度作れば同じ穴が空く。この seam のおかげでクライアントの契約（Bearer・401・5xx・接続失敗・JSON 不正）を Recall サーバ無しで検証できている。
- 🔴 **層規約に触れていない。** `RecallChunkSearchRepository` は SQL を1行も持たず、上流クライアント（`Recall/`）と `PdoChunkSearchGuard`（`Pdo*` 層）を合成する。禁止事項は「Repository が HTTP を直に叩くこと」であって上流クライアントへの委譲ではない。この読みを CLAUDE.md の層の表に1行足した（ADR 0007 が根拠）。
- 🔴 **`PdoChunkSearchGuard` は org を引数で受け取らない。** `RequestScopedOrgIdHolder` から自分で引く。引数にすると「どこかで正しい org が渡されている」という前提が SQL の外へ出てしまう（絶対禁止パターン「`RequestScopedOrgIdHolder` を経由しない SQL」）。ADR 0007 の下書きから変えた点で、理由は ADR 内に記録した。
- 🔴 **デコレータの配線点は2つある。** コンテナの `ChunkRepositoryInterface` 束縛だけでは足りず、`IngestionServiceProvider::chunkRepositoryFactory()` の `Closure`（トランザクションの executor をその場で受ける経路）にも掛けている。片方だけだと **PDF 取り込みの chunk だけ索引に載らない**——検索が静かに欠けるだけなので症状が出るまで気づけない。
- 取り込み時の Recall 失敗は **fail-loud**（静かに索引が欠けるより止まる）。検索の失敗は **warning ログ＋LIKE 検索へフォールバック**（`NENE_RECALL_STRICT=1` で例外）。
- `bin/console` は本リポ初の CLI 入口なので、**PHPStan と CS-Fixer の対象に追加した**（`tools/*.php` は composer script から呼ぶ開発者向けの検査で、運用コマンドの置き場ではない）。ゲートの外に置いた入口は、いずれ検査されていないことを忘れられる。

## テスト

`composer check` 緑（**472 tests / 1,491 assertions**・PHPStan level8 No errors・CS-Fixer 差分なし・OpenAPI / MCP / conformance OK）。追加は 47 件。

- `tests/Recall/HttpRecallClientTest` — 正常・`external_id` null・alpha の有無・401・5xx・接続失敗・JSON 不正・Bearer ヘッダの有無。**トークンが例外メッセージに出ないこと**を明示的に検証
- `tests/Search/RecallChunkSearchRepositoryTest` — 順位保持・`external_id` null を捨てる・soft delete された source / document を落とす・**別 org の chunk id を Recall が返してもガードで落ちる**・フォールバック（warning ログ付き）・strict で例外
- `tests/Chunk/IndexedChunkRepositoryTest` — `external_id` = 採番された id・delete の伝播・Recall 失敗が握り潰されないこと
- `tests/Recall/RecallReindexTest` / `RecallWiringTest`
- 既存の `SearchChunksUseCaseTest` / `PdoChunkSearchRepositoryTest` は**無変更で通る**

## ⚠️ 疎通は未実施

Recall 側の契約実装（`external_id`・`DELETE /v1/documents/{id}/chunks`・Bearer）は **Recall の `main` にまだ入っていない**（`docs/openapi/openapi.yaml` は `chunk_id` を 400 にする Phase 1 のまま）。本 PR は **契約（Recall ADR 0020 §Decision）に対して**実装し、HTTP は fake transport で検証している。実サーバとの往復は Recall 側の着地後に別途行う。

## セルフレビューチェックリスト

- `docs/review/backend-api.md`（UseCase / Repository の変更）
- `docs/review/database.md`（`PdoChunkSearchGuard` / `PdoRecallReindexReader` の SQL）
- `docs/review/docs-policy.md`（ADR 0007・CLAUDE.md）

OpenAPI は無変更（検索は Claude ツール `search_corpus` 専用で HTTP ルートに出ない）。マイグレーションも無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016nBY5HWr51tc9ahxnjGFBf
