### PR TITLE
fix(search): failed な source のチャンクを検索と再索引の対象から外す (#394)

### DIFF
--- a/docs/adr/0007-recall-search-backend.md
+++ b/docs/adr/0007-recall-search-backend.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed（2026-09-02）
+Accepted（2026-09-03）— 施主判断で PR #393 が main にマージされた（`ba3343a`・2026-09-03）。
 
 ## Context
 
@@ -40,7 +40,11 @@ CLAUDE.md の層の表に「Repository は上流クライアント interface を
 
 - org は `RequestScopedOrgIdHolder::getId()`。未解決は既存と同じ `LogicException`。
 - Recall の結果（`external_id` = Corpus の `chunks.id`）を `PdoChunkSearchGuard::filterAlive(list<int> $chunkIds): array<int, Chunk>` に通す。
-  1本の SQL: `chunks c JOIN sources s ON … AND s.is_deleted = 0 JOIN documents d ON … AND d.is_deleted = 0 WHERE c.id IN (…) AND c.organization_id = ?`。
+  1本の SQL: `chunks c JOIN sources s ON … AND s.is_deleted = 0 AND s.status = 'ready' JOIN documents d ON … AND d.is_deleted = 0 WHERE c.id IN (…) AND c.organization_id = ?`。
+  🔴 **二段フィルタは soft delete に加えて取り込み状態も見る**（#394 で追加）。取り込みは chunk を書いてから
+  status を Ready に上げるので、失敗した source は半端な chunk 行を持ったまま `failed` で残る。
+  条件の実体は `SourceStatus::SEARCHABLE_SOURCE_SQL` の1箇所で、`PdoChunkSearchRepository` と
+  `PdoRecallReindexReader::listAliveChunks` も同じ定数を使う。
   返る `Chunk` は DB 行（`createdAt`/`updatedAt`/`tokenCount` が埋まる）。id をキーにした配列で返し、Recall の順位は呼び出し側が
   `ChunkSearchResult(chunk, score)` の並びとして復元する。
   🔴 **org を引数で受け取らず、ガード自身が `RequestScopedOrgIdHolder` から引く。** CLAUDE.md の絶対禁止パターンに
@@ -69,6 +73,9 @@ Recall の失敗は **fail-loud**（`RecallUnavailableException` をそのまま
 PHPStan と CS-Fixer の対象に追加した**——ゲートの外に置いた入口は、いずれ検査されていないことを忘れられる。
 
 読み取りの SQL は `src/Recall/PdoRecallReindexReader.php`（`Pdo` 接頭辞・holder 経由の org スコープ）。
+🔴 **2つのメソッドの絞り込みは意図的に非対称である**（#394）。`listAliveChunks`（投入する側）は `ready` 以外を落とすが、
+`listAliveSourceIds`（先に `deleteBySource` を打つ掃除の側）は落とさない。掃除の側を絞ると、
+取り込みに失敗した source の chunk が **Recall に残ったまま二度と消えなくなる。**
 `ChunkRepositoryInterface` に全走査を足さなかったのは、そこに足すと**全実装（PDO・デコレータ）に、
 運用コマンドのためだけのメソッドが増える**からである。再索引は保守作業であって chunk の永続化の契約ではない。
 

--- a/src/Recall/PdoRecallReindexReader.php
+++ b/src/Recall/PdoRecallReindexReader.php
@@ -7,12 +7,20 @@ namespace NeneCorpus\Recall;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 /**
  * SQL for `recall:reindex`. Org-scoped through {@see RequestScopedOrgIdHolder}
  * like every other Pdo* class, so the reindex of one tenant can never read
  * another one's chunks.
+ *
+ * 🔴 The two methods filter differently on purpose (#394).
+ * `listAliveSourceIds()` is the **clear** list — {@see RecallReindexer} sends a
+ * `deleteBySource` for every id it returns before writing anything — so it stays
+ * as wide as possible. `listAliveChunks()` is the **write** list and drops
+ * sources that are not `ready`. Narrowing the clear list the same way would leave
+ * a failed source's chunks sitting in Recall with nothing left to ever delete them.
  */
 final readonly class PdoRecallReindexReader implements RecallReindexReaderInterface
 {
@@ -44,7 +52,7 @@ final readonly class PdoRecallReindexReader implements RecallReindexReaderInterf
         $rows = $this->query->fetchAll(
             'SELECT ' . self::SELECT_COLUMNS . ' '
             . 'FROM chunks c '
-            . 'INNER JOIN sources s ON s.id = c.source_id AND s.is_deleted = 0 '
+            . 'INNER JOIN sources s ON s.id = c.source_id AND ' . SourceStatus::SEARCHABLE_SOURCE_SQL . ' '
             . 'INNER JOIN documents d ON d.id = c.document_id AND d.is_deleted = 0 '
             . 'WHERE c.organization_id = ? AND c.id > ? '
             . 'ORDER BY c.id ASC '

--- a/src/Search/PdoChunkSearchGuard.php
+++ b/src/Search/PdoChunkSearchGuard.php
@@ -7,6 +7,7 @@ namespace NeneCorpus\Search;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
 /**
@@ -24,9 +25,13 @@ use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
  *    hard-deleted, and the delete is pushed to Recall separately. If that push is
  *    ever missed, deleted material would come back; the `is_deleted = 0` joins
  *    are the second line of defence, matching {@see PdoChunkSearchRepository}.
+ * 3. **Ingestion state.** A source that is not `ready` can still own rows in
+ *    `chunks` — a failed run leaves what it had already committed behind. Those
+ *    rows are a half-written corpus, so `s.status` is checked too (#394).
+ *    See {@see SourceStatus::SEARCHABLE}.
  *
- * Both faults are invisible in single-tenant development, which is exactly why
- * the filter is not optional.
+ * All three faults are invisible in single-tenant, happy-path development, which
+ * is exactly why the filter is not optional.
  */
 final readonly class PdoChunkSearchGuard
 {
@@ -59,7 +64,7 @@ final readonly class PdoChunkSearchGuard
         $rows = $this->query->fetchAll(
             'SELECT ' . self::SELECT_COLUMNS . ' '
             . 'FROM chunks c '
-            . 'INNER JOIN sources s ON s.id = c.source_id AND s.is_deleted = 0 '
+            . 'INNER JOIN sources s ON s.id = c.source_id AND ' . SourceStatus::SEARCHABLE_SOURCE_SQL . ' '
             . 'INNER JOIN documents d ON d.id = c.document_id AND d.is_deleted = 0 '
             . 'WHERE c.id IN (' . $placeholders . ') AND c.organization_id = ?',
             $params,

--- a/src/Search/PdoChunkSearchRepository.php
+++ b/src/Search/PdoChunkSearchRepository.php
@@ -7,8 +7,14 @@ namespace NeneCorpus\Search;
 use LogicException;
 use Nene2\Database\DatabaseQueryExecutorInterface;
 use NeneCorpus\Chunk\Chunk;
+use NeneCorpus\Source\SourceStatus;
 use NeneCorpus\Tenancy\Context\RequestScopedOrgIdHolder;
 
+/**
+ * The join to `sources` carries two conditions, not one: the source must not be
+ * soft-deleted **and** it must be `ready`. See {@see SourceStatus::SEARCHABLE}
+ * for why a `failed` source can still own rows in `chunks`.
+ */
 final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryInterface
 {
     private const LIKE_ESCAPE_CHAR = '!';
@@ -69,7 +75,7 @@ final readonly class PdoChunkSearchRepository implements ChunkSearchRepositoryIn
         $rows = $this->query->fetchAll(
             'SELECT ' . self::SELECT_COLUMNS . ', (' . $scoreExpression . ') AS relevance_score '
             . 'FROM chunks c '
-            . 'INNER JOIN sources s ON s.id = c.source_id AND s.is_deleted = 0 '
+            . 'INNER JOIN sources s ON s.id = c.source_id AND ' . SourceStatus::SEARCHABLE_SOURCE_SQL . ' '
             . 'INNER JOIN documents d ON d.id = c.document_id AND d.is_deleted = 0 '
             . 'WHERE (' . $whereExpression . ') AND c.organization_id = ? '
             . 'ORDER BY relevance_score DESC, c.id ASC '

--- a/src/Source/SourceStatus.php
+++ b/src/Source/SourceStatus.php
@@ -10,4 +10,28 @@ enum SourceStatus: string
     case Processing = 'processing';
     case Ready = 'ready';
     case Failed = 'failed';
+
+    /**
+     * The only status whose chunks may be read by search or pushed to an index (#394).
+     *
+     * Ingestion writes chunks **while the source is still `processing`** and only then
+     * raises it to `ready`; on failure it sets `failed` and leaves the rows it already
+     * committed behind (text/CSV run outside a transaction, and a reindex has already
+     * cleared the previous chunks by then). So a source that is not `ready` may well
+     * own rows in `chunks`, and those rows are a half-written corpus.
+     *
+     * This is an allow list rather than `<> 'failed'` on purpose: a status added later
+     * is excluded until someone decides it is searchable, instead of silently joining
+     * the results.
+     */
+    public const SEARCHABLE = self::Ready;
+
+    /**
+     * Join predicate shared by every query that reads chunks through their source.
+     *
+     * The alias is fixed to `s` because all three call sites already spell the join
+     * that way; keeping the literal in one place is what stops the three from drifting
+     * apart again — they drifted into agreement by copy-paste last time.
+     */
+    public const SEARCHABLE_SOURCE_SQL = "s.is_deleted = 0 AND s.status = '" . self::SEARCHABLE->value . "'";
 }

--- a/tests/Recall/RecallReindexTest.php
+++ b/tests/Recall/RecallReindexTest.php
@@ -62,8 +62,12 @@ final class RecallReindexTest extends TestCase
         );
     }
 
-    private function seedSource(int $orgId, string $name, bool $deleted = false): int
-    {
+    private function seedSource(
+        int $orgId,
+        string $name,
+        bool $deleted = false,
+        SourceStatus $status = SourceStatus::Ready,
+    ): int {
         $holder = new RequestScopedOrgIdHolder();
         $holder->setId($orgId);
 
@@ -71,7 +75,7 @@ final class RecallReindexTest extends TestCase
         $sourceId = $sources->save(new Source(
             name: $name,
             sourceType: SourceType::Text,
-            status: SourceStatus::Ready,
+            status: $status,
             storagePath: 'storage/uploads/' . $name . '.txt',
         ));
 
@@ -129,6 +133,37 @@ final class RecallReindexTest extends TestCase
         self::assertSame(1, $report->clearedSources);
         self::assertSame(1, $report->indexedChunks);
         self::assertSame('生きている', $this->recall->puts[0]['chunks'][0]->content);
+    }
+
+    public function test_reindex_does_not_write_chunks_of_a_failed_source(): void
+    {
+        $live = $this->seedSource(1, 'manual');
+        $this->seedChunk(1, $live, '生きている');
+
+        $broken = $this->seedSource(1, 'broken', status: SourceStatus::Failed);
+        $this->seedChunk(1, $broken, '取り込みに失敗した途中の内容');
+
+        $report = $this->reindexer->reindex(1);
+
+        self::assertSame(1, $report->indexedChunks);
+        self::assertSame('生きている', $this->recall->puts[0]['chunks'][0]->content);
+    }
+
+    public function test_reindex_still_clears_a_failed_source_in_recall(): void
+    {
+        // The write list drops failed sources; the clear list must not. The
+        // decorator pushes each chunk to Recall as it is saved, so a run that
+        // failed halfway has already put rows there. If the reindex stopped
+        // sending `deleteBySource` for that source, nothing ever would.
+        $broken = $this->seedSource(1, 'broken', status: SourceStatus::Failed);
+        $this->seedChunk(1, $broken, '取り込みに失敗した途中の内容');
+
+        $report = $this->reindexer->reindex(1);
+
+        self::assertSame([['org_id' => 1, 'source_id' => $broken]], $this->recall->sourceDeletes);
+        self::assertSame(1, $report->clearedSources);
+        self::assertSame(0, $report->indexedChunks);
+        self::assertSame([], $this->recall->puts);
     }
 
     public function test_reindex_never_reads_another_org(): void

--- a/tests/Search/PdoChunkSearchRepositoryTest.php
+++ b/tests/Search/PdoChunkSearchRepositoryTest.php
@@ -148,6 +148,59 @@ final class PdoChunkSearchRepositoryTest extends TestCase
         self::assertSame([], $results);
     }
 
+    public function test_search_excludes_chunks_of_a_failed_source(): void
+    {
+        // Ingestion writes chunks before it raises the source to `ready`, and on
+        // failure it only flips the status — the rows it already committed stay.
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Safety instructions from a half-finished ingestion.',
+            chunkIndex: 0,
+        ));
+
+        $this->markSourceFailed();
+
+        $results = (new PdoChunkSearchRepository($this->executor, $this->orgIdHolder))->search('safety', 10);
+
+        self::assertSame([], $results);
+    }
+
+    public function test_search_excludes_chunks_of_a_source_still_processing(): void
+    {
+        // A reindex clears the old chunks first, so mid-run the corpus for this
+        // source is incomplete by definition. `ready` is an allow list, not
+        // "anything but failed".
+        $this->chunks->save(new Chunk(
+            documentId: $this->documentId,
+            sourceId: $this->sourceId,
+            content: 'Safety instructions being reindexed right now.',
+            chunkIndex: 0,
+        ));
+
+        $this->markSourceStatus(SourceStatus::Processing);
+
+        $results = (new PdoChunkSearchRepository($this->executor, $this->orgIdHolder))->search('safety', 10);
+
+        self::assertSame([], $results);
+    }
+
+    private function markSourceFailed(): void
+    {
+        $this->markSourceStatus(SourceStatus::Failed);
+    }
+
+    private function markSourceStatus(SourceStatus $status): void
+    {
+        (new PdoSourceRepository($this->executor, $this->orgIdHolder, new FixedClock()))->update(new Source(
+            name: 'Manual',
+            sourceType: SourceType::Pdf,
+            status: $status,
+            storagePath: 'storage/uploads/manual.pdf',
+            id: $this->sourceId,
+        ));
+    }
+
     public function test_search_org_isolation_excludes_other_org_chunks(): void
     {
         $org2Holder = new RequestScopedOrgIdHolder();

--- a/tests/Search/RecallChunkSearchRepositoryTest.php
+++ b/tests/Search/RecallChunkSearchRepositoryTest.php
@@ -173,6 +173,31 @@ final class RecallChunkSearchRepositoryTest extends TestCase
         self::assertSame([], $this->repository()->search('安全', 10));
     }
 
+    public function test_chunk_of_a_failed_source_is_dropped_even_when_recall_returns_it(): void
+    {
+        $id = $this->saveChunk('Equipment safety instructions.');
+
+        // The ingestion run died after committing this chunk. The write-through
+        // decorator had already pushed it to Recall, and nothing deletes it there
+        // — so Recall keeps returning it. The guard is what stops it.
+        $this->markSourceStatus(SourceStatus::Failed);
+
+        $this->recall->willReturn([new RecallSearchHit(chunkId: 900, externalId: $id, score: 0.9)]);
+
+        self::assertSame([], $this->repository()->search('安全', 10));
+    }
+
+    private function markSourceStatus(SourceStatus $status): void
+    {
+        (new PdoSourceRepository($this->executor, $this->orgIdHolder, new FixedClock()))->update(new Source(
+            name: 'Manual',
+            sourceType: SourceType::Pdf,
+            status: $status,
+            storagePath: 'storage/uploads/manual.pdf',
+            id: $this->sourceId,
+        ));
+    }
+
     public function test_chunk_of_another_org_is_dropped_even_when_recall_returns_it(): void
     {
         $otherOrg = new RequestScopedOrgIdHolder();


### PR DESCRIPTION
Closes #394

## 何を直したか

`chunks` を `sources` 経由で読む 3 箇所の join が `is_deleted = 0` しか見ておらず、
**取り込みに失敗した（`status = 'failed'`）source の半端なチャンクが検索と再索引の対象に入っていた。**

| # | 場所 | 症状 |
| --- | --- | --- |
| 1 | `PdoChunkSearchRepository::search` | 既存の LIKE 検索が failed のチャンクを返す |
| 2 | `PdoChunkSearchGuard::filterAlive` | Recall 経路の生存フィルタが素通しする |
| 3 | `PdoRecallReindexReader::listAliveChunks` | `recall:reindex` が failed のチャンクを Recall へ投入する |

## なぜ failed な source にチャンクが残るのか（コードで確認した）

`SourceStatus` は `pending` / `processing` / `ready` / `failed` の4状態。取り込みは
**チャンクを書いてから status を Ready に上げる**順序である。

- `CreateTextSourceUseCase` / `CreateCsvSourceUseCase` — `Processing` で source を作り、
  document / chunks を save してから `Ready` に update。例外を捕まえると `Failed` に update して
  再送出するだけで、**書き終えた行は消さない**。text / CSV 経路はトランザクションを張っていない
  （#393 の 2 番目のコミットが指摘した点）ので、コミット済みの行はそのまま残る。
- `ReindexSourceUseCase` — `Processing` に落として `corpusCleaner->clear()` で旧チャンクを消してから
  作り直す。途中で落ちると **「旧は消え、新は途中まで」という半端な集合**が failed の下に残る。

⇒ 半端に取り込まれた内容が `search_corpus` の引用根拠になりうる。

## `= 'ready'` を選んだ理由（`<> 'failed'` ではなく）

**許可リストにした。** 理由は2つ。

1. **後から status が増えたときの既定が逆になる。** 除外リストだと新しい状態は
   「誰も判断していないのに検索に混ざる」。許可リストなら「誰かが searchable だと決めるまで外れる」。
   このリポの `organization_id` の扱いと同じ向きの安全側である。
2. **`processing` も外すのが正しい。** reindex 中の source は旧チャンクを消した後なので、
   その瞬間のチャンク集合は定義上不完全である。「壊れていないが不完全」なものを
   検索に出す理由がない。

条件の実体は `SourceStatus::SEARCHABLE_SOURCE_SQL` の 1 箇所に置いた。3 箇所は
コピーで揃っていただけで、**同じ条件を 3 回書けばまた離れる**。

## 🔴 `listAliveSourceIds` は変えていない（非対称は意図）

`RecallReindexer` は `listAliveSourceIds()` が返す全 source に `deleteBySource` を打ってから
チャンクを投入する。Recall には「保持している external_id を全部出す」API が無いので、
これが唯一の掃除の経路である。

ここに status 条件を足すと、**取り込みに失敗した source のチャンクが Recall に残ったまま
二度と消えなくなる**（デコレータは save のたびに Recall へ push しているので、途中で落ちた
取り込みは既に Recall に行を作っている）。

⇒ **投入する側は絞り、掃除する側は絞らない。** `test_reindex_still_clears_a_failed_source_in_recall`
がこの非対称を固定している。

## これは #393 の退行ではない

- 1 番目は #393 以前からの既存の緩さ。
- 2・3 番目は #392 / #393（ADR 0007）が追加した新しい経路だが、**意図的に 1 番目と同じ条件へ揃えてある**
  （`PdoChunkSearchGuard` の docblock に "matching `PdoChunkSearchRepository`" と明記）。
  #393 は既存の条件を忠実に写しただけで、緩さを持ち込んだわけではない。
- 見つかったのは #393 の端から端までの疎通のとき。**穴が 1 箇所から 3 箇所に増えた状態で放置しない**のが本 PR。

## テスト（5 件追加・いずれも修正前は落ちる）

条件を元の `s.is_deleted = 0` に戻して実測した: **5 tests, 5 failures**。

| テスト | 場所 |
| --- | --- |
| `test_search_excludes_chunks_of_a_failed_source` | `tests/Search/PdoChunkSearchRepositoryTest.php` |
| `test_search_excludes_chunks_of_a_source_still_processing` | 同上 |
| `test_chunk_of_a_failed_source_is_dropped_even_when_recall_returns_it` | `tests/Search/RecallChunkSearchRepositoryTest.php` |
| `test_reindex_does_not_write_chunks_of_a_failed_source` | `tests/Recall/RecallReindexTest.php` |
| `test_reindex_still_clears_a_failed_source_in_recall` | 同上（非対称を固定） |

`tests/Support/CorpusSchemaSetup.php` には既に `status` 列があったので変更なし。

## ADR

別コミットで `docs/adr/0007-recall-search-backend.md` の Status を
`Proposed` → `Accepted（2026-09-03）` に（施主判断で #393 が `ba3343a` としてマージ済みのため）。
あわせて Decision 2 の二段フィルタの SQL に status 条件を反映し、Decision 4 に上記の非対称の理由を書いた。

## 品質チェック

```
OK (477 tests, 1500 assertions)
[OK] No errors                    ← PHPStan level 8
PHP CS Fixer … "files":[]
OpenAPI contract is valid.
MCP tool catalog is valid.
Conformance OK — no findings (0 suppressed by baseline/ignore).
```

`composer check` 緑。フロント無変更のため `npm run check` は対象外。

## セルフレビューチェックリスト

- `docs/review/database.md`（リポジトリの SQL 変更）
- `docs/review/docs-policy.md`（ADR）

`organization_id` の条件は 3 箇所とも一切触っていない。SQL は `Pdo*` の中だけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
